### PR TITLE
Don't wait for the snapshot to be completed

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -410,7 +410,7 @@ func newCreateSnapshotResponse(snapshot *cloud.Snapshot) (*csi.CreateSnapshotRes
 			SourceVolumeId: snapshot.SourceVolumeID,
 			SizeBytes:      snapshot.Size,
 			CreationTime:   ts,
-			ReadyToUse:     true, // In AWS it's eiter this or error
+			ReadyToUse:     snapshot.ReadyToUse,
 		},
 	}, nil
 }


### PR DESCRIPTION
This patch changes the way the snapshots are being created: Originally the driver waited for the snapshot to complete. This is wrong since the snapshot creation may take a really long time. Also the gRPC would most likely timeout (the call is meant to be blocking) and cause all kinds of other problems.

Now the driver retruns the snapshot as soon as it appears in EC2 with ReadyToUse state in `false` and updates the state accordingly when the controller calls the SnapshotCreate again with the same parameters.