### PR TITLE
Fix CreateVolumeResponse after snapshot restore

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -123,6 +123,7 @@ type Disk struct {
 	VolumeID         string
 	CapacityGiB      int64
 	AvailabilityZone string
+	SnapshotID       string
 }
 
 // DiskOptions represents parameters to create an EBS volume
@@ -318,7 +319,7 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 		return nil, fmt.Errorf("failed to get an available volume in EC2: %v", err)
 	}
 
-	return &Disk{CapacityGiB: size, VolumeID: volumeID, AvailabilityZone: zone}, nil
+	return &Disk{CapacityGiB: size, VolumeID: volumeID, AvailabilityZone: zone, SnapshotID: snapshotID}, nil
 }
 
 func (c *cloud) DeleteDisk(ctx context.Context, volumeID string) (bool, error) {
@@ -485,6 +486,7 @@ func (c *cloud) GetDiskByName(ctx context.Context, name string, capacityBytes in
 		VolumeID:         aws.StringValue(volume.VolumeId),
 		CapacityGiB:      volSizeBytes,
 		AvailabilityZone: aws.StringValue(volume.AvailabilityZone),
+		SnapshotID:       aws.StringValue(volume.SnapshotId),
 	}, nil
 }
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -154,14 +154,9 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	snapshotID := ""
-	if snapshotSource := req.VolumeContentSource.GetSnapshot(); snapshotSource != nil {
-		snapshotID = snapshotSource.SnapshotId
-	}
-
 	// volume exists already
 	if disk != nil {
-		return newCreateVolumeResponse(disk, snapshotID), nil
+		return newCreateVolumeResponse(disk), nil
 	}
 
 	// create a new volume
@@ -204,7 +199,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 		return nil, status.Errorf(errCode, "Could not create volume %q: %v", volName, err)
 	}
-	return newCreateVolumeResponse(disk, snapshotID), nil
+	return newCreateVolumeResponse(disk), nil
 }
 
 func (d *controllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
@@ -517,13 +512,13 @@ func pickAvailabilityZone(requirement *csi.TopologyRequirement) string {
 	return ""
 }
 
-func newCreateVolumeResponse(disk *cloud.Disk, snapshotID string) *csi.CreateVolumeResponse {
+func newCreateVolumeResponse(disk *cloud.Disk) *csi.CreateVolumeResponse {
 	var src *csi.VolumeContentSource
-	if snapshotID != "" {
+	if disk.SnapshotID != "" {
 		src = &csi.VolumeContentSource{
 			Type: &csi.VolumeContentSource_Snapshot{
 				Snapshot: &csi.VolumeContentSource_SnapshotSource{
-					SnapshotId: snapshotID,
+					SnapshotId: disk.SnapshotID,
 				},
 			},
 		}

--- a/tests/sanity/fake_cloud_provider.go
+++ b/tests/sanity/fake_cloud_provider.go
@@ -65,6 +65,7 @@ func (c *fakeCloudProvider) CreateDisk(ctx context.Context, volumeName string, d
 			VolumeID:         fmt.Sprintf("vol-%d", r1.Uint64()),
 			CapacityGiB:      util.BytesToGiB(diskOptions.CapacityBytes),
 			AvailabilityZone: diskOptions.AvailabilityZone,
+			SnapshotID:       diskOptions.SnapshotID,
 		},
 		tags: diskOptions.Tags,
 	}


### PR DESCRIPTION
CSI wants CreateVolumeResponse.ContentSource to be set to the snapshot that has just been restored.

Fixes #444
