### PR TITLE
Device allocator should not use reserved dev names.

### DIFF
--- a/pkg/cloud/devicemanager/allocator.go
+++ b/pkg/cloud/devicemanager/allocator.go
@@ -47,10 +47,10 @@ var _ NameAllocator = &nameAllocator{}
 
 // GetNext gets next available device given existing names that are being used
 // This function iterate through the device names in deterministic order of:
-//     a, b, ... , z, aa, ab, ... , az
+//     ba, ... ,bz, ca, ... , cz
 // and return the first one that is not used yet.
 func (d *nameAllocator) GetNext(existingNames ExistingNames) (string, error) {
-	for _, c1 := range []string{"", "a"} {
+	for _, c1 := range []string{"b", "c"} {
 		for c2 := 'a'; c2 <= 'z'; c2++ {
 			name := fmt.Sprintf("%s%s", c1, string(c2))
 			if _, found := existingNames[name]; !found {

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -27,12 +27,12 @@ func TestNameAllocator(t *testing.T) {
 	tests := []struct {
 		expectedName string
 	}{
-		{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}, {"h"}, {"i"}, {"j"},
-		{"k"}, {"l"}, {"m"}, {"n"}, {"o"}, {"p"}, {"q"}, {"r"}, {"s"}, {"t"},
-		{"u"}, {"v"}, {"w"}, {"x"}, {"y"}, {"z"},
-		{"aa"}, {"ab"}, {"ac"}, {"ad"}, {"ae"}, {"af"}, {"ag"}, {"ah"}, {"ai"}, {"aj"},
-		{"ak"}, {"al"}, {"am"}, {"an"}, {"ao"}, {"ap"}, {"aq"}, {"ar"}, {"as"}, {"at"},
-		{"au"}, {"av"}, {"aw"}, {"ax"}, {"ay"}, {"az"},
+		{"ba"}, {"bb"}, {"bc"}, {"bd"}, {"be"}, {"bf"}, {"bg"}, {"bh"}, {"bi"}, {"bj"},
+		{"bk"}, {"bl"}, {"bm"}, {"bn"}, {"bo"}, {"bp"}, {"bq"}, {"br"}, {"bs"}, {"bt"},
+		{"bu"}, {"bv"}, {"bw"}, {"bx"}, {"by"}, {"bz"},
+		{"ca"}, {"cb"}, {"cc"}, {"cd"}, {"ce"}, {"cf"}, {"cg"}, {"ch"}, {"ci"}, {"cj"},
+		{"ck"}, {"cl"}, {"cm"}, {"cn"}, {"co"}, {"cp"}, {"cq"}, {"cr"}, {"cs"}, {"ct"},
+		{"cu"}, {"cv"}, {"cw"}, {"cx"}, {"cy"}, {"cz"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
According to
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html,
on HVM instances, sda1 and xvda are reserved for root partition. Also,
the available block device range for xvd follow "/dev/xvd[b-c][a-z]"
pattern.

However commit 1ace946 violates the reserved device names and the naming
logic. This causes volume attachment issues. For example, for instances
where /dev/xvda is root partition, the driver tries to create a new
device with the same reserved name.
This change fixes the issue.

Testing:
Deployed Kube 1.14 cluster.
Update manifest.yaml with canary images for sidecards and new names for
API resources.
Tested new plugin and created sc, pvc (pv) and pod.
Volume attaches to node successfully. New device attached is
"/dev/xvdba" as expected.

Pod mounts volume and runs fine.

Fixes #292

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>
