### PR TITLE
Remove namespace field from manifests & template kubeletPath

### DIFF
--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.4.0
+version: 0.5.0
 kubeVersion: ">=1.13.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ebs-external-attacher-role

--- a/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
@@ -8,7 +8,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ebs-external-provisioner-role

--- a/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ebs-external-resizer-role

--- a/aws-ebs-csi-driver/templates/clusterrolebinding-snapshot-controller.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrolebinding-snapshot-controller.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-snapshot-controller
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ebs-snapshot-controller-role

--- a/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
+++ b/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ebs-external-snapshotter-role

--- a/aws-ebs-csi-driver/templates/controller.yaml
+++ b/aws-ebs-csi-driver/templates/controller.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:

--- a/aws-ebs-csi-driver/templates/node.yaml
+++ b/aws-ebs-csi-driver/templates/node.yaml
@@ -3,7 +3,6 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: ebs-csi-node
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
@@ -54,7 +53,7 @@ spec:
               value: unix:/csi/csi.sock
           volumeMounts:
             - name: kubelet-dir
-              mountPath: /var/lib/kubelet
+              mountPath: {{ default "/var/lib/kubelet" .Values.node.kubeletPath }}
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
@@ -86,7 +85,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+              value: {{ default "/var/lib/kubelet" .Values.node.kubeletPath }}/plugins/ebs.csi.aws.com/csi.sock
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -102,15 +101,15 @@ spec:
       volumes:
         - name: kubelet-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: {{ default "/var/lib/kubelet" .Values.node.kubeletPath }}
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
+            path: {{ default "/var/lib/kubelet" .Values.node.kubeletPath }}/plugins/ebs.csi.aws.com/
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ default "/var/lib/kubelet" .Values.node.kubeletPath }}/plugins_registry/
             type: Directory
         - name: device-dir
           hostPath:

--- a/aws-ebs-csi-driver/templates/role-snapshot-controller-leaderelection.yaml
+++ b/aws-ebs-csi-driver/templates/role-snapshot-controller-leaderelection.yaml
@@ -4,7 +4,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ebs-snapshot-controller-leaderelection
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 rules:

--- a/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
+++ b/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
@@ -9,6 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-snapshot-controller
+    namespace: {{ .Release.namespace }}
 roleRef:
   kind: Role
   name: snapshot-controller-leaderelection

--- a/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
+++ b/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
@@ -4,13 +4,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: snapshot-controller-leaderelection
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: ebs-snapshot-controller
-    namespace: kube-system
 roleRef:
   kind: Role
   name: snapshot-controller-leaderelection

--- a/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ebs-csi-controller-sa
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.controller.annotations }}

--- a/aws-ebs-csi-driver/templates/serviceaccount-snapshot-controller.yaml
+++ b/aws-ebs-csi-driver/templates/serviceaccount-snapshot-controller.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ebs-snapshot-controller
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.snapshot.annotations }}

--- a/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -4,7 +4,6 @@ kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: ebs-snapshot-controller
-  namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 
Feature

**What is this PR about? / Why do we need it?**
Remove namespace kube-system from manifests & template kubelet path 

**What testing is done?** 
Installed the chart.

Issue #448 
