### PR TITLE
helm: provide an option to set extra volume tags

### DIFF
--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.1.0
+version: 0.2.0
 kubeVersion: ">=1.13.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -43,3 +43,16 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Convert the `--extra-volume-tags` command line arg from a map.
+*/}}
+{{- define "aws-ebs-csi-driver.extra-volume-tags" -}}
+{{- $result := dict "pairs" (list) -}}
+{{- range $key, $value := .Values.extraVolumeTags -}}
+{{- $noop := printf "%s=%s" $key $value | append $result.pairs | set $result "pairs" -}}
+{{- end -}}
+{{- if gt (len $result.pairs) 0 -}}
+- --extra-volume-tags={{- join "," $result.pairs -}}
+{{- end -}}
+{{- end -}}

--- a/aws-ebs-csi-driver/templates/manifest.yaml
+++ b/aws-ebs-csi-driver/templates/manifest.yaml
@@ -213,10 +213,11 @@ spec:
       containers:
         - name: ebs-plugin
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          args :
+          args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
             - --v=5
+            {{ include "aws-ebs-csi-driver.extra-volume-tags" . }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -39,3 +39,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Extra volume tags to attach to each dynamically provisioned volume.
+# ---
+# extraVolumeTags:
+#   key1: value1
+#   key2: value2
+extraVolumeTags: {}


### PR DESCRIPTION
Add an option to configure extra volume tags.

**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

Add an option to configure extra volume tags in helm chart. See #353 

**What testing is done?** 

Tested using `helm template` with the following cases:

1. Empty value

`values.yaml`
```yaml
extraVolumeTags: {}
```
`result:`
```yaml
        - name: ebs-plugin
          image: "amazon/aws-ebs-csi-driver:v0.4.0"
          args:                                                                                                                                                                  
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=5

```

2. Single pair

`values.yaml`
```yaml
extraVolumeTags:
  key1: value1
```
`result`
```yaml
        - name: ebs-plugin                                                               
          image: "amazon/aws-ebs-csi-driver:v0.4.0"                                                 
          args:                                                                                          
            - --endpoint=$(CSI_ENDPOINT)                                                 
            - --logtostderr                                           
            - --v=5                                                         
            - --extra-volume-tags=key1=value1
```

3. Multiple pairs

`values.yaml`
```yaml
extraVolumeTags:
  key1: value1
  key2: value2
```
`result`
```yaml
        - name: ebs-plugin
          image: "amazon/aws-ebs-csi-driver:v0.4.0"
          args:                                                                                                                                                                  
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr                                                                                                                                                      
            - --v=5                                                                                                                                                              
            - --extra-volume-tags=key1=value1,key2=value2
```