### PR TITLE
Fix klog flag init

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,7 @@ func main() {
 		endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
 		version  = flag.Bool("version", false, "Print the version and exit.")
 	)
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	if *version {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug

**What is this PR about? / Why do we need it?**
PR https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/151 introduced an issue when `klog` replaced `glog` and the `logtostderr` flag.

**What testing is done?** 
Rebuilt images locally and ran E2E tests.
