### PR TITLE
Normalize variable function and method naming

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -195,7 +195,7 @@ type Cloud interface {
 	CreateSnapshot(ctx context.Context, volumeID string, snapshotOptions *SnapshotOptions) (snapshot *Snapshot, err error)
 	DeleteSnapshot(ctx context.Context, snapshotID string) (success bool, err error)
 	GetSnapshotByName(ctx context.Context, name string) (snapshot *Snapshot, err error)
-	GetSnapshotById(ctx context.Context, snapshotID string) (snapshot *Snapshot, err error)
+	GetSnapshotByID(ctx context.Context, snapshotID string) (snapshot *Snapshot, err error)
 	ListSnapshots(ctx context.Context, volumeID string, maxResults int64, nextToken string) (listSnapshotsResponse *ListSnapshotsResponse, err error)
 }
 
@@ -570,7 +570,7 @@ func (c *cloud) GetSnapshotByName(ctx context.Context, name string) (snapshot *S
 	return c.ec2SnapshotResponseToStruct(ec2snapshot), nil
 }
 
-func (c *cloud) GetSnapshotById(ctx context.Context, snapshotID string) (snapshot *Snapshot, err error) {
+func (c *cloud) GetSnapshotByID(ctx context.Context, snapshotID string) (snapshot *Snapshot, err error) {
 	request := &ec2.DescribeSnapshotsInput{
 		SnapshotIds: []*string{
 			aws.String(snapshotID),

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -783,7 +783,7 @@ func TestGetSnapshotByName(t *testing.T) {
 	}
 }
 
-func TestGetSnapshotById(t *testing.T) {
+func TestGetSnapshotByID(t *testing.T) {
 	testCases := []struct {
 		name            string
 		snapshotName    string
@@ -821,7 +821,7 @@ func TestGetSnapshotById(t *testing.T) {
 			ctx := context.Background()
 			mockEC2.EXPECT().DescribeSnapshotsWithContext(gomock.Eq(ctx), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{Snapshots: []*ec2.Snapshot{ec2snapshot}}, nil)
 
-			_, err := c.GetSnapshotById(ctx, tc.snapshotOptions.Tags[SnapshotNameTagKey])
+			_, err := c.GetSnapshotByID(ctx, tc.snapshotOptions.Tags[SnapshotNameTagKey])
 			if err != nil {
 				if tc.expErr == nil {
 					t.Fatalf("GetSnapshotByName() failed: expected no error, got: %v", err)

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -35,7 +35,7 @@ const (
 	EncryptedKey = "encrypted"
 
 	// KmsKeyId represents key for KMS encryption key
-	KmsKeyIdKey = "kmskeyid"
+	KmsKeyIDKey = "kmskeyid"
 )
 
 // constants for default command line flag values

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -113,7 +113,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		volumeType  string
 		iopsPerGB   int
 		isEncrypted bool
-		kmsKeyId    string
+		kmsKeyID    string
 	)
 
 	for key, value := range req.GetParameters() {
@@ -133,8 +133,8 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 			} else {
 				isEncrypted = false
 			}
-		case KmsKeyIdKey:
-			kmsKeyId = value
+		case KmsKeyIDKey:
+			kmsKeyID = value
 		default:
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid parameter key %s for CreateVolume", key)
 		}
@@ -162,7 +162,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		IOPSPerGB:        iopsPerGB,
 		AvailabilityZone: zone,
 		Encrypted:        isEncrypted,
-		KmsKeyID:         kmsKeyId,
+		KmsKeyID:         kmsKeyID,
 	}
 
 	volumeSource := req.GetVolumeContentSource()
@@ -433,7 +433,7 @@ func (d *controllerService) ListSnapshots(ctx context.Context, req *csi.ListSnap
 
 	snapshotID := req.GetSnapshotId()
 	if len(snapshotID) != 0 {
-		snapshot, err := d.cloud.GetSnapshotById(ctx, snapshotID)
+		snapshot, err := d.cloud.GetSnapshotByID(ctx, snapshotID)
 		if err != nil {
 			if err == cloud.ErrNotFound {
 				klog.V(4).Info("ListSnapshots: snapshot not found, returning with success")

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	expZone       = "us-west-2b"
-	expInstanceId = "i-123456789abcdef01"
+	expInstanceID = "i-123456789abcdef01"
 )
 
 func TestCreateVolume(t *testing.T) {
@@ -575,7 +575,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeCapabilities: stdVolCap,
 					Parameters: map[string]string{
 						EncryptedKey: "true",
-						KmsKeyIdKey:  "arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
+						KmsKeyIDKey:  "arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
 					},
 				}
 
@@ -1328,7 +1328,7 @@ func TestListSnapshots(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetSnapshotById(gomock.Eq(ctx), gomock.Eq("snapshot-1")).Return(mockCloudSnapshotsResponse, nil)
+				mockCloud.EXPECT().GetSnapshotByID(gomock.Eq(ctx), gomock.Eq("snapshot-1")).Return(mockCloudSnapshotsResponse, nil)
 
 				awsDriver := controllerService{
 					cloud:         mockCloud,
@@ -1357,7 +1357,7 @@ func TestListSnapshots(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetSnapshotById(gomock.Eq(ctx), gomock.Eq("snapshot-1")).Return(nil, cloud.ErrNotFound)
+				mockCloud.EXPECT().GetSnapshotByID(gomock.Eq(ctx), gomock.Eq("snapshot-1")).Return(nil, cloud.ErrNotFound)
 
 				awsDriver := controllerService{
 					cloud:         mockCloud,
@@ -1386,7 +1386,7 @@ func TestListSnapshots(t *testing.T) {
 				defer mockCtl.Finish()
 
 				mockCloud := mocks.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().GetSnapshotById(gomock.Eq(ctx), gomock.Eq("snapshot-1")).Return(nil, cloud.ErrMultiSnapshots)
+				mockCloud.EXPECT().GetSnapshotByID(gomock.Eq(ctx), gomock.Eq("snapshot-1")).Return(nil, cloud.ErrMultiSnapshots)
 
 				awsDriver := controllerService{
 					cloud:         mockCloud,
@@ -1463,7 +1463,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			name: "success normal",
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerPublishVolumeRequest{
-					NodeId:           expInstanceId,
+					NodeId:           expInstanceID,
 					VolumeCapability: stdVolCap,
 					VolumeId:         "vol-test",
 				}
@@ -1562,7 +1562,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			name: "fail no VolumeCapability",
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerPublishVolumeRequest{
-					NodeId:   expInstanceId,
+					NodeId:   expInstanceID,
 					VolumeId: "vol-test",
 				}
 
@@ -1595,7 +1595,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			name: "fail invalid VolumeCapability",
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerPublishVolumeRequest{
-					NodeId: expInstanceId,
+					NodeId: expInstanceID,
 					VolumeCapability: &csi.VolumeCapability{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_UNKNOWN,
@@ -1669,7 +1669,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerPublishVolumeRequest{
 					VolumeId:         "does-not-exist",
-					NodeId:           expInstanceId,
+					NodeId:           expInstanceID,
 					VolumeCapability: stdVolCap,
 				}
 
@@ -1705,7 +1705,7 @@ func TestControllerPublishVolume(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerPublishVolumeRequest{
 					VolumeId:         "does-not-exist",
-					NodeId:           expInstanceId,
+					NodeId:           expInstanceID,
 					VolumeCapability: stdVolCap,
 				}
 
@@ -1753,7 +1753,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 			name: "success normal",
 			testFunc: func(t *testing.T) {
 				req := &csi.ControllerUnpublishVolumeRequest{
-					NodeId:   expInstanceId,
+					NodeId:   expInstanceID,
 					VolumeId: "vol-test",
 				}
 				expResp := &csi.ControllerUnpublishVolumeResponse{}

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -137,17 +137,17 @@ func (mr *MockCloudMockRecorder) GetDiskByName(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskByName", reflect.TypeOf((*MockCloud)(nil).GetDiskByName), arg0, arg1, arg2)
 }
 
-// GetSnapshotById mocks base method
-func (m *MockCloud) GetSnapshotById(arg0 context.Context, arg1 string) (*cloud.Snapshot, error) {
-	ret := m.ctrl.Call(m, "GetSnapshotById", arg0, arg1)
+// GetSnapshotByID mocks base method
+func (m *MockCloud) GetSnapshotByID(arg0 context.Context, arg1 string) (*cloud.Snapshot, error) {
+	ret := m.ctrl.Call(m, "GetSnapshotByID", arg0, arg1)
 	ret0, _ := ret[0].(*cloud.Snapshot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSnapshotById indicates an expected call of GetSnapshotById
-func (mr *MockCloudMockRecorder) GetSnapshotById(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshotById", reflect.TypeOf((*MockCloud)(nil).GetSnapshotById), arg0, arg1)
+// GetSnapshotByID indicates an expected call of GetSnapshotByID
+func (mr *MockCloudMockRecorder) GetSnapshotByID(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshotByID", reflect.TypeOf((*MockCloud)(nil).GetSnapshotByID), arg0, arg1)
 }
 
 // GetSnapshotByName mocks base method

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -459,7 +459,7 @@ func (d *nodeService) nodePublishVolumeForFileSystem(req *csi.NodePublishVolumeR
 // findDevicePath finds path of device and verifies its existence
 // if the device is not nvme, return the path directly
 // if the device is nvme, finds and returns the nvme device path eg. /dev/nvme1n1
-func (d *nodeService) findDevicePath(devicePath, volumeId string) (string, error) {
+func (d *nodeService) findDevicePath(devicePath, volumeID string) (string, error) {
 	exists, err := d.mounter.ExistsPath(devicePath)
 	if err != nil {
 		return "", err
@@ -474,7 +474,7 @@ func (d *nodeService) findDevicePath(devicePath, volumeId string) (string, error
 	// This is the magic name on which AWS presents NVME devices under /dev/disk/by-id/
 	// For example, vol-0fab1d5e3f72a5e23 creates a symlink at
 	// /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0fab1d5e3f72a5e23
-	nvmeName := "nvme-Amazon_Elastic_Block_Store_" + strings.Replace(volumeId, "-", "", -1)
+	nvmeName := "nvme-Amazon_Elastic_Block_Store_" + strings.Replace(volumeID, "-", "", -1)
 
 	return findNvmeVolume(nvmeName)
 }

--- a/tests/sanity/fake_cloud_provider.go
+++ b/tests/sanity/fake_cloud_provider.go
@@ -178,7 +178,7 @@ func (c *fakeCloudProvider) GetSnapshotByName(ctx context.Context, name string) 
 	return snapshots[0].Snapshot, nil
 }
 
-func (c *fakeCloudProvider) GetSnapshotById(ctx context.Context, snapshotID string) (snapshot *cloud.Snapshot, err error) {
+func (c *fakeCloudProvider) GetSnapshotByID(ctx context.Context, snapshotID string) (snapshot *cloud.Snapshot, err error) {
 	ret, exists := c.snapshots[snapshotID]
 	if !exists {
 		return nil, cloud.ErrNotFound


### PR DESCRIPTION
* Fix golint error and normalize variable or function/method naming

* ~If block ends with a return statement, so drop this else and outdent its block~