### PR TITLE
Make EBS controllerexpansion idempotent

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -863,6 +863,20 @@ func (c *cloud) ResizeDisk(ctx context.Context, volumeID string, newSizeBytes in
 		return oldSizeGiB, nil
 	}
 
+	latestMod, err := c.getLatestVolumeModification(ctx, volumeID)
+	// if there are no errors fetching modifications
+	if err == nil && latestMod != nil {
+		state := aws.StringValue(latestMod.ModificationState)
+		targetSize := aws.Int64Value(latestMod.TargetSize)
+		if (state == ec2.VolumeModificationStateCompleted || state == ec2.VolumeModificationStateOptimizing) && targetSize >= newSizeGiB {
+			return targetSize, nil
+		}
+
+		if state == ec2.VolumeModificationStateModifying {
+			return oldSizeGiB, fmt.Errorf("volume %q is still being expanded to size %d", volumeID, targetSize)
+		}
+	}
+
 	req := &ec2.ModifyVolumeInput{
 		VolumeId: aws.String(volumeID),
 		Size:     aws.Int64(newSizeGiB),
@@ -896,10 +910,11 @@ func (c *cloud) ResizeDisk(ctx context.Context, volumeID string, newSizeBytes in
 
 // waitForVolumeSize waits for a volume modification to finish and return its size.
 func (c *cloud) waitForVolumeSize(ctx context.Context, volumeID string) (int64, error) {
+	// the default context is 10s and hence we should reduce this to more reasonable value and let external-resizer retry
 	backoff := wait.Backoff{
 		Duration: 1 * time.Second,
 		Factor:   1.8,
-		Steps:    20,
+		Steps:    3,
 	}
 
 	var modVolSizeGiB int64

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -687,27 +687,6 @@ func TestResizeDisk(t *testing.T) {
 			expErr:              fmt.Errorf("ResizeDisk generic error"),
 		},
 		{
-			name:     "success: there is a resizing in progress",
-			volumeID: "vol-test",
-			existingVolume: &ec2.Volume{
-				VolumeId:         aws.String("vol-test"),
-				Size:             aws.Int64(1),
-				AvailabilityZone: aws.String(defaultZone),
-			},
-			modifiedVolumeError: awserr.New("IncorrectModificationState", "", nil),
-			descModVolume: &ec2.DescribeVolumesModificationsOutput{
-				VolumesModifications: []*ec2.VolumeModification{
-					{
-						VolumeId:          aws.String("vol-test"),
-						TargetSize:        aws.Int64(2),
-						ModificationState: aws.String(ec2.VolumeModificationStateCompleted),
-					},
-				},
-			},
-			reqSizeGiB: 2,
-			expErr:     nil,
-		},
-		{
 			name:     "failure: volume in modifying state",
 			volumeID: "vol-test",
 			existingVolume: &ec2.Volume{
@@ -733,6 +712,8 @@ func TestResizeDisk(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockEC2 := mocks.NewMockEC2(mockCtrl)
+			// reduce number of steps to reduce test time
+			volumeModificationWaitSteps = 3
 			c := newCloud(mockEC2)
 
 			ctx := context.Background()


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/498

This PR contains following fixes:
- When describeVolume returns volume size to be greater than requested size, we also verify if volume has any modifications pending. I have observed that, AWS can set targetSize on volume even with pending volume modifications. This is the root cause of EBS resize flake.
- When volume modifications check return volume resizing to be completed, we also verify volume size by describing volume. This is to ensure that - we minimize impact of eventual consistency by making two different API calls.


