### PR TITLE
aws-ebs-csi-driver/templates/controller.yaml: fix rendered emptyline

### DIFF
--- a/aws-ebs-csi-driver/templates/controller.yaml
+++ b/aws-ebs-csi-driver/templates/controller.yaml
@@ -44,7 +44,7 @@ spec:
           args:
             {{- if ne .Release.Name "kustomize" }}
             - controller
-            {{ else }}
+            {{- else }}
             # - {all,controller,node} # specify the driver mode
             {{- end }}
             - --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION
Without this, the manifest renders with empty line between the
arguments, which does not look nice.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>
