### PR TITLE
Add missing capability and clusterrole permission to enable topology awareness scheduling

### DIFF
--- a/deploy/kubernetes/v1.12+/node.yaml
+++ b/deploy/kubernetes/v1.12+/node.yaml
@@ -27,6 +27,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch", "update"]
 
 ---
 

--- a/deploy/kubernetes/v1.12+/provisioner.yaml
+++ b/deploy/kubernetes/v1.12+/provisioner.yaml
@@ -16,6 +16,9 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
@@ -36,6 +39,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
 
 ---
 

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -41,6 +41,13 @@ func (d *Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCa
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS,
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Did manual testing on 1.12 and able to verify that volume and pod are co-scheduled in us-east-1c while provisioner is in us-east-1a. 