### PR TITLE
Replace custom wait function with AWS native wait functions

### DIFF
--- a/pkg/cloud/mocks/mock_ec2.go
+++ b/pkg/cloud/mocks/mock_ec2.go
@@ -214,3 +214,41 @@ func (mr *MockEC2MockRecorder) DetachVolumeWithContext(arg0, arg1 interface{}, a
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolumeWithContext", reflect.TypeOf((*MockEC2)(nil).DetachVolumeWithContext), varargs...)
 }
+
+// WaitUntilVolumeAvailableWithContext mocks base method
+func (m *MockEC2) WaitUntilVolumeAvailableWithContext(arg0 aws.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.WaiterOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WaitUntilVolumeAvailableWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilVolumeAvailableWithContext indicates an expected call of WaitUntilVolumeAvailableWithContext
+func (mr *MockEC2MockRecorder) WaitUntilVolumeAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeAvailableWithContext", reflect.TypeOf((*MockEC2)(nil).WaitUntilVolumeAvailableWithContext), varargs...)
+}
+
+// WaitUntilVolumeInUseWithContext mocks base method
+func (m *MockEC2) WaitUntilVolumeInUseWithContext(arg0 aws.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.WaiterOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WaitUntilVolumeInUseWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilVolumeInUseWithContext indicates an expected call of WaitUntilVolumeInUseWithContext
+func (mr *MockEC2MockRecorder) WaitUntilVolumeInUseWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeInUseWithContext", reflect.TypeOf((*MockEC2)(nil).WaitUntilVolumeInUseWithContext), varargs...)
+}

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -116,12 +116,10 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 
 	AfterEach(func() {
 		if !skipManuallyDeletingVolume {
-			err := cloud.WaitForAttachmentState(context.Background(), volumeID, "detached")
-			if err != nil {
+			if err := cloud.WaitForAttachmentState(context.Background(), volumeID, "detached"); err != nil {
 				Fail(fmt.Sprintf("could not detach volume %q: %v", volumeID, err))
 			}
-			ok, err := cloud.DeleteDisk(context.Background(), volumeID)
-			if err != nil || !ok {
+			if ok, err := cloud.DeleteDisk(context.Background(), volumeID); err != nil || !ok {
 				Fail(fmt.Sprintf("could not delete volume %q: %v", volumeID, err))
 			}
 		}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes: #280 

**What is this PR about? / Why do we need it?**
This PR replaces custom wait functions in the `cloud` package with AWS-native wait functions, namely:
`ec2.WaitUntilVolumeInUseWithContext` and `ec2.WaitUntilVolumeAvailableWithContext`

**What testing is done?** 
Unit tests have been written to handle errors returned from the AWS-native wait functions.  Also, unit tests for `cloud.CreateDisk`, `cloud.AttachDisk` and `cloud.DetachDisk` have been refactored so that test functions are defined per test case.