### PR TITLE
Add example IAM policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ And *external-provisioner* must have the togology feature gate enabled with `--f
 ### Kubernetes
 Under the directory [deploy/kubernetes](./deploy/kubernetes), there are a few manifest files that are needed to deploy the CSI driver along with sidecar containers. If you are using Kubernetes v1.12+, use the manifest files under [deploy/kubernetes/v1.12+](deploy/kubernetes/v1.12+); for kubernetes v1.10 and v1.11, use the files under [deploy/kubernetes/v1.[10,11]](deploy/kubernetes/v1.[10,11]).
 
-In this example we'll use Kubernetes v1.12. First of all, edit the `deploy/kubernetes/v1.12+/secrets.yaml` file and add AWS credentials of the IAM user. It's a best practice to only grant required permission to the driver.
+In this example we'll use Kubernetes v1.12. First of all, edit the `deploy/kubernetes/v1.12+/secrets.yaml` file and add AWS credentials of the IAM user. It's a best practice to only grant required permission to the driver. A sample IAM policy can be found in [example-iam-policy.json](example-iam-policy.json).
 
 The file will look like this:
 

--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:CreateSnapshot",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteSnapshot",
+        "ec2:DeleteTags",
+        "ec2:DeleteVolume",
+        "ec2:DescribeInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DetachVolume"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #113 
**What is this PR about? / Why do we need it?**
This adds an example IAM policy with the required permissions.
**What testing is done?** 
I ran the integration tests (`make test-integration`) on an EC2 instance using a role that had this policy attached.