### PR TITLE
Implement device path discovery for NVMe support

### DIFF
--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/util/mount"
 
 	sanity "github.com/kubernetes-csi/csi-test/pkg/sanity"
 
@@ -44,7 +45,12 @@ func TestSanity(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	ebsDriver = driver.NewFakeDriver(endpoint, cloud.NewFakeCloudProvider(), driver.NewFakeMounter())
+	fakeMounter := &mount.FakeMounter{
+		Filesystem: map[string]mount.FileType{
+			"/dev/xvdbc": mount.FileTypeFile,
+		},
+	}
+	ebsDriver = driver.NewFakeDriver(endpoint, cloud.NewFakeCloudProvider(), fakeMounter)
 	go func() {
 		Expect(ebsDriver.Run()).NotTo(HaveOccurred())
 	}()


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Add support for nvme on Nitro instance
Fixes: #178 

**What testing is done?** 
Manually tested following scenario:
 - [x] nvme on m5.xlarge with filesystem mode
 - [x] nvme on m5.xlarge with block volume mode