### PR TITLE
*: remove deprecated "beta.kubernetes.io/os" nodeSelector

### DIFF
--- a/aws-ebs-csi-driver/templates/daemonset.yaml
+++ b/aws-ebs-csi-driver/templates/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
                 values:
                 - fargate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:

--- a/aws-ebs-csi-driver/templates/deployment.yaml
+++ b/aws-ebs-csi-driver/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         {{- with .Values.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -16,7 +16,7 @@ spec:
         app: ebs-csi-controller
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         beta.kubernetes.io/arch: amd64
       serviceAccount: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -24,7 +24,7 @@ spec:
                 values:
                 - fargate
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         beta.kubernetes.io/arch: amd64
       hostNetwork: true
       priorityClassName: system-node-critical


### PR DESCRIPTION

**What is this PR about? / Why do we need it?**

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md

> kubelet  the beta.kubernetes.io/os and beta.kubernetes.io/arch labels, deprecated since v1.14, are targeted for removal in v1.18.
