### PR TITLE
New parameter additionalTags to tag EBS volumes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ There are several optional parameters that could be passed into `CreateVolumeReq
 | "fsType"          | ext2, ext3, ext4 | ext4     | File system type that will be formatted during volume creation |
 | "encrypted"       |                  |          | Whether the volume should be encrypted or not. Valid values are "true" or "false" | 
 | "kmsKeyId"        |                  |          | The full ARN of the key to use when encrypting the volume. When not specified, the default KMS key is used |
+| "additionalTags"  |                  |          | Comma separated key=value list of tags to set on the EBS volume |
 
 ## Prerequisites
 ### Kubernetes

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -50,6 +50,8 @@ const (
 
 var (
 	ValidVolumeTypes = []string{VolumeTypeIO1, VolumeTypeGP2, VolumeTypeSC1, VolumeTypeST1}
+	// VolumeNameTagKey is the key value that refers to the volume's name.
+	VolumeNameTagKey = "CSIVolumeName"
 )
 
 // AWS provisioning limits.
@@ -71,8 +73,6 @@ const (
 
 // Tags
 const (
-	// VolumeNameTagKey is the key value that refers to the volume's name.
-	VolumeNameTagKey = "CSIVolumeName"
 	// SnapshotNameTagKey is the key value that refers to the snapshot's name.
 	SnapshotNameTagKey = "CSIVolumeSnapshotName"
 )
@@ -104,7 +104,7 @@ type Disk struct {
 // DiskOptions represents parameters to create an EBS volume
 type DiskOptions struct {
 	CapacityBytes    int64
-	Tags             map[string]string
+	AdditionalTags   map[string]string
 	VolumeType       string
 	IOPSPerGB        int
 	AvailabilityZone string
@@ -240,8 +240,10 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 	}
 
 	var tags []*ec2.Tag
-	for key, value := range diskOptions.Tags {
-		tags = append(tags, &ec2.Tag{Key: &key, Value: &value})
+	tags = append(tags, &ec2.Tag{Key: &VolumeNameTagKey, Value: &volumeName})
+	for key, value := range diskOptions.AdditionalTags {
+		k, v := key, value
+		tags = append(tags, &ec2.Tag{Key: &k, Value: &v})
 	}
 	tagSpec := ec2.TagSpecification{
 		ResourceType: aws.String("volume"),

--- a/pkg/cloud/fakes.go
+++ b/pkg/cloud/fakes.go
@@ -57,13 +57,17 @@ func (c *FakeCloudProvider) GetMetadata() MetadataService {
 
 func (c *FakeCloudProvider) CreateDisk(ctx context.Context, volumeName string, diskOptions *DiskOptions) (*Disk, error) {
 	r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
+	tags := map[string]string{VolumeNameTagKey: volumeName}
+	for k, v := range diskOptions.AdditionalTags {
+		tags[k] = v
+	}
 	d := &fakeDisk{
 		Disk: &Disk{
 			VolumeID:         fmt.Sprintf("vol-%d", r1.Uint64()),
 			CapacityGiB:      util.BytesToGiB(diskOptions.CapacityBytes),
 			AvailabilityZone: diskOptions.AvailabilityZone,
 		},
-		tags: diskOptions.Tags,
+		tags: tags,
 	}
 	c.disks[volumeName] = d
 	return d.Disk, nil

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -64,7 +65,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -94,7 +94,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -123,7 +122,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: cloud.DefaultVolumeSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -137,7 +135,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: 2147483648, // 1 GiB + 1 byte = 2 GiB
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -151,7 +148,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: defaultFsType},
 			},
 		},
@@ -168,7 +164,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -184,7 +179,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -200,7 +194,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -217,7 +210,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: ""},
 			},
 		},
@@ -255,7 +247,6 @@ func TestCreateVolume(t *testing.T) {
 			},
 			expVol: &csi.Volume{
 				CapacityBytes: stdVolSize,
-				VolumeId:      "vol-test",
 				VolumeContext: map[string]string{FsTypeKey: expFsType},
 				AccessibleTopology: []*csi.Topology{
 					{
@@ -263,6 +254,53 @@ func TestCreateVolume(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "success with additionalTags",
+			req: &csi.CreateVolumeRequest{
+				Name:               "vol-test",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters: map[string]string{
+					"additionalOptions": "foo=bar,bar=foo,foobar=,barfoo",
+				},
+			},
+			expVol: &csi.Volume{
+				CapacityBytes: stdVolSize,
+				VolumeContext: map[string]string{"fsType": ""},
+			},
+		},
+		{
+			name: "fail additionalTags, reserved key",
+			req: &csi.CreateVolumeRequest{
+				Name:               "vol-test",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters: map[string]string{
+					"additionalTags": fmt.Sprintf("foo=bar,bar=foo,%s=vol-test", cloud.VolumeNameTagKey),
+				},
+			},
+			expVol: &csi.Volume{
+				CapacityBytes: stdVolSize,
+				VolumeContext: map[string]string{"fsType": ""},
+			},
+			expErrCode: 3,
+		},
+		{
+			name: "fail additionalTags, invalid format",
+			req: &csi.CreateVolumeRequest{
+				Name:               "vol-test",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				Parameters: map[string]string{
+					"additionalTags": "foo=bar=baz",
+				},
+			},
+			expVol: &csi.Volume{
+				CapacityBytes: stdVolSize,
+				VolumeContext: map[string]string{"fsType": ""},
+			},
+			expErrCode: 3,
 		},
 	}
 

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -92,7 +92,6 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			CapacityBytes:    defaultDiskSizeBytes,
 			VolumeType:       defaultVoluemType,
 			AvailabilityZone: availabilityZone,
-			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName},
 		}
 		metadata := e2eMetdataService{availabilityZone: availabilityZone}
 		var err error
@@ -100,7 +99,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}
-		disk, err := cloud.CreateDisk(context.Background(), "", diskOptions)
+		disk, err := cloud.CreateDisk(context.Background(), dummyVolumeName, diskOptions)
 		if err != nil {
 			Fail(fmt.Sprintf("could not provision a volume: %v", err))
 		}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New Feature
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/180

**What is this PR about? / Why do we need it?**
This PR enables tagging created EBS volumes with custom tags. Most of the plumbing was already there since a tag is used to identify the volume, exposed a new parameter  `additionalTags` and added unit test cases.

**What testing is done?** 
* Unit test cases
* Locally tested on a cluster
