### PR TITLE
Bump vendored kubernetes to v1.12.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 go:
   - "1.10.x"
-  - "1.11.1"
+  - "1.11.2"
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.11.1-stretch as builder
+FROM golang:1.11.2-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 ADD . .
 RUN make 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ kubectl create -f deploy/kubernetes/v1.12+/sample_app
 Please go through [CSI Spec](https://github.com/container-storage-interface/spec/blob/master/spec.md) and [General CSI driver development guideline](https://kubernetes-csi.github.io/docs/Development.html) to get some basic understanding of CSI driver before you start.
 
 ### Requirements
-* Golang 1.11.1+
+* Golang 1.11.2+
 * [Ginkgo](https://github.com/onsi/ginkgo) for integration and end-to-end testing
 * Docker 17.05+ for releasing
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,6 @@ require (
 	google.golang.org/grpc v1.16.0
 	k8s.io/apimachinery v0.0.0-20181121071008-d4f83ca2e260
 	k8s.io/klog v0.1.0 // indirect
-	k8s.io/kubernetes v1.12.2
+	k8s.io/kubernetes v1.12.3
 	k8s.io/utils v0.0.0-20181115163542-0d26856f57b3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -64,7 +64,7 @@ k8s.io/apimachinery v0.0.0-20181121071008-d4f83ca2e260 h1:aWwjpwRiIZglT1lHFRE7PI
 k8s.io/apimachinery v0.0.0-20181121071008-d4f83ca2e260/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=
 k8s.io/klog v0.1.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/kubernetes v1.12.2 h1:J94sY8nziFyzMNhnbD5CiSZTo7yWytir0ia+vJuwYfc=
-k8s.io/kubernetes v1.12.2/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.12.3 h1:1FH8TXY6pIuOHoNlsq9bB6rmCP0vfvQZH5YN7OXCHXU=
+k8s.io/kubernetes v1.12.3/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20181115163542-0d26856f57b3 h1:S3/Kq185JnolOEemhmDXXd23l2t4bX5hPQPQPADlF1E=
 k8s.io/utils v0.0.0-20181115163542-0d26856f57b3/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 # k8s.io/klog v0.1.0
 k8s.io/klog
-# k8s.io/kubernetes v1.12.2
+# k8s.io/kubernetes v1.12.3
 k8s.io/kubernetes/pkg/util/mount
 k8s.io/kubernetes/pkg/util/file
 k8s.io/kubernetes/pkg/util/io


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
When trying to test and build locally I get:
```
➜  aws-ebs-csi-driver git:(master) make test
go test -v -race ./pkg/...
go: verifying k8s.io/kubernetes@v1.12.2: checksum mismatch
	downloaded: h1:JEj2cxR+5T31U4klP5hI5dxjr6udRIHm+4dzCEPk498=
	go.sum:     h1:J94sY8nziFyzMNhnbD5CiSZTo7yWytir0ia+vJuwYfc=
make: *** [test] Error 1
➜  aws-ebs-csi-driver git:(master) go version
go version go1.11.2 darwin/amd64
```
I'm not really sure why this works in CI and when running `make image`, maybe its a darwin thing 🤷‍♂️.

If I delete `mod.sum` and recreate it, the hash for `k8s.io/kubernetes` is different 

```
-k8s.io/kubernetes v1.12.2 h1:J94sY8nziFyzMNhnbD5CiSZTo7yWytir0ia+vJuwYfc=
+k8s.io/kubernetes v1.12.2 h1:JEj2cxR+5T31U4klP5hI5dxjr6udRIHm+4dzCEPk498=
```

Either way, Kubernetes 1.12.3 is out with a fix for a major vulnerability and bumping up the version fixes this mod issue also.

**What testing is done?** 
After updating to the new version:
```
➜  aws-ebs-csi-driver git:(vendored-kubernetes) make
mkdir -p bin
CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.driverVersion=0.1.0-alpha -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=643014b968afff5cff6909ace80f7de56861291e -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=2018-12-05T19:24:56Z" -o bin/aws-ebs-csi-driver ./cmd/
➜  aws-ebs-csi-driver git:(vendored-kubernetes) echo $?
0
➜  aws-ebs-csi-driver git:(vendored-kubernetes) make test
go test -v -race ./pkg/...
...
➜  aws-ebs-csi-driver git:(vendored-kubernetes) echo $?
0
```
