### PR TITLE
Refactor the code

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 )
 
@@ -42,12 +41,10 @@ func main() {
 		os.Exit(0)
 	}
 
-	cloud, err := cloud.NewCloud()
+	drv, err := driver.NewDriver(*endpoint)
 	if err != nil {
 		glog.Fatalln(err)
 	}
-
-	drv := driver.NewDriver(cloud, nil, *endpoint)
 	if err := drv.Run(); err != nil {
 		glog.Fatalln(err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -219,7 +219,7 @@ func TestCreateVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
-		awsDriver := NewDriver(cloud.NewFakeCloudProvider(), NewFakeMounter(), "")
+		awsDriver := NewFakeDriver("")
 
 		resp, err := awsDriver.CreateVolume(context.TODO(), tc.req)
 		if err != nil {
@@ -298,7 +298,7 @@ func TestDeleteVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
-		awsDriver := NewDriver(cloud.NewFakeCloudProvider(), NewFakeMounter(), "")
+		awsDriver := NewFakeDriver("")
 		_, err := awsDriver.DeleteVolume(context.TODO(), tc.req)
 		if err != nil {
 			srvErr, ok := status.FromError(err)

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package driver
 
-import "k8s.io/kubernetes/pkg/util/mount"
+import (
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"k8s.io/kubernetes/pkg/util/mount"
+)
 
 func NewFakeMounter() *mount.SafeFormatAndMount {
 	return &mount.SafeFormatAndMount{
@@ -27,4 +30,15 @@ func NewFakeMounter() *mount.SafeFormatAndMount {
 		Exec: mount.NewFakeExec(nil),
 	}
 
+}
+
+// NewFakeDriver creates a new mock driver used for testing
+func NewFakeDriver(endpoint string) *Driver {
+	cloud := cloud.NewFakeCloudProvider()
+	return &Driver{
+		endpoint: endpoint,
+		nodeID:   cloud.GetMetadata().GetInstanceID(),
+		cloud:    cloud,
+		mounter:  NewFakeMounter(),
+	}
 }

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -32,6 +32,13 @@ const (
 	defaultFsType = "ext4"
 )
 
+var (
+	// nodeCaps represents the capability of node service.
+	nodeCaps = []csi.NodeServiceCapability_RPC_Type{
+		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+	}
+)
+
 func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	glog.V(4).Infof("NodeStageVolume: called with args %+v", *req)
 	volumeID := req.GetVolumeId()
@@ -189,7 +196,7 @@ func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeS
 func (d *Driver) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	glog.V(4).Infof("NodeGetCapabilities: called with args %+v", *req)
 	var caps []*csi.NodeServiceCapability
-	for _, cap := range d.nodeCaps {
+	for _, cap := range nodeCaps {
 		c := &csi.NodeServiceCapability{
 			Type: &csi.NodeServiceCapability_Rpc{
 				Rpc: &csi.NodeServiceCapability_RPC{

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -54,9 +54,8 @@ func TestIntegration(t *testing.T) {
 var _ = BeforeSuite(func() {
 	// Run CSI Driver in its own goroutine
 	var err error
-	ebs, err = cloud.NewCloud()
-	Expect(err).To(BeNil(), "Set up Cloud client failed with error")
-	drv = driver.NewDriver(ebs, nil, endpoint)
+	drv, err = driver.NewDriver(endpoint)
+	Expect(err).To(BeNil())
 	go func() {
 		err := drv.Run()
 		Expect(err).To(BeNil())

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -25,7 +25,6 @@ import (
 
 	sanity "github.com/kubernetes-csi/csi-test/pkg/sanity"
 
-	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 )
 
@@ -44,7 +43,7 @@ func TestSanity(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	ebsDriver = driver.NewDriver(cloud.NewFakeCloudProvider(), driver.NewFakeMounter(), endpoint)
+	ebsDriver = driver.NewFakeDriver(endpoint)
 	go func() {
 		Expect(ebsDriver.Run()).NotTo(HaveOccurred())
 	}()


### PR DESCRIPTION
1. Split `NewDriver` into two methods `NewDriver` and `NewMockDriver`.
So that one is only takes in endpoint and serves as production uses and
the other create driver with mock dependencies
2. Move controller capability, node capability and volume capability out
of driver struct since they are constant that should never change for a
specific version of driver
