### PR TITLE
Add nodeAffinity to avoid Fargate worker nodes

### DIFF
--- a/aws-ebs-csi-driver/templates/daemonset.yaml
+++ b/aws-ebs-csi-driver/templates/daemonset.yaml
@@ -20,6 +20,15 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       nodeSelector:
         beta.kubernetes.io/os: linux
       hostNetwork: true

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -14,6 +14,15 @@ spec:
       labels:
         app: ebs-csi-node
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       nodeSelector:
         beta.kubernetes.io/os: linux
         beta.kubernetes.io/arch: amd64


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Add nodeAffinity in the daemonset to avoid schedule ebs-csi-node pods on Fargate worker nodes, as Fargate does not support ebs.

If there is a pod running in Fargate, the daemoset tries to place ebs-csi-node pod in the same node, with causes the pod to Pending state.

**What testing is done?** 
Apply the original with kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master" -> pods Pending.

Adding the nodeAffinity, all pods in the Pending state on Fargate are deleted and new are only created at EC2 nodes
