### PR TITLE
Add PodSecurityPolicy manifest templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ generate-kustomize: bin/helm
 	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/csidriver.yaml > ../deploy/kubernetes/base/csidriver.yaml
 	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/node.yaml -f ../deploy/kubernetes/values/controller.yaml > ../deploy/kubernetes/base/node.yaml
 	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/serviceaccount-csi-controller.yaml > ../deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/clusterrole-node.yaml > ../deploy/kubernetes/base/clusterrole-node.yaml
+	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/clusterrolebinding-node.yaml > ../deploy/kubernetes/base/clusterrolebinding-node.yaml
+	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/podsecuritypolicy-node.yaml > ../deploy/kubernetes/base/podsecuritypolicy-node.yaml
+	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/serviceaccount-node.yaml > ../deploy/kubernetes/base/serviceaccount-node.yaml
 	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/clusterrole-resizer.yaml -f ../deploy/kubernetes/values/resizer.yaml > ../deploy/kubernetes/overlays/alpha/rbac_add_resizer_clusterrole.yaml
 	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/clusterrole-snapshot-controller.yaml -f ../deploy/kubernetes/values/snapshotter.yaml > ../deploy/kubernetes/overlays/alpha/rbac_add_snapshot_controller_clusterrole.yaml
 	cd aws-ebs-csi-driver && ../bin/helm template kustomize . -s templates/clusterrole-snapshotter.yaml -f ../deploy/kubernetes/values/snapshotter.yaml > ../deploy/kubernetes/overlays/alpha/rbac_add_snapshotter_clusterrole.yaml

--- a/aws-ebs-csi-driver/templates/clusterrole-node.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrole-node.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node
+  labels:
+    {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+      - ebs-csi-node

--- a/aws-ebs-csi-driver/templates/clusterrolebinding-node.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrolebinding-node.yaml
@@ -1,0 +1,15 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node
+  labels:
+    {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-node
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-csi-node

--- a/aws-ebs-csi-driver/templates/node.yaml
+++ b/aws-ebs-csi-driver/templates/node.yaml
@@ -39,6 +39,7 @@ spec:
         {{- with .Values.node.tolerations }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+      serviceAccountName: ebs-csi-node
       containers:
         - name: ebs-plugin
           securityContext:

--- a/aws-ebs-csi-driver/templates/podsecuritypolicy-node.yaml
+++ b/aws-ebs-csi-driver/templates/podsecuritypolicy-node.yaml
@@ -1,0 +1,26 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: ebs-csi-node
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPorts:
+    - min: 9808
+      max: 9808
+  volumes:
+    - "configMap"
+    - "emptyDir"
+    - "secret"
+    - "hostPath"
+  allowedHostPaths:
+    - pathPrefix: "/dev"
+    - pathPrefix: "/var/lib/kubelet"

--- a/aws-ebs-csi-driver/templates/serviceaccount-node.yaml
+++ b/aws-ebs-csi-driver/templates/serviceaccount-node.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-node

--- a/deploy/kubernetes/base/clusterrole-node.yaml
+++ b/deploy/kubernetes/base/clusterrole-node.yaml
@@ -1,0 +1,14 @@
+---
+# Source: aws-ebs-csi-driver/templates/clusterrole-node.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+      - ebs-csi-node

--- a/deploy/kubernetes/base/clusterrolebinding-node.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-node.yaml
@@ -1,0 +1,16 @@
+---
+# Source: aws-ebs-csi-driver/templates/clusterrolebinding-node.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ebs-csi-node
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+  - kind: ServiceAccount
+    name: ebs-csi-node
+    namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-csi-node

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -35,6 +35,7 @@ spec:
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
+      serviceAccountName: ebs-csi-node
       containers:
         - name: ebs-plugin
           securityContext:

--- a/deploy/kubernetes/base/podsecuritypolicy-node.yaml
+++ b/deploy/kubernetes/base/podsecuritypolicy-node.yaml
@@ -1,0 +1,28 @@
+---
+# Source: aws-ebs-csi-driver/templates/podsecuritypolicy-node.yaml
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: ebs-csi-node
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPorts:
+    - min: 9808
+      max: 9808
+  volumes:
+    - "configMap"
+    - "emptyDir"
+    - "secret"
+    - "hostPath"
+  allowedHostPaths:
+    - pathPrefix: "/dev"
+    - pathPrefix: "/var/lib/kubelet"

--- a/deploy/kubernetes/base/serviceaccount-node.yaml
+++ b/deploy/kubernetes/base/serviceaccount-node.yaml
@@ -1,0 +1,6 @@
+---
+# Source: aws-ebs-csi-driver/templates/serviceaccount-node.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-csi-node


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Both?

**What is this PR about? / Why do we need it?**

Node Daemonset has "above normal" privilege requirements, like hostPaths, hostPorts, etc.

In clusters with PSPs enabled, default policy is unlikely to grant these privileges. This creates a dedicated PSP for the node DaemonSet.

**What testing is done?** 

Additional resources where deployed on one of our development clusters and enabled DaemonSet to be scheduled.