### PR TITLE
enable users to set ec2-endpoint for nonstandard regions

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -222,6 +223,11 @@ func newEC2Cloud(metadata MetadataService, svc *ec2metadata.EC2Metadata) (Cloud,
 		Region:                        aws.String(metadata.GetRegion()),
 		Credentials:                   credentials.NewChainCredentials(provider),
 		CredentialsChainVerboseErrors: aws.Bool(true),
+	}
+
+	endpoint := os.Getenv("AWS_EC2_ENDPOINT")
+	if endpoint != "" {
+		awsConfig.Endpoint = aws.String(endpoint)
 	}
 
 	return &cloud{


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This a new feature. It allows users to specify a custom ec2 endpoint using the environment variable AWS_EC2_ENDPOINT. 

**What is this PR about? / Why do we need it?**

We're running k8s in multiple, non-standard AWS regions. The regions and endpoints are not included in the AWS Go SDK by default. Currently, the correct AWS region is retrieved from the EC2 metadata, but it fails to find the region in SDK's defaults.go and attempts to construct an ec2 URL with an incorrect domain suffix, amazonaws.com. We've been forking this project, vendoring dependencies, and patching the AWS SDK. The proposed change should allow us to use the upstream code without modification across all of our target regions. It does not impact default behavior.

**What testing is done?** 

Verified that setting the AWS_EC2_ENDPOINT environment variable caused the AWS client to use the provided hostname for requests. For example, with AWS_EC2_ENDPOINT set to test.example.com, the client attempted to connect to https://test.example.com. 