### PR TITLE
Improve csi-snapshotter ClusterRole

### DIFF
--- a/aws-ebs-csi-driver/templates/rbac.yaml
+++ b/aws-ebs-csi-driver/templates/rbac.yaml
@@ -87,15 +87,6 @@ metadata:
   name: ebs-external-snapshotter-role
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
@@ -108,17 +99,8 @@ rules:
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
 
 ---
 kind: ClusterRoleBinding

--- a/deploy/kubernetes/overlays/alpha/rbac_add_snapshotter.yaml
+++ b/deploy/kubernetes/overlays/alpha/rbac_add_snapshotter.yaml
@@ -6,15 +6,6 @@ metadata:
   name: ebs-external-snapshotter-role
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
@@ -27,17 +18,8 @@ rules:
     resources: ["volumesnapshotcontents"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
-    resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
-  - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete"]
 ---
 
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind cleanup

**What is this PR about? / Why do we need it?**
With v2.0.0 of kubernetes-csi/external-snapshotter, it is split into two component - the csi-snapshotter sidecar and the snapshot controller (ref https://github.com/kubernetes-csi/external-snapshotter/pull/182). As the `VolumeSnapshot` watch is moved to the new snapshot controller, the csi-snapshotter sidecar ClusterRole no longer needs to rules for volumesnapshots.
This PR adapts the csi-snapshotter sidecar RBAC according to https://github.com/kubernetes-csi/external-snapshotter/blob/v2.1.1/deploy/kubernetes/csi-snapshotter/rbac-csi-snapshotter.yaml.

**What testing is done?** 
