### PR TITLE
Switch to use go 1.11.1 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 go:
   - "1.10.x"
-  - "1.11.x"
+  - "1.11.1"
 
 before_install:
   - go get github.com/mattn/goveralls


### PR DESCRIPTION
Recent go 1.11.2 release breaks the go mod hash: https://travis-ci.org/kubernetes-sigs/aws-ebs-csi-driver/jobs/450071762

Fix go patch version to 1.11.1 to resolve the build issue.

I will update go version for both docker build and travis together later.