### PR TITLE
Binds controller pods to ec2 nodes: #492

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/name: aws-ebs-csi-driver
   template:
     metadata:
+      annotations:
+        eks.amazonaws.com/compute-type: ec2
       labels:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix.
Fixes: #492

**What is this PR about? / Why do we need it?**

The controller pods have to run on EC2 nodes even if `kube-system` namespace uses fargate profile.

**What testing is done?** 

1. Created a fargate profile for `kube-system` namespaces
2. Deployed with: `kubectl apply -k deploy/kubernetes/overlays/stable/`
3. Made sure the controller pods are on EC2 nodes
