### PR TITLE
Add missing IAM permissions

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -11,10 +11,12 @@
         "ec2:DeleteSnapshot",
         "ec2:DeleteTags",
         "ec2:DeleteVolume",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
+        "ec2:DescribeVolumesModifications",
         "ec2:DetachVolume",
         "ec2:ModifyVolume"
       ],


### PR DESCRIPTION
Originally authored by @pierresteiner at #461. He was unable to complete the PR due to being unable to sign a CLA. I have no such barrier so I am submitting instead.

> Without that, I was getting a nasty error message with 0.5.0
> 
> ```
> E0310 15:07:10.063122       1 controller.go:910] error syncing claim "835b97fa-62e0-11ea-b720-06ab0707f8ae": failed to provision volume with StorageClass "ebs-sc": rpc error: code = Internal desc = Could not create volume "pvc-835b97fa-62e0-11ea-b720-06ab0707f8ae": failed to get availability zone UnauthorizedOperation: You are not authorized to perform this operation.
> ```
> 
> **Is this a bug fix or adding new feature?**: Bug
> 
> **What is this PR about? / Why do we need it?**: It fixes the list of permission
> 
> **What testing is done?**: Yes
> 
> EDIT: I did use IRSA, so the pods did not benefit from any permission from the worker. I hope that this is the only missing permission

