### PR TITLE
Create volumes in outpost for outpost instances

### DIFF
--- a/pkg/cloud/mocks/mock_ec2metadata.go
+++ b/pkg/cloud/mocks/mock_ec2metadata.go
@@ -61,3 +61,18 @@ func (mr *MockEC2MetadataMockRecorder) GetInstanceIdentityDocument() *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceIdentityDocument", reflect.TypeOf((*MockEC2Metadata)(nil).GetInstanceIdentityDocument))
 }
+
+// GetMetadata mocks base method
+func (m *MockEC2Metadata) GetMetadata(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetadata", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMetadata indicates an expected call of GetMetadata
+func (mr *MockEC2MetadataMockRecorder) GetMetadata(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockEC2Metadata)(nil).GetMetadata), arg0)
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -40,8 +40,12 @@ const (
 )
 
 const (
-	DriverName  = "ebs.csi.aws.com"
-	TopologyKey = "topology." + DriverName + "/zone"
+	DriverName      = "ebs.csi.aws.com"
+	TopologyKey     = "topology." + DriverName + "/zone"
+	AwsPartitionKey = "topology." + DriverName + "/partition"
+	AwsAccountIDKey = "topology." + DriverName + "/account-id"
+	AwsRegionKey    = "topology." + DriverName + "/region"
+	AwsOutpostIDKey = "topology." + DriverName + "/outpost-id"
 )
 
 type Driver struct {

--- a/pkg/driver/mocks/mock_metadata_service.go
+++ b/pkg/driver/mocks/mock_metadata_service.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	arn "github.com/aws/aws-sdk-go/aws/arn"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -72,6 +73,20 @@ func (m *MockMetadataService) GetInstanceType() string {
 func (mr *MockMetadataServiceMockRecorder) GetInstanceType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceType", reflect.TypeOf((*MockMetadataService)(nil).GetInstanceType))
+}
+
+// GetOutpostArn mocks base method
+func (m *MockMetadataService) GetOutpostArn() arn.ARN {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOutpostArn")
+	ret0, _ := ret[0].(arn.ARN)
+	return ret0
+}
+
+// GetOutpostArn indicates an expected call of GetOutpostArn
+func (mr *MockMetadataServiceMockRecorder) GetOutpostArn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutpostArn", reflect.TypeOf((*MockMetadataService)(nil).GetOutpostArn))
 }
 
 // GetRegion mocks base method

--- a/tester/single-az-config.yaml
+++ b/tester/single-az-config.yaml
@@ -90,7 +90,7 @@ install: |
 
   kubectl get po -n kube-system
 
-uninstall: | 
+uninstall: |
   echo "Removing driver"
   bin/helm del --purge aws-ebs-csi-driver
 

--- a/tests/e2e/driver/driver.go
+++ b/tests/e2e/driver/driver.go
@@ -16,7 +16,7 @@ package driver
 
 import (
 	"github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/vendor/github.com/aws/aws-sdk-go/aws/arn/arn.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/arn/arn.go
@@ -1,0 +1,93 @@
+// Package arn provides a parser for interacting with Amazon Resource Names.
+package arn
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	arnDelimiter = ":"
+	arnSections  = 6
+	arnPrefix    = "arn:"
+
+	// zero-indexed
+	sectionPartition = 1
+	sectionService   = 2
+	sectionRegion    = 3
+	sectionAccountID = 4
+	sectionResource  = 5
+
+	// errors
+	invalidPrefix   = "arn: invalid prefix"
+	invalidSections = "arn: not enough sections"
+)
+
+// ARN captures the individual fields of an Amazon Resource Name.
+// See http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html for more information.
+type ARN struct {
+	// The partition that the resource is in. For standard AWS regions, the partition is "aws". If you have resources in
+	// other partitions, the partition is "aws-partitionname". For example, the partition for resources in the China
+	// (Beijing) region is "aws-cn".
+	Partition string
+
+	// The service namespace that identifies the AWS product (for example, Amazon S3, IAM, or Amazon RDS). For a list of
+	// namespaces, see
+	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces.
+	Service string
+
+	// The region the resource resides in. Note that the ARNs for some resources do not require a region, so this
+	// component might be omitted.
+	Region string
+
+	// The ID of the AWS account that owns the resource, without the hyphens. For example, 123456789012. Note that the
+	// ARNs for some resources don't require an account number, so this component might be omitted.
+	AccountID string
+
+	// The content of this part of the ARN varies by service. It often includes an indicator of the type of resource —
+	// for example, an IAM user or Amazon RDS database - followed by a slash (/) or a colon (:), followed by the
+	// resource name itself. Some services allows paths for resource names, as described in
+	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-paths.
+	Resource string
+}
+
+// Parse parses an ARN into its constituent parts.
+//
+// Some example ARNs:
+// arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment
+// arn:aws:iam::123456789012:user/David
+// arn:aws:rds:eu-west-1:123456789012:db:mysql-db
+// arn:aws:s3:::my_corporate_bucket/exampleobject.png
+func Parse(arn string) (ARN, error) {
+	if !strings.HasPrefix(arn, arnPrefix) {
+		return ARN{}, errors.New(invalidPrefix)
+	}
+	sections := strings.SplitN(arn, arnDelimiter, arnSections)
+	if len(sections) != arnSections {
+		return ARN{}, errors.New(invalidSections)
+	}
+	return ARN{
+		Partition: sections[sectionPartition],
+		Service:   sections[sectionService],
+		Region:    sections[sectionRegion],
+		AccountID: sections[sectionAccountID],
+		Resource:  sections[sectionResource],
+	}, nil
+}
+
+// IsARN returns whether the given string is an ARN by looking for
+// whether the string starts with "arn:" and contains the correct number
+// of sections delimited by colons(:).
+func IsARN(arn string) bool {
+	return strings.HasPrefix(arn, arnPrefix) && strings.Count(arn, ":") >= arnSections-1
+}
+
+// String returns the canonical representation of the ARN
+func (arn ARN) String() string {
+	return arnPrefix +
+		arn.Partition + arnDelimiter +
+		arn.Service + arnDelimiter +
+		arn.Region + arnDelimiter +
+		arn.AccountID + arnDelimiter +
+		arn.Resource
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,6 @@
 # github.com/aws/aws-sdk-go v1.29.11
 github.com/aws/aws-sdk-go/aws
+github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/aws/awsutil
 github.com/aws/aws-sdk-go/aws/client


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix

**What is this PR about? / Why do we need it?**
[Outposts Documentation](https://docs.aws.amazon.com/outposts/latest/userguide/what-is-outposts.html) for background.

Currently, we're running oblivious to outposts. Volumes are created in the parent region instead of the outpost itself. In order to fix it, we need to pass the `outpostArn` to [CreateVolume](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html).

I'm leveraging the `outpost-arn` instance metadata to determine if we're in an outpost instance. There are two possible responses from the endpoint:

- The outpost-arn if it's an outpost instance
- `404` if it's a regular non-outpost instance.

I've verified the behavior using [this test code](https://gist.github.com/ayberk/102a8995569d5e9002bbb27db209b42e) on a test outpost.

**What testing is done?** 
Tested on an actual outpost instance and verified it works. 
