### PR TITLE
Add version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 IMAGE=amazon/aws-ebs-csi-driver
 VERSION=0.1.0-alpha
+GIT_COMMIT?=$(shell git rev-parse HEAD)
+BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE}"
 
 .PHONY: aws-ebs-csi-driver
 aws-ebs-csi-driver:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.vendorVersion=${VERSION}" -o bin/aws-ebs-csi-driver ./cmd/
+	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-ebs-csi-driver ./cmd/
 
 .PHONY: test
 test:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
@@ -25,8 +27,20 @@ import (
 )
 
 func main() {
-	var endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+	var (
+		endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+		version  = flag.Bool("version", false, "Print the version and exit.")
+	)
 	flag.Parse()
+
+	if *version {
+		info, err := driver.GetVersionJSON()
+		if err != nil {
+			glog.Fatalln(err)
+		}
+		fmt.Println(info)
+		os.Exit(0)
+	}
 
 	cloud, err := cloud.NewCloud()
 	if err != nil {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -33,11 +33,6 @@ const (
 	topologyKey = "topology." + driverName + "/zone"
 )
 
-var (
-	// vendorVersion is the version driver and is set during build
-	vendorVersion string
-)
-
 type Driver struct {
 	endpoint string
 	nodeID   string

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -27,7 +27,7 @@ func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoReques
 	glog.V(4).Infof("GetPluginInfo: called with args %+v", *req)
 	resp := &csi.GetPluginInfoResponse{
 		Name:          driverName,
-		VendorVersion: vendorVersion,
+		VendorVersion: driverVersion,
 	}
 
 	return resp, nil

--- a/pkg/driver/version.go
+++ b/pkg/driver/version.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+)
+
+// These are set during build time via -ldflags
+var (
+	driverVersion string
+	gitCommit     string
+	buildDate     string
+)
+
+type VersionInfo struct {
+	DriverVersion string `json:"driverVersion"`
+	GitCommit     string `json:"gitCommit"`
+	BuildDate     string `json:"buildDate"`
+	GoVersion     string `json:"goVersion"`
+	Compiler      string `json:"compiler"`
+	Platform      string `json:"platform"`
+}
+
+func GetVersion() VersionInfo {
+	return VersionInfo{
+		DriverVersion: driverVersion,
+		GitCommit:     gitCommit,
+		BuildDate:     buildDate,
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func GetVersionJSON() (string, error) {
+	info := GetVersion()
+	marshalled, err := json.MarshalIndent(&info, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(marshalled), nil
+}

--- a/pkg/driver/version_test.go
+++ b/pkg/driver/version_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestGetVersion(t *testing.T) {
+	version := GetVersion()
+
+	expected := VersionInfo{
+		DriverVersion: "",
+		GitCommit:     "",
+		BuildDate:     "",
+		GoVersion:     runtime.Version(),
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+
+	if !reflect.DeepEqual(version, expected) {
+		t.Fatalf("structs not equall\ngot:\n%+v\nexpected:\n%+v", version, expected)
+	}
+}
+
+func TestGetVersionJSON(t *testing.T) {
+	version, err := GetVersionJSON()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := fmt.Sprintf(`{
+  "driverVersion": "",
+  "gitCommit": "",
+  "buildDate": "",
+  "goVersion": "%s",
+  "compiler": "%s",
+  "platform": "%s"
+}`, runtime.Version(), runtime.Compiler, fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH))
+
+	if version != expected {
+		t.Fatalf("json not equall\ngot:\n%s\nexpected:\n%s", version, expected)
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/21

**What is this PR about? / Why do we need it?**
This PR adds `--version` flag at the top level command.
Running `aws-ebs-csi-driver --version` will pretty print the JSON, with the same format as `kubectl version`.

This PR does not add support for printing the info in any other format. 

**What testing is done?** 
Locally built the image and tested:
```
➜  aws-ebs-csi-driver git:(version) ✗ docker run -it amazon/aws-ebs-csi-driver:0.1.0-alpha --version
{
  "driverVersion": "0.1.0-alpha",
  "gitCommit": "c7b3689df8a5cdf212ca80f9f0332ac3d518eefc",
  "buildDate": "2018-12-04T18:45:21Z",
  "goVersion": "go1.11.1",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```
I am not aware of a way to unit test when using `-ldflags`, if anyone has some pointers would be glad to add a unit test.