### PR TITLE
New block volume e2e tests

### DIFF
--- a/hack/feature-gates.yaml
+++ b/hack/feature-gates.yaml
@@ -2,7 +2,9 @@
     featureGates:
       CSIDriverRegistry: "true"
       CSINodeInfo: "true"
+      CSIBlockVolume: "true"
   kubelet:
     featureGates:
       CSIDriverRegistry: "true"
       CSINodeInfo: "true"
+      CSIBlockVolume: "true"

--- a/tests/e2e/testsuites/dynamically_provisioned_cmd_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_cmd_volume_tester.go
@@ -16,22 +16,21 @@ package testsuites
 
 import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
-
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 
 	. "github.com/onsi/ginkgo"
 )
 
-// DynamicallyProvisionedWriterReaderVolumeTest will provision required StorageClass(es), PVC(s) and Pod(s)
+// DynamicallyProvisionedCmdVolumeTest will provision required StorageClass(es), PVC(s) and Pod(s)
 // Waiting for the PV provisioner to create a new PV
-// Testing if the Pod(s) can write and read to mounted volumes
-type DynamicallyProvisionedWriterReaderVolumeTest struct {
+// Testing if the Pod(s) Cmd is run with a 0 exit code
+type DynamicallyProvisionedCmdVolumeTest struct {
 	CSIDriver driver.DynamicPVTestDriver
 	Pods      []PodDetails
 }
 
-func (t *DynamicallyProvisionedWriterReaderVolumeTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+func (t *DynamicallyProvisionedCmdVolumeTest) Run(client clientset.Interface, namespace *v1.Namespace) {
 	for _, pod := range t.Pods {
 		tpod, cleanup := pod.SetupWithDynamicVolumes(client, namespace, t.CSIDriver)
 		// defer must be called here for resources not get removed before using them


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/221

**What is this PR about? / Why do we need it?**
Add 2 new e2e tests that provisions block volumes.
* a single pod with 1 block volume
* a single pod with 1 block volume and 1 filesystem volume

**What testing is done?** 
Locally ran the e2e tests:

```
• [SLOW TEST:58.178 seconds]
[ebs-csi-e2e] [single-az] Dynamic Provisioning
/Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:35
  should create a raw block volume on demand
  /Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:204
------------------------------
SSSSSSSSSS
Ran 1 of 32 Specs in 58.178 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 31 Skipped
PASS

Ginkgo ran 1 suite in 1m6.767981631s
Test Suite Passed

• [SLOW TEST:90.392 seconds]
[ebs-csi-e2e] [single-az] Dynamic Provisioning
/Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:35
  should create a raw block volume and a filesystem volume on demand and bind to the same pod
  /Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:228
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 32 Specs in 90.393 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 31 Skipped
PASS

Ginkgo ran 1 suite in 1m38.738854833s
Test Suite Passed
```