### PR TITLE
Remove volume IOPS limit

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -66,7 +66,7 @@ const (
 	// MinTotalIOPS represents the minimum Input Output per second.
 	MinTotalIOPS = 100
 	// MaxTotalIOPS represents the maximum Input Output per second.
-	MaxTotalIOPS = 20000
+	MaxTotalIOPS = 64000
 	// MaxNumTagsPerResource represents the maximum number of tags per AWS resource.
 	MaxNumTagsPerResource = 50
 	// MaxTagKeyLength represents the maximum key length for a tag.

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -59,14 +59,9 @@ var (
 )
 
 // AWS provisioning limits.
-// Sources:
-//   http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html
+// Source:
 //   https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
 const (
-	// MinTotalIOPS represents the minimum Input Output per second.
-	MinTotalIOPS = 100
-	// MaxTotalIOPS represents the maximum Input Output per second.
-	MaxTotalIOPS = 64000
 	// MaxNumTagsPerResource represents the maximum number of tags per AWS resource.
 	MaxNumTagsPerResource = 50
 	// MaxTagKeyLength represents the maximum key length for a tag.
@@ -245,12 +240,6 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 	case VolumeTypeIO1:
 		createType = diskOptions.VolumeType
 		iops = capacityGiB * int64(diskOptions.IOPSPerGB)
-		if iops < MinTotalIOPS {
-			iops = MinTotalIOPS
-		}
-		if iops > MaxTotalIOPS {
-			iops = MaxTotalIOPS
-		}
 	case "":
 		createType = DefaultVolumeType
 	default:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.
Fixes: #306 

**What is this PR about? / Why do we need it?**

Our project requires the full IOPS capacity of EBS volumes.

Max IOPS for SSD (io1) volumes was increased from 20,000 to 32,000:
https://aws.amazon.com/about-aws/whats-new/2017/12/amazon-ebs-provisioned-iops-ssd--io1--volumes-now-support-32-000-iops-and-500-mbs-per-volume/
and later to 64,000:
https://aws.amazon.com/about-aws/whats-new/2018/11/amazon-elastic-block-store-announces-double-the-performance-of-provisioned-iops-volumes/

Rather than chasing this limit, allow the AWS SDK to surface errors for IOPS value out of range.

**What testing is done?** 

go test