### PR TITLE
Refactor NewCloud by pass in region

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -175,6 +175,14 @@ func TestCreateDisk(t *testing.T) {
 				mockEC2.EXPECT().DescribeSnapshotsWithContext(gomock.Eq(ctx), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{Snapshots: []*ec2.Snapshot{snapshot}}, nil).AnyTimes()
 			}
 
+			if len(tc.diskOptions.AvailabilityZone) == 0 {
+				mockEC2.EXPECT().DescribeAvailabilityZonesWithContext(gomock.Eq(ctx), gomock.Any()).Return(&ec2.DescribeAvailabilityZonesOutput{
+					AvailabilityZones: []*ec2.AvailabilityZone{
+						{ZoneName: aws.String(defaultZone)},
+					},
+				}, nil)
+			}
+
 			disk, err := c.CreateDisk(ctx, tc.volumeName, tc.diskOptions)
 			if err != nil {
 				if tc.expErr == nil {
@@ -1041,13 +1049,9 @@ func TestListSnapshots(t *testing.T) {
 
 func newCloud(mockEC2 EC2) Cloud {
 	return &cloud{
-		metadata: &Metadata{
-			InstanceID:       "test-instance",
-			Region:           "test-region",
-			AvailabilityZone: defaultZone,
-		},
-		dm:  dm.NewDeviceManager(),
-		ec2: mockEC2,
+		region: "test-region",
+		dm:     dm.NewDeviceManager(),
+		ec2:    mockEC2,
 	}
 }
 

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -19,7 +19,9 @@ package cloud
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type EC2Metadata interface {
@@ -62,6 +64,12 @@ func (m *Metadata) GetRegion() string {
 // GetAvailabilityZone returns the Availability Zone which the instance is in.
 func (m *Metadata) GetAvailabilityZone() string {
 	return m.AvailabilityZone
+}
+
+func NewMetadata() (MetadataService, error) {
+	sess := session.Must(session.NewSession(&aws.Config{}))
+	svc := ec2metadata.New(sess)
+	return NewMetadataService(svc)
 }
 
 // NewMetadataService returns a new MetadataServiceImplementation.

--- a/pkg/cloud/mocks/mock_ec2.go
+++ b/pkg/cloud/mocks/mock_ec2.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	aws "github.com/aws/aws-sdk-go/aws"
+	context "context"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
@@ -36,7 +36,7 @@ func (m *MockEC2) EXPECT() *MockEC2MockRecorder {
 }
 
 // AttachVolumeWithContext mocks base method
-func (m *MockEC2) AttachVolumeWithContext(arg0 aws.Context, arg1 *ec2.AttachVolumeInput, arg2 ...request.Option) (*ec2.VolumeAttachment, error) {
+func (m *MockEC2) AttachVolumeWithContext(arg0 context.Context, arg1 *ec2.AttachVolumeInput, arg2 ...request.Option) (*ec2.VolumeAttachment, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -54,7 +54,7 @@ func (mr *MockEC2MockRecorder) AttachVolumeWithContext(arg0, arg1 interface{}, a
 }
 
 // CreateSnapshotWithContext mocks base method
-func (m *MockEC2) CreateSnapshotWithContext(arg0 aws.Context, arg1 *ec2.CreateSnapshotInput, arg2 ...request.Option) (*ec2.Snapshot, error) {
+func (m *MockEC2) CreateSnapshotWithContext(arg0 context.Context, arg1 *ec2.CreateSnapshotInput, arg2 ...request.Option) (*ec2.Snapshot, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -72,7 +72,7 @@ func (mr *MockEC2MockRecorder) CreateSnapshotWithContext(arg0, arg1 interface{},
 }
 
 // CreateVolumeWithContext mocks base method
-func (m *MockEC2) CreateVolumeWithContext(arg0 aws.Context, arg1 *ec2.CreateVolumeInput, arg2 ...request.Option) (*ec2.Volume, error) {
+func (m *MockEC2) CreateVolumeWithContext(arg0 context.Context, arg1 *ec2.CreateVolumeInput, arg2 ...request.Option) (*ec2.Volume, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -90,7 +90,7 @@ func (mr *MockEC2MockRecorder) CreateVolumeWithContext(arg0, arg1 interface{}, a
 }
 
 // DeleteSnapshotWithContext mocks base method
-func (m *MockEC2) DeleteSnapshotWithContext(arg0 aws.Context, arg1 *ec2.DeleteSnapshotInput, arg2 ...request.Option) (*ec2.DeleteSnapshotOutput, error) {
+func (m *MockEC2) DeleteSnapshotWithContext(arg0 context.Context, arg1 *ec2.DeleteSnapshotInput, arg2 ...request.Option) (*ec2.DeleteSnapshotOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -108,7 +108,7 @@ func (mr *MockEC2MockRecorder) DeleteSnapshotWithContext(arg0, arg1 interface{},
 }
 
 // DeleteVolumeWithContext mocks base method
-func (m *MockEC2) DeleteVolumeWithContext(arg0 aws.Context, arg1 *ec2.DeleteVolumeInput, arg2 ...request.Option) (*ec2.DeleteVolumeOutput, error) {
+func (m *MockEC2) DeleteVolumeWithContext(arg0 context.Context, arg1 *ec2.DeleteVolumeInput, arg2 ...request.Option) (*ec2.DeleteVolumeOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -125,8 +125,26 @@ func (mr *MockEC2MockRecorder) DeleteVolumeWithContext(arg0, arg1 interface{}, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeWithContext", reflect.TypeOf((*MockEC2)(nil).DeleteVolumeWithContext), varargs...)
 }
 
+// DescribeAvailabilityZonesWithContext mocks base method
+func (m *MockEC2) DescribeAvailabilityZonesWithContext(arg0 context.Context, arg1 *ec2.DescribeAvailabilityZonesInput, arg2 ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeAvailabilityZonesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAvailabilityZonesWithContext indicates an expected call of DescribeAvailabilityZonesWithContext
+func (mr *MockEC2MockRecorder) DescribeAvailabilityZonesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZonesWithContext", reflect.TypeOf((*MockEC2)(nil).DescribeAvailabilityZonesWithContext), varargs...)
+}
+
 // DescribeInstancesWithContext mocks base method
-func (m *MockEC2) DescribeInstancesWithContext(arg0 aws.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.Option) (*ec2.DescribeInstancesOutput, error) {
+func (m *MockEC2) DescribeInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.Option) (*ec2.DescribeInstancesOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,7 +162,7 @@ func (mr *MockEC2MockRecorder) DescribeInstancesWithContext(arg0, arg1 interface
 }
 
 // DescribeSnapshotsWithContext mocks base method
-func (m *MockEC2) DescribeSnapshotsWithContext(arg0 aws.Context, arg1 *ec2.DescribeSnapshotsInput, arg2 ...request.Option) (*ec2.DescribeSnapshotsOutput, error) {
+func (m *MockEC2) DescribeSnapshotsWithContext(arg0 context.Context, arg1 *ec2.DescribeSnapshotsInput, arg2 ...request.Option) (*ec2.DescribeSnapshotsOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -162,7 +180,7 @@ func (mr *MockEC2MockRecorder) DescribeSnapshotsWithContext(arg0, arg1 interface
 }
 
 // DescribeVolumesModificationsWithContext mocks base method
-func (m *MockEC2) DescribeVolumesModificationsWithContext(arg0 aws.Context, arg1 *ec2.DescribeVolumesModificationsInput, arg2 ...request.Option) (*ec2.DescribeVolumesModificationsOutput, error) {
+func (m *MockEC2) DescribeVolumesModificationsWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesModificationsInput, arg2 ...request.Option) (*ec2.DescribeVolumesModificationsOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -180,7 +198,7 @@ func (mr *MockEC2MockRecorder) DescribeVolumesModificationsWithContext(arg0, arg
 }
 
 // DescribeVolumesWithContext mocks base method
-func (m *MockEC2) DescribeVolumesWithContext(arg0 aws.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.Option) (*ec2.DescribeVolumesOutput, error) {
+func (m *MockEC2) DescribeVolumesWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.Option) (*ec2.DescribeVolumesOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -198,7 +216,7 @@ func (mr *MockEC2MockRecorder) DescribeVolumesWithContext(arg0, arg1 interface{}
 }
 
 // DetachVolumeWithContext mocks base method
-func (m *MockEC2) DetachVolumeWithContext(arg0 aws.Context, arg1 *ec2.DetachVolumeInput, arg2 ...request.Option) (*ec2.VolumeAttachment, error) {
+func (m *MockEC2) DetachVolumeWithContext(arg0 context.Context, arg1 *ec2.DetachVolumeInput, arg2 ...request.Option) (*ec2.VolumeAttachment, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -216,7 +234,7 @@ func (mr *MockEC2MockRecorder) DetachVolumeWithContext(arg0, arg1 interface{}, a
 }
 
 // ModifyVolumeWithContext mocks base method
-func (m *MockEC2) ModifyVolumeWithContext(arg0 aws.Context, arg1 *ec2.ModifyVolumeInput, arg2 ...request.Option) (*ec2.ModifyVolumeOutput, error) {
+func (m *MockEC2) ModifyVolumeWithContext(arg0 context.Context, arg1 *ec2.ModifyVolumeInput, arg2 ...request.Option) (*ec2.ModifyVolumeOutput, error) {
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -59,7 +59,12 @@ type controllerService struct {
 // newControllerService creates a new controller service
 // it panics if failed to create the service
 func newControllerService(driverOptions *DriverOptions) controllerService {
-	cloud, err := cloud.NewCloud()
+	metadata, err := cloud.NewMetadata()
+	if err != nil {
+		panic(err)
+	}
+	region := metadata.GetRegion()
+	cloud, err := cloud.NewCloud(region)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/driver/fakes.go
+++ b/pkg/driver/fakes.go
@@ -34,7 +34,11 @@ func NewFakeDriver(endpoint string, fakeCloud cloud.Cloud, fakeMounter *mount.Fa
 			driverOptions: driverOptions,
 		},
 		nodeService: nodeService{
-			metadata: fakeCloud.GetMetadata(),
+			metadata: &cloud.Metadata{
+				InstanceID:       "instanceID",
+				Region:           "region",
+				AvailabilityZone: "az",
+			},
 			mounter:  &NodeMounter{mount.SafeFormatAndMount{Interface: fakeMounter, Exec: mount.NewFakeExec(nil)}},
 			inFlight: internal.NewInFlight(),
 		},

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -137,18 +137,6 @@ func (mr *MockCloudMockRecorder) GetDiskByName(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskByName", reflect.TypeOf((*MockCloud)(nil).GetDiskByName), arg0, arg1, arg2)
 }
 
-// GetMetadata mocks base method
-func (m *MockCloud) GetMetadata() cloud.MetadataService {
-	ret := m.ctrl.Call(m, "GetMetadata")
-	ret0, _ := ret[0].(cloud.MetadataService)
-	return ret0
-}
-
-// GetMetadata indicates an expected call of GetMetadata
-func (mr *MockCloudMockRecorder) GetMetadata() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockCloud)(nil).GetMetadata))
-}
-
 // GetSnapshotById mocks base method
 func (m *MockCloud) GetSnapshotById(arg0 context.Context, arg1 string) (*cloud.Snapshot, error) {
 	ret := m.ctrl.Call(m, "GetSnapshotById", arg0, arg1)

--- a/pkg/driver/mocks/mock_mounter.go
+++ b/pkg/driver/mocks/mock_mounter.go
@@ -34,18 +34,6 @@ func (m *MockMounter) EXPECT() *MockMounterMockRecorder {
 	return m.recorder
 }
 
-// CleanSubPaths mocks base method
-func (m *MockMounter) CleanSubPaths(arg0, arg1 string) error {
-	ret := m.ctrl.Call(m, "CleanSubPaths", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CleanSubPaths indicates an expected call of CleanSubPaths
-func (mr *MockMounterMockRecorder) CleanSubPaths(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanSubPaths", reflect.TypeOf((*MockMounter)(nil).CleanSubPaths), arg0, arg1)
-}
-
 // DeviceOpened mocks base method
 func (m *MockMounter) DeviceOpened(arg0 string) (bool, error) {
 	ret := m.ctrl.Call(m, "DeviceOpened", arg0)
@@ -214,19 +202,6 @@ func (mr *MockMounterMockRecorder) IsMountPointMatch(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMountPointMatch", reflect.TypeOf((*MockMounter)(nil).IsMountPointMatch), arg0, arg1)
 }
 
-// IsNotMountPoint mocks base method
-func (m *MockMounter) IsNotMountPoint(arg0 string) (bool, error) {
-	ret := m.ctrl.Call(m, "IsNotMountPoint", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsNotMountPoint indicates an expected call of IsNotMountPoint
-func (mr *MockMounterMockRecorder) IsNotMountPoint(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNotMountPoint", reflect.TypeOf((*MockMounter)(nil).IsNotMountPoint), arg0)
-}
-
 // List mocks base method
 func (m *MockMounter) List() ([]mount.MountPoint, error) {
 	ret := m.ctrl.Call(m, "List")
@@ -301,20 +276,6 @@ func (mr *MockMounterMockRecorder) PathIsDevice(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PathIsDevice", reflect.TypeOf((*MockMounter)(nil).PathIsDevice), arg0)
 }
 
-// PrepareSafeSubpath mocks base method
-func (m *MockMounter) PrepareSafeSubpath(arg0 mount.Subpath) (string, func(), error) {
-	ret := m.ctrl.Call(m, "PrepareSafeSubpath", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(func())
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// PrepareSafeSubpath indicates an expected call of PrepareSafeSubpath
-func (mr *MockMounterMockRecorder) PrepareSafeSubpath(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareSafeSubpath", reflect.TypeOf((*MockMounter)(nil).PrepareSafeSubpath), arg0)
-}
-
 // Run mocks base method
 func (m *MockMounter) Run(arg0 string, arg1 ...string) ([]byte, error) {
 	varargs := []interface{}{arg0}
@@ -331,18 +292,6 @@ func (m *MockMounter) Run(arg0 string, arg1 ...string) ([]byte, error) {
 func (mr *MockMounterMockRecorder) Run(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockMounter)(nil).Run), varargs...)
-}
-
-// SafeMakeDir mocks base method
-func (m *MockMounter) SafeMakeDir(arg0, arg1 string, arg2 os.FileMode) error {
-	ret := m.ctrl.Call(m, "SafeMakeDir", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SafeMakeDir indicates an expected call of SafeMakeDir
-func (mr *MockMounterMockRecorder) SafeMakeDir(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeMakeDir", reflect.TypeOf((*MockMounter)(nil).SafeMakeDir), arg0, arg1, arg2)
 }
 
 // Unmount mocks base method

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -77,13 +77,13 @@ type nodeService struct {
 // newNodeService creates a new node service
 // it panics if failed to create the service
 func newNodeService() nodeService {
-	cloud, err := cloud.NewCloud()
+	metadata, err := cloud.NewMetadata()
 	if err != nil {
 		panic(err)
 	}
 
 	return nodeService{
-		metadata: cloud.GetMetadata(),
+		metadata: metadata,
 		mounter:  newNodeMounter(),
 		inFlight: internal.NewInFlight(),
 	}
@@ -353,14 +353,13 @@ func (d *nodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 
 func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	klog.V(4).Infof("NodeGetInfo: called with args %+v", *req)
-	m := d.metadata
 
 	topology := &csi.Topology{
-		Segments: map[string]string{TopologyKey: m.GetAvailabilityZone()},
+		Segments: map[string]string{TopologyKey: d.metadata.GetAvailabilityZone()},
 	}
 
 	return &csi.NodeGetInfoResponse{
-		NodeId:             m.GetInstanceID(),
+		NodeId:             d.metadata.GetInstanceID(),
 		MaxVolumesPerNode:  d.getVolumesLimit(),
 		AccessibleTopology: topology,
 	}, nil

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -363,8 +363,8 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		}
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
-		metadata := e2eMetdataService{availabilityZone: availabilityZone}
-		cloud, err := awscloud.NewCloudWithMetadata(metadata)
+		region := availabilityZone[0 : len(availabilityZone)-1]
+		cloud, err := awscloud.NewCloud(region)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}

--- a/tests/sanity/fake_cloud_provider.go
+++ b/tests/sanity/fake_cloud_provider.go
@@ -30,7 +30,6 @@ type fakeCloudProvider struct {
 	disks map[string]*fakeDisk
 	// snapshots contains mapping from snapshot ID to snapshot
 	snapshots map[string]*fakeSnapshot
-	m         *cloud.Metadata
 	pub       map[string]string
 	tokens    map[string]int64
 }
@@ -50,17 +49,8 @@ func newFakeCloudProvider() *fakeCloudProvider {
 		disks:     make(map[string]*fakeDisk),
 		snapshots: make(map[string]*fakeSnapshot),
 		pub:       make(map[string]string),
-		m: &cloud.Metadata{
-			InstanceID:       "instanceID",
-			Region:           "region",
-			AvailabilityZone: "az",
-		},
-		tokens: make(map[string]int64),
+		tokens:    make(map[string]int64),
 	}
-}
-
-func (c *fakeCloudProvider) GetMetadata() cloud.MetadataService {
-	return c.m
 }
 
 func (c *fakeCloudProvider) CreateDisk(ctx context.Context, volumeName string, diskOptions *cloud.DiskOptions) (*cloud.Disk, error) {
@@ -137,7 +127,7 @@ func (c *fakeCloudProvider) GetDiskByID(ctx context.Context, volumeID string) (*
 }
 
 func (c *fakeCloudProvider) IsExistInstance(ctx context.Context, nodeID string) bool {
-	return nodeID == c.m.GetInstanceID()
+	return nodeID == "instanceID"
 }
 
 func (c *fakeCloudProvider) CreateSnapshot(ctx context.Context, volumeID string, snapshotOptions *cloud.SnapshotOptions) (snapshot *cloud.Snapshot, err error) {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Refactor `NewCloud` method by pass in region. This will benefits: #378 