### PR TITLE
Add controller support for custom EC2 Endpoints

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -51,6 +51,12 @@ spec:
                   name: aws-secret
                   key: access_key
                   optional: true
+            - name: AWS_EC2_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: aws-config
+                  key: aws_ec2_endpoint
+                  optional: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/


### PR DESCRIPTION
Expose the AWS_EC2_ENDPOINT environment variable as a ConfigMap for the Controller. This allows deployment of the controller to environments using EC2-compatible clouds such as Eucalyptus/CloudStack or Government Community clouds disconnected from the internet. The controller already has support for the environment variable, it just needs to be exposed in the config map.

This was tested on Eucalyptus and confirmed to be functioning properly.

**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Enhances support of CSI driver for private cloud deployments.

**What testing is done?** 
Tested and verified to work on Eucalyptus. After making the change to controller.yaml, the configMap needs to be created
```
kubectl create configmap -n kube-system --from-literal=aws_ec2_endpoint=https://<ec2_endpoint> aws-config
```