### PR TITLE
Fix bug in e2e test

### DIFF
--- a/tests/e2e/testsuites/specs.go
+++ b/tests/e2e/testsuites/specs.go
@@ -16,6 +16,7 @@ package testsuites
 
 import (
 	"fmt"
+
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
 
 	"k8s.io/api/core/v1"
@@ -54,8 +55,8 @@ func (pod *PodDetails) SetupWithDynamicVolumes(client clientset.Interface, names
 	tpod := NewTestPod(client, namespace, pod.Cmd)
 	cleanupFuncs := make([]func(), 0)
 	for n, v := range pod.Volumes {
-		var tpvc *TestPersistentVolumeClaim
-		tpvc, cleanupFuncs = v.SetupDynamicPersistentVolumeClaim(client, namespace, csiDriver)
+		tpvc, funcs := v.SetupDynamicPersistentVolumeClaim(client, namespace, csiDriver)
+		cleanupFuncs = append(cleanupFuncs, funcs...)
 
 		tpod.SetupVolume(tpvc.persistentVolumeClaim, fmt.Sprintf("%s%d", v.VolumeMount.NameGenerate, n+1), fmt.Sprintf("%s%d", v.VolumeMount.MountPathGenerate, n+1), v.VolumeMount.ReadOnly)
 	}
@@ -66,8 +67,8 @@ func (pod *PodDetails) SetupWithPreProvisionedVolumes(client clientset.Interface
 	tpod := NewTestPod(client, namespace, pod.Cmd)
 	cleanupFuncs := make([]func(), 0)
 	for n, v := range pod.Volumes {
-		var tpvc *TestPersistentVolumeClaim
-		tpvc, cleanupFuncs = v.SetupPreProvisionedPersistentVolumeClaim(client, namespace, csiDriver)
+		tpvc, funcs := v.SetupPreProvisionedPersistentVolumeClaim(client, namespace, csiDriver)
+		cleanupFuncs = append(cleanupFuncs, funcs...)
 
 		tpod.SetupVolume(tpvc.persistentVolumeClaim, fmt.Sprintf("%s%d", v.VolumeMount.NameGenerate, n+1), fmt.Sprintf("%s%d", v.VolumeMount.MountPathGenerate, n+1), v.VolumeMount.ReadOnly)
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix bug in e2e test where cleanup is missing for dynamic created pvs and pre created pvs.

**Testing**
Saw pvc deleting log for each pvc instead of only one:
```
[1mSTEP[0m: Deleting pod ebs-volume-tester-nrc2f in namespace e2e-tests-ebs-ccr6c
Feb 24 17:39:20.779: INFO: deleting PVC "e2e-tests-ebs-ccr6c"/"pvc-r6l9h"
Feb 24 17:39:20.779: INFO: Deleting PersistentVolumeClaim "pvc-r6l9h"
[1mSTEP[0m: waiting for claim's PV "pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534" to be deleted
Feb 24 17:39:20.845: INFO: Waiting up to 10m0s for PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 to get deleted
Feb 24 17:39:20.914: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (69.126832ms)
Feb 24 17:39:25.979: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (5.134088766s)
Feb 24 17:39:31.063: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (10.217669843s)
Feb 24 17:39:36.128: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (15.283071825s)
Feb 24 17:39:41.193: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (20.347712215s)
Feb 24 17:39:46.258: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (25.413006618s)
Feb 24 17:39:51.326: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (30.480756698s)
Feb 24 17:39:56.393: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (35.547826331s)
Feb 24 17:40:01.460: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 found and phase=Released (40.614691837s)
Feb 24 17:40:06.525: INFO: PersistentVolume pvc-f5047e9e-385a-11e9-abc0-025ab9cfe534 was removed
Feb 24 17:40:06.525: INFO: Waiting up to 5m0s for PersistentVolumeClaim e2e-tests-ebs-ccr6c to be removed
Feb 24 17:40:06.589: INFO: Claim "e2e-tests-ebs-ccr6c" in namespace "pvc-r6l9h" doesn't exist in the system
Feb 24 17:40:06.589: INFO: deleting StorageClass e2e-tests-ebs-ccr6c-ebs.csi.aws.com-dynamic-sc-2xs5b
Feb 24 17:40:06.661: INFO: deleting PVC "e2e-tests-ebs-ccr6c"/"pvc-d985d"
Feb 24 17:40:06.661: INFO: Deleting PersistentVolumeClaim "pvc-d985d"
[1mSTEP[0m: waiting for claim's PV "pvc-e87ddcb4-385a-11e9-abc0-025ab9cfe534" to be deleted
Feb 24 17:40:06.728: INFO: Waiting up to 10m0s for PersistentVolume pvc-e87ddcb4-385a-11e9-abc0-025ab9cfe534 to get deleted
Feb 24 17:40:06.792: INFO: PersistentVolume pvc-e87ddcb4-385a-11e9-abc0-025ab9cfe534 found and phase=Released (64.409588ms)
Feb 24 17:40:11.857: INFO: PersistentVolume pvc-e87ddcb4-385a-11e9-abc0-025ab9cfe534 was removed
Feb 24 17:40:11.857: INFO: Waiting up to 5m0s for PersistentVolumeClaim e2e-tests-ebs-ccr6c to be removed
Feb 24 17:40:11.922: INFO: Claim "e2e-tests-ebs-ccr6c" in namespace "pvc-d985d" doesn't exist in the system
Feb 24 17:40:11.922: INFO: deleting StorageClass e2e-tests-ebs-ccr6c-ebs.csi.aws.com-dynamic-sc-jzfbb
```