### PR TITLE
Move test integration

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if ! [[ "$0" =~ hack/test-integration.sh ]]; then
+  echo "must be run from repository root"
+  exit 127
+fi
+
+go test -c ./tests/integration/... -o bin/integration.test && \
+  sudo -E bin/integration.test -test.v -ginkgo.v

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,20 @@
+## Integration Testing
+
+### Requirements 
+
+1. macOS or Linux
+1. `GOPATH` environment variable [set](https://github.com/golang/go/wiki/SettingGOPATH)
+1. [AWS account](https://aws.amazon.com/account/) that has been [configured locally](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+
+Must satisfy also the requirements for `aws-ebs-csi-driver`
+
+### Run Integration Tests Locally
+
+```bash
+make test-integration
+```
+
+### Additional Information
+
+- GitHub [repo](https://github.com/aws/aws-k8s-tester) for `aws-k8s-tester`, which includes information about releases and running locally
+- Kubernetes Enhancement Proposal ([KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-aws/20181126-aws-k8s-tester.md)) for `aws-k8s-tester`


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature

**What is this PR about? / Why do we need it?**
make test-integration uses [aws-k8s-tester](https://github.com/aws/aws-k8s-tester/)

**What testing is done?** 
Ran locally

@gyuho @leakingtapan 