### PR TITLE
Controller default deployment to EC2 compute type.

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/name: aws-ebs-csi-driver
   template:
     metadata:
+      annotations:
+        eks.amazonaws.com/compute-type: ec2
       labels:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Neither bug or feature

**What is this PR about? / Why do we need it?**
AWS [documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) assumes the controller will run in EC2 compute type. However, when a Fargate profile exists on the namespace and can cause controller to run as a Fargate pod, the required IAM role needs to be configured via [IAM role for service account (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). This can cause the pod to be stuck in CrashLoopBackOff when it is unable to get the correct IAM permission to perform an action.

I do not believe adding this annotation will affect EBS CSI deployment to a non-EKS Kubernetes cluster.

**What testing is done?** 
Manually deploy the manifest with Fargate profile exist on the kube-system namespace, pod was able to avoid being schedule on Fargate node