### PR TITLE
Refactor driver to modularize node service and controller service

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -167,12 +167,10 @@ type cloud struct {
 var _ Cloud = &cloud{}
 
 // NewCloud returns a new instance of AWS cloud
-// Pass in nil metadata to use an auto created EC2Metadata service
 // It panics if session is invalid
 func NewCloud() (Cloud, error) {
 	svc := newEC2MetadataSvc()
 
-	var err error
 	metadata, err := NewMetadataService(svc)
 	if err != nil {
 		return nil, fmt.Errorf("could not get metadata from AWS: %v", err)

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -268,7 +268,7 @@ func TestCreateVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
+			awsDriver := controllerService{cloud: cloud.NewFakeCloudProvider()}
 
 			resp, err := awsDriver.CreateVolume(context.TODO(), tc.req)
 			if err != nil {
@@ -353,7 +353,7 @@ func TestDeleteVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
+			awsDriver := controllerService{cloud: cloud.NewFakeCloudProvider()}
 			_, err := awsDriver.DeleteVolume(context.TODO(), tc.req)
 			if err != nil {
 				srvErr, ok := status.FromError(err)
@@ -499,7 +499,7 @@ func TestCreateSnapshot(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
-		awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
+		awsDriver := controllerService{cloud: cloud.NewFakeCloudProvider()}
 		resp, err := awsDriver.CreateSnapshot(context.TODO(), tc.req)
 		if err != nil {
 			srvErr, ok := status.FromError(err)
@@ -565,7 +565,7 @@ func TestDeleteSnapshot(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
-		awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
+		awsDriver := controllerService{cloud: cloud.NewFakeCloudProvider()}
 		snapResp, err := awsDriver.CreateSnapshot(context.TODO(), snapReq)
 		if err != nil {
 			t.Fatalf("Error creating testing snapshot: %v", err)
@@ -707,7 +707,7 @@ func TestControllerPublishVolume(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setup(tc.req)
-			awsDriver := NewFakeDriver("", fakeCloud, NewFakeMounter())
+			awsDriver := controllerService{cloud: fakeCloud}
 			_, err := awsDriver.ControllerPublishVolume(context.TODO(), tc.req)
 			if err != nil {
 				srvErr, ok := status.FromError(err)
@@ -772,7 +772,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setup(tc.req)
-			awsDriver := NewFakeDriver("", fakeCloud, NewFakeMounter())
+			awsDriver := controllerService{cloud: cloud.NewFakeCloudProvider()}
 			_, err := awsDriver.ControllerUnpublishVolume(context.TODO(), tc.req)
 			if err != nil {
 				srvErr, ok := status.FromError(err)

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -29,21 +29,27 @@ func NewFakeMounter() *mount.FakeMounter {
 	}
 }
 
-func NewFakeSafeFormatAndMounter(fakeMounter *mount.FakeMounter) *mount.SafeFormatAndMount {
+func NewFakeSafeFormatAndMounter(fakeMounter mount.Interface) *mount.SafeFormatAndMount {
 	return &mount.SafeFormatAndMount{
 		Interface: fakeMounter,
 		Exec:      mount.NewFakeExec(nil),
 	}
-
 }
 
 // NewFakeDriver creates a new mock driver used for testing
 func NewFakeDriver(endpoint string, fakeCloud *cloud.FakeCloudProvider, fakeMounter *mount.FakeMounter) *Driver {
 	return &Driver{
 		endpoint: endpoint,
-		nodeID:   fakeCloud.GetMetadata().GetInstanceID(),
-		cloud:    fakeCloud,
-		mounter:  NewFakeSafeFormatAndMounter(fakeMounter),
-		inFlight: internal.NewInFlight(),
+		controllerService: controllerService{
+			cloud: fakeCloud,
+		},
+		nodeService: nodeService{
+			metadata: fakeCloud.GetMetadata(),
+			mounter: &mount.SafeFormatAndMount{
+				Interface: fakeMounter,
+				Exec:      mount.NewFakeExec(nil),
+			},
+			inFlight: internal.NewInFlight(),
+		},
 	}
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -225,7 +226,9 @@ func TestNodeStageVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), tc.fakeMounter)
+			awsDriver := newTestNodeService(
+				cloud.NewFakeCloudProvider().GetMetadata(),
+				tc.fakeMounter)
 
 			_, err := awsDriver.NodeStageVolume(context.TODO(), tc.req)
 			if err != nil {
@@ -325,7 +328,9 @@ func TestNodeUnstageVolume(t *testing.T) {
 			if len(tc.fakeMountPoints) > 0 {
 				fakeMounter.MountPoints = tc.fakeMountPoints
 			}
-			awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), fakeMounter)
+			awsDriver := newTestNodeService(
+				cloud.NewFakeCloudProvider().GetMetadata(),
+				fakeMounter)
 
 			_, err := awsDriver.NodeUnstageVolume(context.TODO(), tc.req)
 			if err != nil {
@@ -569,7 +574,9 @@ func TestNodePublishVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), tc.fakeMounter)
+			awsDriver := newTestNodeService(
+				cloud.NewFakeCloudProvider().GetMetadata(),
+				tc.fakeMounter)
 
 			_, err := awsDriver.NodePublishVolume(context.TODO(), tc.req)
 			if err != nil {
@@ -647,7 +654,10 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			if tc.fakeMountPoint != nil {
 				fakeMounter.MountPoints = append(fakeMounter.MountPoints, *tc.fakeMountPoint)
 			}
-			awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), fakeMounter)
+
+			awsDriver := newTestNodeService(
+				cloud.NewFakeCloudProvider().GetMetadata(),
+				fakeMounter)
 
 			_, err := awsDriver.NodeUnpublishVolume(context.TODO(), tc.req)
 			if err != nil {
@@ -673,7 +683,11 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 func TestNodeGetVolumeStats(t *testing.T) {
 	req := &csi.NodeGetVolumeStatsRequest{}
-	awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
+
+	awsDriver := newTestNodeService(
+		cloud.NewFakeCloudProvider().GetMetadata(),
+		NewFakeMounter())
+
 	expErrCode := codes.Unimplemented
 
 	_, err := awsDriver.NodeGetVolumeStats(context.TODO(), req)
@@ -691,7 +705,10 @@ func TestNodeGetVolumeStats(t *testing.T) {
 
 func TestNodeGetCapabilities(t *testing.T) {
 	req := &csi.NodeGetCapabilitiesRequest{}
-	awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
+	awsDriver := newTestNodeService(
+		cloud.NewFakeCloudProvider().GetMetadata(),
+		NewFakeMounter())
+
 	caps := []*csi.NodeServiceCapability{
 		{
 			Type: &csi.NodeServiceCapability_Rpc{
@@ -718,8 +735,13 @@ func TestNodeGetCapabilities(t *testing.T) {
 
 func TestNodeGetInfo(t *testing.T) {
 	req := &csi.NodeGetInfoRequest{}
-	awsDriver := NewFakeDriver("", cloud.NewFakeCloudProvider(), NewFakeMounter())
-	m := awsDriver.cloud.GetMetadata()
+	cloud := cloud.NewFakeCloudProvider()
+
+	awsDriver := newTestNodeService(
+		cloud.GetMetadata(),
+		NewFakeMounter())
+
+	m := cloud.GetMetadata()
 	expResp := &csi.NodeGetInfoResponse{
 		NodeId: "instanceID",
 		AccessibleTopology: &csi.Topology{
@@ -737,5 +759,13 @@ func TestNodeGetInfo(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expResp, resp) {
 		t.Fatalf("Expected response {%+v}, got {%+v}", expResp, resp)
+	}
+}
+
+func newTestNodeService(metadata cloud.MetadataService, mounter mount.Interface) nodeService {
+	return nodeService{
+		metadata: cloud.NewFakeCloudProvider().GetMetadata(),
+		mounter:  NewFakeSafeFormatAndMounter(mounter),
+		inFlight: internal.NewInFlight(),
 	}
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Currently, all the driver's dependency are grouped in `Driver` struct. This causes controller service has access to `mounter` and node service has access to `cloud`. This is to increase the maintainability and to modularize the components.

Refactor driver by modularizing node service and controller service so that each service has its own struct with required dependency fields. 
