### PR TITLE
Fix the bug by passing fstype correctly

### DIFF
--- a/examples/kubernetes/static-provisioning/README.md
+++ b/examples/kubernetes/static-provisioning/README.md
@@ -1,0 +1,52 @@
+# Static Provisioning 
+This example shows how to create and consume persistence volume from exising EBS using static provisioning. 
+
+## Usage
+1. Edit the PersistentVolume spec in [example manifest](./specs/example.yaml). Update `volumeHandle` with EBS volume ID that you are going to use, and update the `fsType` with the filesystem type of the volume. In this example, I have a pre-created EBS  volume in us-east-1c availability zone and it is formatted with xfs filesystem.
+
+```
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-pv
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  csi:
+    driver: ebs.csi.aws.com
+    volumeHandle: {volumeId} 
+    fsType: xfs
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: topology.ebs.csi.aws.com/zone
+          operator: In
+          values:
+          - us-east-1c 
+```
+Note that node affinity is used here since EBS volume is created in us-east-1c, hence only node in the same AZ can consume this persisence volume. 
+
+2. Deploy the example:
+```sh
+kubectl apply -f specs/
+```
+
+3. Verify application pod is running:
+```sh
+kubectl describe po app
+```
+
+4. Validate the pod successfully wrote data to the volume:
+```sh
+kubectl exec -it app cat /data/out.txt
+```
+
+5. Cleanup resources:
+```sh
+kubectl delete -f specs/
+```

--- a/examples/kubernetes/static-provisioning/specs/example.yaml
+++ b/examples/kubernetes/static-provisioning/specs/example.yaml
@@ -4,11 +4,31 @@ metadata:
   name: ebs-sc
 provisioner: ebs.csi.aws.com
 volumeBindingMode: WaitForFirstConsumer
-parameters:
-  csi.storage.k8s.io/fstype: xfs
-  type: io1
-  iopsPerGB: "50"
-  encrypted: "true"
+reclaimPolicy: Retain
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test-pv
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  csi:
+    driver: ebs.csi.aws.com
+    volumeHandle: vol-05786ec9ec9526b67
+    fsType: xfs
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: topology.ebs.csi.aws.com/zone
+          operator: In
+          values:
+          - us-east-1c 
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -20,7 +40,7 @@ spec:
   storageClassName: ebs-sc
   resources:
     requests:
-      storage: 4Gi
+      storage: 50Gi
 ---
 apiVersion: v1
 kind: Pod

--- a/hack/run-e2e-test
+++ b/hack/run-e2e-test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -uo pipefail
+set -euo pipefail
 
 OS_ARCH=$(go env GOOS)-amd64
 TEST_ID=$RANDOM
@@ -47,6 +47,15 @@ chmod +x $KOPS_PATH
 
 helm::install
 
+echo "Build and push test driver image"
+eval $(aws ecr get-login --region $REGION --no-include-email)
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+IMAGE_TAG=$TEST_ID
+IMAGE_NAME=$AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/aws-ebs-csi-driver
+docker build -t $IMAGE_NAME:$IMAGE_TAG .
+docker push $IMAGE_NAME:$IMAGE_TAG
+
+set +e
 echo "Creating cluster $CLUSTER_NAME"
 CLUSTER_YAML_PATH=$TEST_DIR/$CLUSTER_NAME.yaml
 SSH_KEY_PATH=$TEST_DIR/id_rsa
@@ -76,14 +85,6 @@ while [[ 1 ]]; do
         sleep 30
     fi
 done;
-
-# Push test driver image
-eval $(aws ecr get-login --region $REGION --no-include-email)
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-IMAGE_TAG=$TEST_ID
-IMAGE_NAME=$AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/aws-ebs-csi-driver
-docker build -t $IMAGE_NAME:$IMAGE_TAG .
-docker push $IMAGE_NAME:$IMAGE_TAG
 
 echo "Deploying driver"
 helm::init

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -105,7 +105,6 @@ type Disk struct {
 	VolumeID         string
 	CapacityGiB      int64
 	AvailabilityZone string
-	FsType           string
 }
 
 // DiskOptions represents parameters to create an EBS volume

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -25,9 +25,6 @@ const (
 
 // constants of keys in volume parameters
 const (
-	// FsTypeKey represents key for filesystem type
-	FsTypeKey = "fstype"
-
 	// VolumeTypeKey represents key for volume type
 	VolumeTypeKey = "type"
 

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -103,8 +103,8 @@ func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size 
 // GetParameters returns the parameters specific for this driver
 func GetParameters(volumeType string, fsType string, encrypted bool) map[string]string {
 	parameters := map[string]string{
-		"type":   volumeType,
-		"fsType": fsType,
+		"type":                      volumeType,
+		"csi.storage.k8s.io/fstype": fsType,
 	}
 	if iops := IOPSPerGBForVolumeType(volumeType); iops != "" {
 		parameters["iopsPerGB"] = iops


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes: #324 #326 

/cc @wongma7 @jsafrane @shanesiebken 

**What is this PR about? / Why do we need it?**
This fixes a bug to use `fstype` inside volume capacity for NodeStageVolume and NodePublishVolume call. So that pre-created persistence volume's fstype is used when mounting the volume correctly.

This change also removed the usage of `fstype` in driver's storage class parameter in favor of reserved `csi.storage.k8s.io/fstype` parameter.

**What testing is done?** 
Tested on Kops cluster with a pre-created xfs EBS volume and consume it with `fstype` set in the PV spec. 