### PR TITLE
Device allocator should not use reserved dev names.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
-IMAGE=amazon/aws-ebs-csi-driver
+IMAGE=aragunathan/aws-ebs-csi-driver
 VERSION=0.4.0
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -53,8 +53,8 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csinodeinfos"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
@@ -85,7 +85,7 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete"]
-  - apiGroups: ["csi.storage.k8s.io"]
+  - apiGroups: ["storage.k8s.io"]
     resources: ["csidrivers"]
     verbs: ["create", "delete"]
 
@@ -176,7 +176,7 @@ spec:
           operator: Exists
       containers:
         - name: ebs-plugin
-          image: amazon/aws-ebs-csi-driver:latest
+          image: aragunathan/aws-ebs-csi-driver:latest
           args :
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -212,10 +212,9 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: cluster-driver-registrar
-          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:canary
           args:
             - --csi-address=$(ADDRESS)
-            - --driver-requires-attachment=true
             - --v=5
           env:
             - name: ADDRESS
@@ -224,7 +223,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.0.1
+          image: quay.io/k8scsi/csi-provisioner:canary
           args:
             - --provisioner=ebs.csi.aws.com
             - --csi-address=$(ADDRESS)
@@ -237,7 +236,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          image: quay.io/k8scsi/csi-attacher:canary
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -248,7 +247,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v1.0.1
+          image: quay.io/k8scsi/csi-snapshotter:canary
           args:
             - --csi-address=$(ADDRESS)
             - --connection-timeout=15s
@@ -259,7 +258,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.0.2
+          image: quay.io/k8scsi/livenessprobe:canary
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=3s
@@ -295,7 +294,7 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: amazon/aws-ebs-csi-driver:latest
+          image: aragunathan/aws-ebs-csi-driver:latest
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
@@ -344,7 +343,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.0.2
+          image: quay.io/k8scsi/livenessprobe:canary
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=3s

--- a/pkg/cloud/devicemanager/allocator.go
+++ b/pkg/cloud/devicemanager/allocator.go
@@ -47,10 +47,10 @@ var _ NameAllocator = &nameAllocator{}
 
 // GetNext gets next available device given existing names that are being used
 // This function iterate through the device names in deterministic order of:
-//     a, b, ... , z, aa, ab, ... , az
+//     ba, ... ,bz, ca, ... , cz
 // and return the first one that is not used yet.
 func (d *nameAllocator) GetNext(existingNames ExistingNames) (string, error) {
-	for _, c1 := range []string{"", "a"} {
+	for _, c1 := range []string{"b", "c"} {
 		for c2 := 'a'; c2 <= 'z'; c2++ {
 			name := fmt.Sprintf("%s%s", c1, string(c2))
 			if _, found := existingNames[name]; !found {

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -27,12 +27,12 @@ func TestNameAllocator(t *testing.T) {
 	tests := []struct {
 		expectedName string
 	}{
-		{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}, {"j"},
-		{"k"}, {"l"}, {"m"}, {"n"}, {"o"}, {"p"}, {"q"}, {"r"}, {"s"}, {"t"},
-		{"u"}, {"v"}, {"w"}, {"x"}, {"y"}, {"z"},
-		{"aa"}, {"ab"}, {"ac"}, {"ad"}, {"ae"}, {"af"}, {"ag"}, {"ah"}, {"ai"}, {"aj"},
-		{"ak"}, {"al"}, {"am"}, {"an"}, {"ao"}, {"ap"}, {"aq"}, {"ar"}, {"as"}, {"at"},
-		{"au"}, {"av"}, {"aw"}, {"ax"}, {"ay"}, {"az"},
+		{"ba"}, {"bb"}, {"bc"}, {"bd"}, {"be"}, {"bf"}, {"bg"}, {"bh"}, {"bi"}, {"bj"},
+		{"bk"}, {"bl"}, {"bm"}, {"bn"}, {"bo"}, {"bp"}, {"bq"}, {"br"}, {"bs"}, {"bt"},
+		{"bu"}, {"bv"}, {"bw"}, {"bx"}, {"by"}, {"bz"},
+		{"ca"}, {"cb"}, {"cc"}, {"cd"}, {"ce"}, {"cf"}, {"cg"}, {"ch"}, {"ci"}, {"cj"},
+		{"ck"}, {"cl"}, {"cm"}, {"cn"}, {"co"}, {"cp"}, {"cq"}, {"cr"}, {"cs"}, {"ct"},
+		{"cu"}, {"cv"}, {"cw"}, {"cx"}, {"cy"}, {"cz"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
According to
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html,
on HVM instances, sda1 and xvda are reserved for root partition. Also,
the available block device range for xvd follow "/dev/xvd[b-c][a-z]"
pattern.

However commit 1ace946 violates the reserved device names and the naming
logic. This causes volume attachment issues. For example, for instances
where /dev/xvda is root partition, the driver tries to create a new
device with the same reserved name.

This change fixes that. 

Deployed Kube 1.14 cluster. 
Update manifest.yaml with canary images for sidecards and new names for API resources.
Tested new plugin and created sc, pvc (pv) and pod.
Volume attaches to node successfully. New device attached is "/dev/xvdba" as expected.
 
Pod mounts volume and runs fine.

Fixes #292

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>


