### PR TITLE
Update stable overlay to 0.5.0

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ bases:
 - ../../base
 images:
 - name: amazon/aws-ebs-csi-driver
-  newTag: v0.4.0
+  newTag: v0.5.0
 - name: quay.io/k8scsi/csi-provisioner
   newTag: v1.3.0
 - name: quay.io/k8scsi/csi-attacher


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug 

**What is this PR about? / Why do we need it?** 0.5.0 was released, bump overlay kustomization to match. This fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/494 because the `node` arg was added to the template but it isn't recognized by 0.4.0, need to bump to 0.5.0 for stable overlay to continue working.

**What testing is done?** 
