### PR TITLE
Added tolerations for node support

### DIFF
--- a/aws-ebs-csi-driver/templates/manifest.yaml
+++ b/aws-ebs-csi-driver/templates/manifest.yaml
@@ -338,13 +338,12 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+{{ toYaml .Values.tolerations | indent 8 }}
       containers:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}" 
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -36,7 +36,9 @@ resources: {}
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
 
 affinity: {}
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** kind of both

**What is this PR about? / Why do we need it?**
At the moment the `tolerations` value is defined yet never used. Without it it's impossible to deploy ebs-csi-driver (the node component) to nodes with taints (which is necessary if you specialise nodes)

**What testing is done?** 
I modified the chart locally and generated using different tolerations, including empty, default and with extra custom tolerations.
