### PR TITLE
Return correct error when restoring non-existent snapshot

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -273,6 +273,9 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 
 	response, err := c.ec2.CreateVolumeWithContext(ctx, request)
 	if err != nil {
+		if isAWSErrorSnapshotNotFound(err) {
+			return nil, ErrNotFound
+		}
 		return nil, fmt.Errorf("could not create volume in EC2: %v", err)
 	}
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -164,7 +164,11 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	disk, err = d.cloud.CreateDisk(ctx, volName, opts)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not create volume %q: %v", volName, err)
+		errCode := codes.Internal
+		if err == cloud.ErrNotFound {
+			errCode = codes.NotFound
+		}
+		return nil, status.Errorf(errCode, "Could not create volume %q: %v", volName, err)
 	}
 	disk.FsType = fsType
 	return newCreateVolumeResponse(disk), nil


### PR DESCRIPTION
This should fix the issue #287: return correct error code when restoring a volume referencing non-existent snapshot.