### PR TITLE
Fix NodeStageVolume returning prematurely

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -74,8 +74,8 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	}
 
 	if ok := d.inFlight.Insert(req); !ok {
-		klog.Infof("NodeStageVolume: volume=%q operation is already in progress", volumeID)
-		return &csi.NodeStageVolumeResponse{}, nil
+		msg := fmt.Sprintf("request to stage volume=%q is already in progress", volumeID)
+		return nil, status.Error(codes.Internal, msg)
 	}
 	defer func() {
 		klog.Infof("NodeStageVolume: volume=%q operation finished", req.GetVolumeId())


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
PR https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/163 introduced a bug where `NodeStageVolume` would return prematurely.
This was only evident when using HDD volumes because the formatting takes longer than the default **15** seconds, unfortunately when I tested the change for https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/163#discussion_r244741296 I only ran the sample app with a SSD and did not catch this bug :(.

When I ran the remaining e2e tests, all HDD volume tests were failing to delete EBS volumes because they were still being formatted.

Below log, shows that `NodeStageVolume: volume="vol-0504e2cf8285d7bcc" operation is already in progress` after 15 seconds(default retry period) but because it doesn't return an error the next operation `NodePublishVolume` is called.

```
I0109 21:47:06.265099       1 node.go:55] NodeStageVolume: called with args {VolumeId:vol-0504e2cf8285d7bcc PublishContext:map[devicePath:/dev/xvdbb] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount VolumeCapability:mount:<fs_type:"ext2" > access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1547070289563-8081-ebs.csi.aws.com fsType:ext2] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0109 21:47:06.265186       1 node.go:77] NodeStageVolume: volume="vol-0504e2cf8285d7bcc" operation is already in progress
I0109 21:47:06.267684       1 node.go:248] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0109 21:47:06.273550       1 node.go:162] NodePublishVolume: called with args {VolumeId:vol-0504e2cf8285d7bcc PublishContext:map[devicePath:/dev/xvdbb] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount TargetPath:/var/lib/kubelet/pods/08d7000f-1458-11e9-8557-2acd0797fa41/volumes/kubernetes.io~csi/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/mount VolumeCapability:mount:<fs_type:"ext2" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[fsType:ext2 storage.kubernetes.io/csiProvisionerIdentity:1547070289563-8081-ebs.csi.aws.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0109 21:47:06.273600       1 node.go:208] NodePublishVolume: creating dir /var/lib/kubelet/pods/08d7000f-1458-11e9-8557-2acd0797fa41/volumes/kubernetes.io~csi/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/mount
I0109 21:47:06.273632       1 node.go:213] NodePublishVolume: mounting /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount at /var/lib/kubelet/pods/08d7000f-1458-11e9-8557-2acd0797fa41/volumes/kubernetes.io~csi/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/mount
I0109 21:47:06.273666       1 mount_linux.go:146] Mounting cmd (mount) with arguments ([-t ext4 -o bind /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount /var/lib/kubelet/pods/08d7000f-1458-11e9-8557-2acd0797fa41/volumes/kubernetes.io~csi/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/mount])
I0109 21:47:06.283116       1 mount_linux.go:146] Mounting cmd (mount) with arguments ([-t ext4 -o bind,remount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount /var/lib/kubelet/pods/08d7000f-1458-11e9-8557-2acd0797fa41/volumes/kubernetes.io~csi/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/mount])
I0109 21:48:26.498530       1 mount_linux.go:492] Disk successfully formatted (mkfs): ext2 - /dev/xvdbb /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount
I0109 21:48:26.498575       1 mount_linux.go:146] Mounting cmd (mount) with arguments ([-t ext2 -o defaults /dev/xvdbb /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-03a7e5f0-1458-11e9-8557-2acd0797fa41/globalmount])
I0109 21:48:26.527167       1 node.go:81] NodeStageVolume: volume="vol-0504e2cf8285d7bcc" operation finished
```

**What testing is done?** 
Locally ran all e2e tests