### PR TITLE
Switch to Alpine 3.8 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 ADD . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/aws-ebs-csi-driver ./cmd/aws-ebs-csi-driver
 
-FROM registry.fedoraproject.org/fedora-minimal
+FROM alpine:3.8
+RUN apk add --no-cache ca-certificates e2fsprogs
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
-RUN microdnf install -y e2fsprogs && microdnf clean all
 
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]


### PR DESCRIPTION
Fixes #59.

Image size decreases considerably:

```
quay.io/bertinatto/ebs-csi-driver           testing            b73128d25c5d   2 minutes ago    30.2MB
```