### PR TITLE
Add max number of volumes that can be attached to an instance

### DIFF
--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -30,12 +30,14 @@ type EC2Metadata interface {
 // MetadataService represents AWS metadata service.
 type MetadataService interface {
 	GetInstanceID() string
+	GetInstanceType() string
 	GetRegion() string
 	GetAvailabilityZone() string
 }
 
 type Metadata struct {
 	InstanceID       string
+	InstanceType     string
 	Region           string
 	AvailabilityZone string
 }
@@ -45,6 +47,11 @@ var _ MetadataService = &Metadata{}
 // GetInstanceID returns the instance identification.
 func (m *Metadata) GetInstanceID() string {
 	return m.InstanceID
+}
+
+// GetInstanceID returns the instance type.
+func (m *Metadata) GetInstanceType() string {
+	return m.InstanceType
 }
 
 // GetRegion returns the region which the instance is in.
@@ -72,6 +79,10 @@ func NewMetadataService(svc EC2Metadata) (MetadataService, error) {
 		return nil, fmt.Errorf("could not get valid EC2 instance ID")
 	}
 
+	if len(doc.InstanceType) == 0 {
+		return nil, fmt.Errorf("could not get valid EC2 instance type")
+	}
+
 	if len(doc.Region) == 0 {
 		return nil, fmt.Errorf("could not get valid EC2 region")
 	}
@@ -82,6 +93,7 @@ func NewMetadataService(svc EC2Metadata) (MetadataService, error) {
 
 	return &Metadata{
 		InstanceID:       doc.InstanceID,
+		InstanceType:     doc.InstanceType,
 		Region:           doc.Region,
 		AvailabilityZone: doc.AvailabilityZone,
 	}, nil

--- a/pkg/cloud/metadata_test.go
+++ b/pkg/cloud/metadata_test.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	stdInstanceID       = "instance-1"
+	stdInstanceType     = "t2.medium"
 	stdRegion           = "instance-1"
 	stdAvailabilityZone = "az-1"
 )
@@ -44,6 +45,7 @@ func TestNewMetadataService(t *testing.T) {
 			isAvailable: true,
 			identityDocument: ec2metadata.EC2InstanceIdentityDocument{
 				InstanceID:       stdInstanceID,
+				InstanceType:     stdInstanceType,
 				Region:           stdRegion,
 				AvailabilityZone: stdAvailabilityZone,
 			},
@@ -54,6 +56,7 @@ func TestNewMetadataService(t *testing.T) {
 			isAvailable: false,
 			identityDocument: ec2metadata.EC2InstanceIdentityDocument{
 				InstanceID:       stdInstanceID,
+				InstanceType:     stdInstanceType,
 				Region:           stdRegion,
 				AvailabilityZone: stdAvailabilityZone,
 			},
@@ -64,6 +67,7 @@ func TestNewMetadataService(t *testing.T) {
 			isAvailable: true,
 			identityDocument: ec2metadata.EC2InstanceIdentityDocument{
 				InstanceID:       stdInstanceID,
+				InstanceType:     stdInstanceType,
 				Region:           stdRegion,
 				AvailabilityZone: stdAvailabilityZone,
 			},
@@ -75,6 +79,7 @@ func TestNewMetadataService(t *testing.T) {
 			isPartial:   true,
 			identityDocument: ec2metadata.EC2InstanceIdentityDocument{
 				InstanceID:       "",
+				InstanceType:     stdInstanceType,
 				Region:           stdRegion,
 				AvailabilityZone: stdAvailabilityZone,
 			},
@@ -86,6 +91,7 @@ func TestNewMetadataService(t *testing.T) {
 			isPartial:   true,
 			identityDocument: ec2metadata.EC2InstanceIdentityDocument{
 				InstanceID:       stdInstanceID,
+				InstanceType:     stdInstanceType,
 				Region:           "",
 				AvailabilityZone: stdAvailabilityZone,
 			},
@@ -97,6 +103,7 @@ func TestNewMetadataService(t *testing.T) {
 			isPartial:   true,
 			identityDocument: ec2metadata.EC2InstanceIdentityDocument{
 				InstanceID:       stdInstanceID,
+				InstanceType:     stdInstanceType,
 				Region:           stdRegion,
 				AvailabilityZone: "",
 			},
@@ -122,6 +129,10 @@ func TestNewMetadataService(t *testing.T) {
 
 				if m.GetInstanceID() != tc.identityDocument.InstanceID {
 					t.Fatalf("GetInstanceID() failed: expected %v, got %v", tc.identityDocument.InstanceID, m.GetInstanceID())
+				}
+
+				if m.GetInstanceType() != tc.identityDocument.InstanceType {
+					t.Fatalf("GetInstanceType() failed: expected %v, got %v", tc.identityDocument.InstanceType, m.GetInstanceType())
 				}
 
 				if m.GetRegion() != tc.identityDocument.Region {

--- a/pkg/driver/mocks/mock_metadata_service.go
+++ b/pkg/driver/mocks/mock_metadata_service.go
@@ -60,6 +60,20 @@ func (mr *MockMetadataServiceMockRecorder) GetInstanceID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceID", reflect.TypeOf((*MockMetadataService)(nil).GetInstanceID))
 }
 
+// GetInstanceType mocks base method
+func (m *MockMetadataService) GetInstanceType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetInstanceType indicates an expected call of GetInstanceType
+func (mr *MockMetadataServiceMockRecorder) GetInstanceType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceType", reflect.TypeOf((*MockMetadataService)(nil).GetInstanceType))
+}
+
 // GetRegion mocks base method
 func (m *MockMetadataService) GetRegion() string {
 	m.ctrl.T.Helper()

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -17,16 +17,17 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+
 	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/testsuites"
 	. "github.com/onsi/ginkgo"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"math/rand"
-	"os"
-	"strings"
 
 	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 )
@@ -50,6 +51,10 @@ type e2eMetdataService struct {
 
 // GetInstanceID will always return an empty string as the test does not need to run on an EC2 machine
 func (s e2eMetdataService) GetInstanceID() string {
+	return ""
+}
+
+func (s e2eMetdataService) GetInstanceType() string {
 	return ""
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

/king feature

**What is this PR about? / Why do we need it?**

Without having this field set, k8s will interpret that the node can handle any amount of volumes. I'll create an issue to customize this number per instance type.

Closes #39

/assign @leakingtapan 