### PR TITLE
Change flag for PULL_NUMBER with test-integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ ifdef AWS_K8S_TESTER_VPC_ID
 	VPC_ID_FLAG=--vpc-id=${AWS_K8S_TESTER_VPC_ID}
 endif
 
-CSI_FLAG=--csi=master
+PR_NUM_FLAG=
 ifdef PULL_NUMBER
-	CSI_FLAG=--csi=${PULL_NUMBER}
+	PR_NUM_FLAG=--pr-num=${PULL_NUMBER}
 endif
 
 .PHONY: aws-ebs-csi-driver
@@ -54,7 +54,7 @@ test-sanity:
 test-integration:
 	curl -L ${AWS_K8S_TESTER_DOWNLOAD_URL} -o ${AWS_K8S_TESTER_PATH}
 	chmod +x ${AWS_K8S_TESTER_PATH}
-	${AWS_K8S_TESTER_PATH} csi test integration --terminate-on-exit=true --timeout=20m ${CSI_FLAG} ${VPC_ID_FLAG}
+	${AWS_K8S_TESTER_PATH} csi test integration --terminate-on-exit=true --timeout=20m ${PR_NUM_FLAG} ${VPC_ID_FLAG}
 
 .PHONY: test-e2e
 test-e2e:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.git
 # Hard-coded version is needed in case GitHub API rate limit is exceeded.
 # TODO: When aws-k8s-tester becomes a full release (https://developer.github.com/v3/repos/releases/#get-the-latest-release), use:
 # $(shell curl -s --request GET --url https://api.github.com/repos/aws/aws-k8s-tester/releases/latest | jq -r '.tag_name? // "<current version number>"')
-AWS_K8S_TESTER_VERSION?=$(shell curl -s --request GET --url https://api.github.com/repos/aws/aws-k8s-tester/tags | jq -r '.[0]?.name // "0.1.9"')
+AWS_K8S_TESTER_VERSION?=$(shell curl -s --request GET --url https://api.github.com/repos/aws/aws-k8s-tester/tags | jq -r '.[0]?.name // "0.2.0"')
 AWS_K8S_TESTER_OS_ARCH?=$(shell go env GOOS)-amd64
 AWS_K8S_TESTER_DOWNLOAD_URL?=https://github.com/aws/aws-k8s-tester/releases/download/${AWS_K8S_TESTER_VERSION}/aws-k8s-tester-${AWS_K8S_TESTER_VERSION}-${AWS_K8S_TESTER_OS_ARCH}
 AWS_K8S_TESTER_PATH?=/tmp/aws-k8s-tester


### PR DESCRIPTION
I do not have write access to @kschumy's repository, thus creating a one.

Is this a bug fix or adding new feature?
Bug fix

What is this PR about? / Why do we need it?
The flag needed for PULL_NUMBER for test-integration is changing. See: aws/aws-k8s-tester#31

What testing is done?
Local

Closes: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/170.

/cc @leakingtapan 