### PR TITLE
New volume snapshot e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/kubernetes-csi/csi-test v1.1.0
+	github.com/kubernetes-csi/external-snapshotter v1.0.1
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kubernetes-csi/csi-test v1.1.0 h1:a7CfGqhGDs0h7AZt1f6LTIUzBazcRf6eBdTUBXB4xE4=
 github.com/kubernetes-csi/csi-test v1.1.0/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
+github.com/kubernetes-csi/external-snapshotter v1.0.1 h1:mR9hun6TViPyNDa+SFoRxnIXQmITIVM840ODiuNG784=
+github.com/kubernetes-csi/external-snapshotter v1.0.1/go.mod h1:oYfxnsuh48V1UDYORl77YQxQbbdokNy7D73phuFpksY=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -221,6 +223,7 @@ gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20181204000039-89a74a8d264d h1:HQoGWsWUe/FmRcX9BU440AAMnzBFEf+DBo4nbkQlNzs=
 k8s.io/api v0.0.0-20181204000039-89a74a8d264d/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
+k8s.io/api v0.0.0-20190226013409-f951fa7b8c72 h1:4wrH+M4Kpkbbjs4UzT7XOvuhgBczsd4eXfBn9T5WqKk=
 k8s.io/apiextensions-apiserver v0.0.0-20181204003920-20c909e7c8c3 h1:bpFjd6jnk/2Wi5ZqnJaTbaHt4GhCYwc2UlhcyYrOx24=
 k8s.io/apiextensions-apiserver v0.0.0-20181204003920-20c909e7c8c3/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93 h1:tT6oQBi0qwLbbZSfDkdIsb23EwaLY85hoAV4SpXfdao=

--- a/hack/feature-gates.yaml
+++ b/hack/feature-gates.yaml
@@ -3,6 +3,7 @@
       CSIDriverRegistry: "true"
       CSINodeInfo: "true"
       CSIBlockVolume: "true"
+      VolumeSnapshotDataSource: "true"
   kubelet:
     featureGates:
       CSIDriverRegistry: "true"

--- a/tests/e2e/driver/driver.go
+++ b/tests/e2e/driver/driver.go
@@ -15,14 +15,21 @@ limitations under the License.
 package driver
 
 import (
+	"github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
 	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	VolumeSnapshotClassKind = "VolumeSnapshotClass"
+	SnapshotAPIVersion      = "snapshot.storage.k8s.io/v1alpha1"
+)
+
 type PVTestDriver interface {
 	DynamicPVTestDriver
 	PreProvisionedVolumeTestDriver
+	VolumeSnapshotTestDriver
 }
 
 // DynamicPVTestDriver represents an interface for a CSI driver that supports DynamicPV
@@ -35,6 +42,10 @@ type DynamicPVTestDriver interface {
 type PreProvisionedVolumeTestDriver interface {
 	// GetPersistentVolume returns a PersistentVolume with pre-provisioned volumeHandle
 	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume
+}
+
+type VolumeSnapshotTestDriver interface {
+	GetVolumeSnapshotClass(namespace string) *v1alpha1.VolumeSnapshotClass
 }
 
 func getStorageClass(
@@ -64,5 +75,19 @@ func getStorageClass(
 		ReclaimPolicy:     reclaimPolicy,
 		VolumeBindingMode: bindingMode,
 		AllowedTopologies: allowedTopologies,
+	}
+}
+
+func getVolumeSnapshotClass(generateName string, provisioner string) *v1alpha1.VolumeSnapshotClass {
+	return &v1alpha1.VolumeSnapshotClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       VolumeSnapshotClassKind,
+			APIVersion: SnapshotAPIVersion,
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateName,
+		},
+		Snapshotter: provisioner,
 	}
 }

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -16,6 +16,7 @@ package driver
 
 import (
 	"fmt"
+	"github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1"
 	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -41,7 +42,7 @@ func InitEbsCSIDriver() PVTestDriver {
 
 func (d *ebsCSIDriver) GetDynamicProvisionStorageClass(parameters map[string]string, mountOptions []string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, bindingMode *storagev1.VolumeBindingMode, allowedTopologyValues []string, namespace string) *storagev1.StorageClass {
 	provisioner := d.driverName
-	generatedName := fmt.Sprintf("%s-%s-dynamic-sc-", namespace, provisioner)
+	generateName := fmt.Sprintf("%s-%s-dynamic-sc-", namespace, provisioner)
 	allowedTopologies := []v1.TopologySelectorTerm{}
 	if len(allowedTopologyValues) > 0 {
 		allowedTopologies = []v1.TopologySelectorTerm{
@@ -55,7 +56,13 @@ func (d *ebsCSIDriver) GetDynamicProvisionStorageClass(parameters map[string]str
 			},
 		}
 	}
-	return getStorageClass(generatedName, provisioner, parameters, mountOptions, reclaimPolicy, bindingMode, allowedTopologies)
+	return getStorageClass(generateName, provisioner, parameters, mountOptions, reclaimPolicy, bindingMode, allowedTopologies)
+}
+
+func (d *ebsCSIDriver) GetVolumeSnapshotClass(namespace string) *v1alpha1.VolumeSnapshotClass {
+	provisioner := d.driverName
+	generateName := fmt.Sprintf("%s-%s-dynamic-sc-", namespace, provisioner)
+	return getVolumeSnapshotClass(generateName, provisioner)
 }
 
 func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume {

--- a/tests/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+
+	"k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	restclientset "k8s.io/client-go/rest"
+
+	. "github.com/onsi/ginkgo"
+)
+
+// DynamicallyProvisionedVolumeSnapshotTest will provision required StorageClass(es),VolumeSnapshotClass(es), PVC(s) and Pod(s)
+// Waiting for the PV provisioner to create a new PV
+// Testing if the Pod(s) can write and read to mounted volumes
+// Create a snapshot, validate the data is still on the disk, and then write and read to it again
+// And finally delete the snapshot
+// This test only supports a single volume
+type DynamicallyProvisionedVolumeSnapshotTest struct {
+	CSIDriver   driver.PVTestDriver
+	Pod         PodDetails
+	RestoredPod PodDetails
+}
+
+func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(client clientset.Interface, restclient restclientset.Interface, namespace *v1.Namespace) {
+	tpod := NewTestPod(client, namespace, t.Pod.Cmd)
+	volume := t.Pod.Volumes[0]
+	tpvc, pvcCleanup := volume.SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver)
+	for i := range pvcCleanup {
+		defer pvcCleanup[i]()
+	}
+	tpod.SetupVolume(tpvc.persistentVolumeClaim, volume.VolumeMount.NameGenerate+"1", volume.VolumeMount.MountPathGenerate+"1", volume.VolumeMount.ReadOnly)
+
+	By("deploying the pod")
+	tpod.Create()
+	defer tpod.Cleanup()
+	By("checking that the pods command exits with no error")
+	tpod.WaitForSuccess()
+
+	By("taking snapshots")
+	tvsc, cleanup := CreateVolumeSnapshotClass(restclient, namespace, t.CSIDriver)
+	defer cleanup()
+
+	snapshot := tvsc.CreateSnapshot(tpvc.persistentVolumeClaim)
+	defer tvsc.DeleteSnapshot(snapshot)
+	tvsc.ReadyToUse(snapshot)
+
+	t.RestoredPod.Volumes[0].DataSource = &DataSource{Name: snapshot.Name}
+	trpod := NewTestPod(client, namespace, t.RestoredPod.Cmd)
+	rvolume := t.RestoredPod.Volumes[0]
+	trpvc, rpvcCleanup := rvolume.SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver)
+	for i := range rpvcCleanup {
+		defer rpvcCleanup[i]()
+	}
+	trpod.SetupVolume(trpvc.persistentVolumeClaim, rvolume.VolumeMount.NameGenerate+"1", rvolume.VolumeMount.MountPathGenerate+"1", rvolume.VolumeMount.ReadOnly)
+
+	By("deploying a second pod with a volume restored from the snapshot")
+	trpod.Create()
+	defer trpod.Cleanup()
+	By("checking that the pods command exits with no error")
+	trpod.WaitForSuccess()
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/228 

**What is this PR about? / Why do we need it?**
Add a new e2e test to provision a pod, write to a volume, take a snapshot, provision a new pod with a volume source as the snapshot, and then validate the data is as expected.
```
• [SLOW TEST:175.757 seconds]
[ebs-csi-e2e] [single-az] Dynamic Provisioning
/Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:39
  should create a pod, write and read to it, take a volume snapshot, and create another pod from the snapshot
  /Users/dkoshkin/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/dynamic_provisioning.go:411
------------------------------
SSSSSSSSSSSS
Ran 1 of 33 Specs in 175.758 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 32 Skipped
PASS

Ginkgo ran 1 suite in 3m4.633563865s
Test Suite Passed
``` 

**What testing is done?** 
Locally ran the e2e test about 10 times.