### PR TITLE
Remove the deprecated connection-timeout flag for liveness probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 GO111MODULE=on
+GOPROXY=direct
 
 .EXPORT_ALL_VARIABLES:
 

--- a/aws-ebs-csi-driver/templates/manifest.yaml
+++ b/aws-ebs-csi-driver/templates/manifest.yaml
@@ -340,7 +340,6 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -429,7 +428,6 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/deploy/kubernetes/manifest.yaml
+++ b/deploy/kubernetes/manifest.yaml
@@ -169,7 +169,6 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -254,7 +253,6 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=3s
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
The connection-timeout is deprecated: https://github.com/kubernetes-csi/livenessprobe/blob/v1.1.0/cmd/livenessprobe/main.go#L41

