### PR TITLE
Don't pick random AZ on volume creation

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -96,24 +96,6 @@ func TestCreateDisk(t *testing.T) {
 		ctx := context.Background()
 		mockEC2.EXPECT().CreateVolumeWithContext(gomock.Eq(ctx), gomock.Any()).Return(vol, tc.expErr)
 
-		if tc.diskOptions.AvailabilityZone == "" {
-			describeAvailabilityZonesResp := &ec2.DescribeAvailabilityZonesOutput{
-				AvailabilityZones: []*ec2.AvailabilityZone{
-					&ec2.AvailabilityZone{
-						ZoneName: aws.String("us-west-2a"),
-					},
-					&ec2.AvailabilityZone{
-						ZoneName: aws.String("us-west-2b"),
-					},
-					&ec2.AvailabilityZone{
-						ZoneName: aws.String("us-west-2c"),
-					},
-				},
-			}
-
-			mockEC2.EXPECT().DescribeAvailabilityZonesWithContext(gomock.Eq(ctx), gomock.Any()).Return(describeAvailabilityZonesResp, nil)
-		}
-
 		disk, err := c.CreateDisk(ctx, tc.volumeName, tc.diskOptions)
 		if err != nil {
 			if tc.expErr == nil {

--- a/pkg/cloud/mocks/mock_ec2.go
+++ b/pkg/cloud/mocks/mock_ec2.go
@@ -89,24 +89,6 @@ func (mr *MockEC2MockRecorder) DeleteVolumeWithContext(arg0, arg1 interface{}, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeWithContext", reflect.TypeOf((*MockEC2)(nil).DeleteVolumeWithContext), varargs...)
 }
 
-// DescribeAvailabilityZonesWithContext mocks base method
-func (m *MockEC2) DescribeAvailabilityZonesWithContext(arg0 aws.Context, arg1 *ec2.DescribeAvailabilityZonesInput, arg2 ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "DescribeAvailabilityZonesWithContext", varargs...)
-	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeAvailabilityZonesWithContext indicates an expected call of DescribeAvailabilityZonesWithContext
-func (mr *MockEC2MockRecorder) DescribeAvailabilityZonesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZonesWithContext", reflect.TypeOf((*MockEC2)(nil).DescribeAvailabilityZonesWithContext), varargs...)
-}
-
 // DescribeInstancesWithContext mocks base method
 func (m *MockEC2) DescribeInstancesWithContext(arg0 aws.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.Option) (*ec2.DescribeInstancesOutput, error) {
 	varargs := []interface{}{arg0, arg1}


### PR DESCRIPTION
This partly reverts 760663c to prevent issue #52. This is not meant to
be the definite solution; it just buys us some time while keeping the
driver functional.

/kind bug
/assign @leakingtapan