### PR TITLE
optimization: cache go mod during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,14 @@
 
 FROM golang:1.14.1-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+
+# Cache go modules
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
 ADD . .
 RUN make
-RUN go test ./pkg/...
 
 FROM amazonlinux:2
 RUN yum install ca-certificates e2fsprogs xfsprogs util-linux -y


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
cache go mod during docker build