### PR TITLE
Schedule the EBS CSI DaemonSet on all nodes by default

### DIFF
--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -57,8 +57,7 @@ resources: {}
 nodeSelector: {}
 
 tolerations:
-  - key: CriticalAddonsOnly
-    operator: Exists
+  - operator: Exists
 
 affinity: {}
 

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -19,8 +19,7 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
+        - operator: Exists
       containers:
         - name: ebs-plugin
           securityContext:


### PR DESCRIPTION
Fixes a bug.

I think that the EBS CSI DaemonSet should schedule on all nodes regardless of taints, similar to what's done in the VPC CNI. Exceptions can still be made by re-rendering the helm chart in aws-ebs-csi-driver.

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/420#issuecomment-558409004 suggests the previous version was specific to one installation. By making the default behavior to run everywhere we err on the side of things working.

I'm running these changes on my production cluster without issues.