### PR TITLE
Make requests idempotent

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -23,6 +23,7 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -40,7 +41,8 @@ type Driver struct {
 	cloud cloud.Cloud
 	srv   *grpc.Server
 
-	mounter *mount.SafeFormatAndMount
+	mounter  *mount.SafeFormatAndMount
+	inFlight *internal.InFlight
 }
 
 func NewDriver(endpoint string) (*Driver, error) {
@@ -57,6 +59,7 @@ func NewDriver(endpoint string) (*Driver, error) {
 		nodeID:   m.GetInstanceID(),
 		cloud:    cloud,
 		mounter:  newSafeMounter(),
+		inFlight: internal.NewInFlight(),
 	}, nil
 }
 

--- a/pkg/driver/internal/inflight.go
+++ b/pkg/driver/internal/inflight.go
@@ -1,0 +1,57 @@
+package internal
+
+import (
+	"sync"
+)
+
+// Idempotent is the interface required to manage in flight requests.
+type Idempotent interface {
+	// The CSI data types are generated using a protobuf. The
+	// generated structures are guaranteed to implement the
+	// Stringer interface. Example
+	// https://github.com/container-storage-interface/spec/blob/master/lib/go/csi/csi.pb.go#L3508
+	// We can use the generated string as the key of our internal
+	// inflight database of requests.
+	String() string
+}
+
+// InFlight is a struct used to manage in flight requests.
+type InFlight struct {
+	mux      *sync.Mutex
+	inFlight map[string]bool
+}
+
+// NewInFlight instanciates a InFlight structures.
+func NewInFlight() *InFlight {
+	return &InFlight{
+		mux:      &sync.Mutex{},
+		inFlight: make(map[string]bool),
+	}
+}
+
+// Upsert inserts the entry to the current list of inflight
+// requests. If it's not then it's added and returns true. Returns
+// false if request was not added to list of inflight requests.
+func (db *InFlight) Upsert(entry Idempotent) bool {
+	db.mux.Lock()
+	defer db.mux.Unlock()
+
+	hash := entry.String()
+
+	_, ok := db.inFlight[hash]
+	if !ok {
+		db.inFlight[hash] = true
+	}
+
+	return !ok
+}
+
+// Delete removes the entry from the inFlight entries map. It doesn't
+// return anything, and will do nothing if the specified key doesn't
+// exist.
+func (db *InFlight) Delete(h Idempotent) {
+	db.mux.Lock()
+	defer db.mux.Unlock()
+
+	delete(db.inFlight, h.String())
+}

--- a/pkg/driver/internal/inflight_test.go
+++ b/pkg/driver/internal/inflight_test.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+func TestInFlight(t *testing.T) {
+	stdVolCap := []*csi.VolumeCapability{
+		{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+		},
+	}
+	stdVolSize := int64(5 * 1024 * 1024 * 1024)
+	stdCapRange := &csi.CapacityRange{RequiredBytes: stdVolSize}
+	stdParams := map[string]string{
+		"fsType":     "ext3",
+		"volumeType": "gp2",
+	}
+
+	testCases := []struct {
+		delete  bool
+		expResp bool
+		name    string
+		req     *csi.CreateVolumeRequest
+	}{
+		{
+			name:    "success normal",
+			delete:  false,
+			expResp: true,
+			req: &csi.CreateVolumeRequest{
+				Name:               "random-vol-name",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         stdParams,
+			},
+		},
+		{
+			name:    "success adding copy of request",
+			delete:  false,
+			expResp: false,
+			req: &csi.CreateVolumeRequest{
+				Name:               "random-vol-name",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         stdParams,
+			},
+		},
+		{
+			name:    "success adding request with different name",
+			delete:  false,
+			expResp: true,
+			req: &csi.CreateVolumeRequest{
+				Name:               "random-vol-name-foobar",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         stdParams,
+			},
+		},
+		{
+			name:    "success adding request with different parameters",
+			delete:  false,
+			expResp: true,
+			req: &csi.CreateVolumeRequest{
+				Name:               "random-vol-name-foobar",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			name:    "success after deleting request",
+			delete:  true,
+			expResp: true,
+			req: &csi.CreateVolumeRequest{
+				Name:               "random-vol-name",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters:         stdParams,
+			},
+		},
+	}
+
+	db := NewInFlight()
+
+	for _, tc := range testCases {
+		t.Logf("Test case: %s", tc.name)
+
+		if tc.delete {
+			db.Delete(tc.req)
+		}
+
+		resp := db.Upsert(tc.req)
+		if tc.expResp != resp {
+			t.Fatalf("expected upsert to be %+v, got %+v", tc.expResp, resp)
+		}
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.

**What is this PR about? / Why do we need it?**

The CSI spec requires most operations to be idempotent. 

Currently, some of the requests rely on AWS API to achieve this. An example is CreateVolume. If by any chance AWS API request latency increases the CO might issue the same request that will fail. This leads the CO to send more CreateVolume requests and the possibility of creating multiple disks for the same request. (NOTE: This bus (multiple disks being created) is fixed in another PR but the underlying issue is still not fixed).

Other requests might take more time to complete. An example is NodeStageVolume. If the volume was just created it will need to be formatted for the mount to succeed. If the format takes too much time the CO can send another NodeStageVolume request that will fail because the previous one is still in progress.

This PR introduces a new class to handle inflight requests. It relies on the fact that the Golang protobuf implements the Stringer interface for all structures that it generates. We can use that string to compare requests and keep a list of the ones that are inflight.

**What testing is done?** 

Added unit tests for the new internal data structure to manage in flight requests.

### TODO
- Make more requests idempotent