### PR TITLE
Update kubernetes-csi/external-snapshotter components to v2.1.1

### DIFF
--- a/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccount: ebs-snapshot-controller
       containers:
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          image: quay.io/k8scsi/snapshot-controller:v2.1.1
           args:
             - --v=5
             - --leader-election=false

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -18,7 +18,7 @@ sidecars:
     tag: "v1.2.0"
   snapshotterImage:
     repository: quay.io/k8scsi/csi-snapshotter
-    tag: "v2.0.1"
+    tag: "v2.1.1"
   livenessProbeImage:
     repository: quay.io/k8scsi/livenessprobe
     tag: "v1.1.0"

--- a/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
+++ b/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
         - name: csi-snapshotter
-          image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true

--- a/deploy/kubernetes/overlays/alpha/snapshot_controller.yaml
+++ b/deploy/kubernetes/overlays/alpha/snapshot_controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: ebs-snapshot-controller
       containers:
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          image: quay.io/k8scsi/snapshot-controller:v2.1.1
           args:
             - --v=5
             - --leader-election=false


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind cleanup

**What is this PR about? / Why do we need it?**
Update kubernetes-csi/external-snapshotter components to v2.1.1 - ref https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v2.1.1.

**What testing is done?** 
