### PR TITLE
Implement raw block volume support

### DIFF
--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -74,6 +74,24 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 		},
 		{
+			name: "success normal [raw block]",
+			req: &csi.NodeStageVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: "/dev/fake"},
+				StagingTargetPath: "/test/path",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Block{
+						Block: &csi.VolumeCapability_BlockVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeId: "vol-test",
+			},
+			expActions:     []mount.FakeAction{},
+			expMountPoints: []mount.MountPoint{},
+		},
+		{
 			name: "success mount options fsType ext3",
 			req: &csi.NodeStageVolumeRequest{
 				PublishContext:    map[string]string{DevicePathKey: "/dev/fake"},
@@ -419,6 +437,39 @@ func TestNodePublishVolume(t *testing.T) {
 				{
 					Device: "/test/staging/path",
 					Opts:   []string{"bind", "test-flag"},
+					Path:   "/test/target/path",
+					Type:   defaultFsType,
+				},
+			},
+		},
+		{
+			name: "success normal [raw block]",
+			req: &csi.NodePublishVolumeRequest{
+				PublishContext:    map[string]string{DevicePathKey: "/dev/fake"},
+				StagingTargetPath: "/test/staging/path",
+				TargetPath:        "/test/target/path",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Block{
+						Block: &csi.VolumeCapability_BlockVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				VolumeId: "vol-test",
+			},
+			expActions: []mount.FakeAction{
+				{
+					Action: "mount",
+					FSType: defaultFsType,
+					Source: "/dev/fake",
+					Target: "/test/target/path",
+				},
+			},
+			expMountPoints: []mount.MountPoint{
+				{
+					Device: "/dev/fake",
+					Opts:   []string{"bind"},
 					Path:   "/test/target/path",
 					Type:   defaultFsType,
 				},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Ref: #101 

**What is this PR about? / Why do we need it?**
To reach feature parity for in-tree ebs plugin and to support CSI migration, adding support for raw block volume

**What testing is done?** 
Manually tested using:
**pvc**
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: block-pvc
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Block
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 10Gi
```

**pod**
```
apiVersion: v1
kind: Pod
metadata:
  name: pod-with-block-volume
spec:
  containers:
    - name: fc-container
      image: fedora:26
      command: ["/bin/sh", "-c"]
      args: [ "tail -f /dev/null" ]
      volumeDevices:
        - name: data
          devicePath: /dev/xvda
  volumes:
    - name: data
      persistentVolumeClaim:
        claimName: block-pvc
```

verified the device is accessible using `dd`:
```sh
>> kk exec -ti pod-with-block-volume bash
>> dd if=/dev/zero of=/dev/xvda bs=1024k count=100
100+0 records in
100+0 records out
104857600 bytes (105 MB, 100 MiB) copied, 0.0492386 s, 2.1 GB/s
```