### PR TITLE
Use default kubeconfig location

### DIFF
--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -15,6 +15,8 @@ limitations under the License.
 package e2e
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -22,7 +24,15 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+const kubeconfigEnvVar = "KUBECONFIG"
+
 func init() {
+	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
+	// it does not fall back to defaults
+	if os.Getenv(kubeconfigEnvVar) == "" {
+		kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		os.Setenv(kubeconfigEnvVar, kubeconfig)
+	}
 	framework.HandleFlags()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/182

**What is this PR about? / Why do we need it?**
Fallback to `$HOME/.kube/config` if `$KUBECONFIG` is not set.

**What testing is done?** 
```
➜  aws-ebs-csi-driver git:(master) ✗ unset KUBECONFIG
➜  aws-ebs-csi-driver git:(dkoshkin/block-volume-e2e) ✗ echo $KUBECONFIG

➜  aws-ebs-csi-driver git:(dkoshkin/block-volume-e2e) ✗ ginkgo -v --focus "should create a raw block volume on demand" tests/e2e
Feb 26 07:37:13.474: INFO: The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.
Running Suite: AWS EBS CSI Driver End-to-End Tests
==================================================
Random Seed: 1551184624 - Will randomize all specs
Will run 1 of 32 specs

SSSS
------------------------------
[ebs-csi-e2e] [single-az] Dynamic Provisioning
  should create a raw block volume on demand
  /Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:204
[BeforeEach] [ebs-csi-e2e] [single-az] Dynamic Provisioning
  /Users/dkoshkin/go/pkg/mod/k8s.io/kubernetes@v1.13.1/test/e2e/framework/framework.go:153
STEP: Creating a kubernetes client
Feb 26 07:37:13.476: INFO: >>> kubeConfig: /Users/dkoshkin/.kube/config


➜  aws-ebs-csi-driver git:(dkoshkin/block-volume-e2e) ✗ cp ~/.kube/config ~/.kube/config2
➜  aws-ebs-csi-driver git:(dkoshkin/block-volume-e2e) ✗ export KUBECONFIG=~/.kube/config2
➜  aws-ebs-csi-driver git:(dkoshkin/block-volume-e2e) ✗ ginkgo -v --focus "should create a raw block volume on demand" tests/e2e
Feb 26 07:38:44.404: INFO: The --provider flag is not set.  Treating as a conformance test.  Some tests may not be run.
Running Suite: AWS EBS CSI Driver End-to-End Tests
==================================================
Random Seed: 1551184715 - Will randomize all specs
Will run 1 of 32 specs

SSSSSSSSSSSSSSSS
------------------------------
[ebs-csi-e2e] [single-az] Dynamic Provisioning
  should create a raw block volume on demand
  /Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:204
[BeforeEach] [ebs-csi-e2e] [single-az] Dynamic Provisioning
  /Users/dkoshkin/go/pkg/mod/k8s.io/kubernetes@v1.13.1/test/e2e/framework/framework.go:153
STEP: Creating a kubernetes client
Feb 26 07:38:44.405: INFO: >>> kubeConfig: /Users/dkoshkin/.kube/config2
```
