### PR TITLE
Update manifest for Kubernetes 1.15

### DIFF
--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -84,13 +84,16 @@ roleRef:
 ---
 
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
   namespace: kube-system
 spec:
   serviceName: ebs-csi-controller
   replicas: 1
+  selector:
+    matchLabels:
+      app: ebs-csi-controller
   template:
     metadata:
       labels:
@@ -139,7 +142,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.1.0
+          image: quay.io/k8scsi/csi-provisioner:v1.3.0
           args:
             - --provisioner=ebs.csi.aws.com
             - --csi-address=$(ADDRESS)
@@ -152,7 +155,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.0
+          image: quay.io/k8scsi/csi-attacher:v1.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -177,7 +180,7 @@ spec:
 ---
 # Node Service
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: ebs-csi-node
   namespace: kube-system

--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -83,35 +83,6 @@ roleRef:
 
 ---
 
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: ebs-cluster-driver-registrar-role
-rules:
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
-  - apiGroups: ["csi.storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: ebs-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: ebs-csi-controller-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: ebs-cluster-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
 kind: StatefulSet
 apiVersion: apps/v1beta1
 metadata:
@@ -167,18 +138,6 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
-        - name: cluster-driver-registrar
-          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
-          args:
-            - --csi-address=$(ADDRESS)
-            - --driver-requires-attachment=true
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.1.0
           args:
@@ -313,3 +272,13 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+
+---
+
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: ebs.csi.aws.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
`deploy/kubernetes` does not work since Kubernetes 1.14:

* The cluster-driver-registrar sidecar container was not released in 1.14 and the version from 1.13 does not work. It is now formally deprecated, so create `CSIDriver` instance during installation.
* Bumped image versions to 1.15.
* Fixed also couple of issues with the yaml file along the way.
