### PR TITLE
Make NodeStageVolume idempotent

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -22,6 +22,7 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
 	"k8s.io/klog"
@@ -40,7 +41,8 @@ type Driver struct {
 	cloud cloud.Cloud
 	srv   *grpc.Server
 
-	mounter *mount.SafeFormatAndMount
+	mounter  *mount.SafeFormatAndMount
+	inFlight *internal.InFlight
 }
 
 func NewDriver(endpoint string) (*Driver, error) {
@@ -57,6 +59,7 @@ func NewDriver(endpoint string) (*Driver, error) {
 		nodeID:   m.GetInstanceID(),
 		cloud:    cloud,
 		mounter:  newSafeMounter(),
+		inFlight: internal.NewInFlight(),
 	}, nil
 }
 

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -40,5 +41,6 @@ func NewFakeDriver(endpoint string) *Driver {
 		nodeID:   cloud.GetMetadata().GetInstanceID(),
 		cloud:    cloud,
 		mounter:  NewFakeMounter(),
+		inFlight: internal.NewInFlight(),
 	}
 }

--- a/pkg/driver/internal/inflight.go
+++ b/pkg/driver/internal/inflight.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"sync"
+)
+
+// Idempotent is the interface required to manage in flight requests.
+type Idempotent interface {
+	// The CSI data types are generated using a protobuf.
+	// The generated structures are guaranteed to implement the Stringer interface.
+	// Example: https://github.com/container-storage-interface/spec/blob/master/lib/go/csi/csi.pb.go#L3508
+	// We can use the generated string as the key of our internal inflight database of requests.
+	String() string
+}
+
+// InFlight is a struct used to manage in flight requests.
+type InFlight struct {
+	mux      *sync.Mutex
+	inFlight map[string]bool
+}
+
+// NewInFlight instanciates a InFlight structures.
+func NewInFlight() *InFlight {
+	return &InFlight{
+		mux:      &sync.Mutex{},
+		inFlight: make(map[string]bool),
+	}
+}
+
+// Insert inserts the entry to the current list of inflight requests.
+// Returns false when the key already exists.
+func (db *InFlight) Insert(entry Idempotent) bool {
+	db.mux.Lock()
+	defer db.mux.Unlock()
+
+	hash := entry.String()
+
+	_, ok := db.inFlight[hash]
+	if ok {
+		return false
+	}
+
+	db.inFlight[hash] = true
+	return true
+}
+
+// Delete removes the entry from the inFlight entries map.
+// It doesn't return anything, and will do nothing if the specified key doesn't exist.
+func (db *InFlight) Delete(h Idempotent) {
+	db.mux.Lock()
+	defer db.mux.Unlock()
+
+	delete(db.inFlight, h.String())
+}

--- a/pkg/driver/internal/inflight_test.go
+++ b/pkg/driver/internal/inflight_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+type testRequest struct {
+	request *csi.CreateVolumeRequest
+	expResp bool
+	delete  bool
+}
+
+var stdVolCap = []*csi.VolumeCapability{
+	{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		},
+	},
+}
+var stdVolSize = int64(5 * 1024 * 1024 * 1024)
+var stdCapRange = &csi.CapacityRange{RequiredBytes: stdVolSize}
+var stdParams = map[string]string{
+	"fsType":     "ext3",
+	"volumeType": "gp2",
+}
+
+func TestInFlight(t *testing.T) {
+	testCases := []struct {
+		name     string
+		requests []testRequest
+	}{
+		{
+			name: "success normal",
+			requests: []testRequest{
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: true,
+				},
+			},
+		},
+		{
+			name: "success adding request with different name",
+			requests: []testRequest{
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-foobar",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: true,
+				},
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name-foobar",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: true,
+				},
+			},
+		},
+		{
+			name: "success adding request with different parameters",
+			requests: []testRequest{
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name-foobar",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         map[string]string{"foo": "bar"},
+					},
+					expResp: true,
+				},
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name-foobar",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+					},
+					expResp: true,
+				},
+			},
+		},
+		{
+			name: "success adding request with different parameters",
+			requests: []testRequest{
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name-foobar",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         map[string]string{"foo": "bar"},
+					},
+					expResp: true,
+				},
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name-foobar",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         map[string]string{"foo": "baz"},
+					},
+					expResp: true,
+				},
+			},
+		},
+		{
+			name: "failure adding copy of request",
+			requests: []testRequest{
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: true,
+				},
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: false,
+				},
+			},
+		},
+		{
+			name: "success add, delete, add copy",
+			requests: []testRequest{
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: true,
+				},
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: false,
+					delete:  true,
+				},
+				{
+					request: &csi.CreateVolumeRequest{
+						Name:               "random-vol-name",
+						CapacityRange:      stdCapRange,
+						VolumeCapabilities: stdVolCap,
+						Parameters:         stdParams,
+					},
+					expResp: true,
+				},
+			},
+		},
+	}
+
+	for n := range testCases {
+		t.Run(testCases[n].name, func(t *testing.T) {
+			db := NewInFlight()
+			for _, r := range testCases[n].requests {
+				var resp bool
+				if r.delete {
+					db.Delete(r.request)
+				} else {
+					resp = db.Insert(r.request)
+				}
+				if r.expResp != resp {
+					t.Fatalf("expected insert to be %+v, got %+v", r.expResp, resp)
+				}
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.

If NodeStageVolume takes longer than the default [CSI timeout](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/csi/csi_plugin.go#L57) to format the volume the CO can issue another request. This can lead to multiple inflight format commands against the volume and unexpected behavior.

**What is this PR about? / Why do we need it?**

The CSI spec requires most operations to be idempotent.

Currently, some of the requests rely on AWS API to achieve this. An example is CreateVolume. If by any chance AWS API request latency increases the CO might issue the same request that will fail. This leads the CO to send more CreateVolume requests and the possibility of creating multiple disks for the same request. (NOTE: This bug (multiple disks being created) is fixed in another PR but the underlying issue is still not fixed).

Other requests might take more time to complete. An example is NodeStageVolume. If the volume was just created it will need to be formatted for the mount to succeed. If the format takes too much time the CO can send another NodeStageVolume request that will fail because the previous one is still in progress.

This PR introduces a new class to handle inflight requests. It relies on the fact that the Golang protobuf implements the Stringer interface for all structures that it generates. We can use that string to compare requests and keep a list of the ones that are being processed.

Regarding NodeStageVolume idempotency, the spec says:

```
This operation MUST be idempotent. If the volume corresponding to the volume_id is
already staged to the staging_target_path, and is identical to the specified 
volume_capability the Plugin MUST reply 0 OK.
```
We check if the volume is already mounted at staging_target_path using mount.GetDeviceNameFromMount.

**What testing is done?**

Added unit tests for the new internal data structure to manage in flight requests.
