### PR TITLE
Double iops/gb for io1 and io2 e2e tests

### DIFF
--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -140,8 +140,8 @@ func MinimumSizeForVolumeType(volumeType string) string {
 func IOPSPerGBForVolumeType(volumeType string) string {
 	switch volumeType {
 	case "io1", "io2":
-		// Minimum disk size is 4, minimum IOPS is 100
-		return "25"
+		// Maximum IOPS/GB for io1 is 50
+		return "50"
 	default:
 		return ""
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** tests timeout inexplicably, i still have not had much chance to deep dive/repro why so let's just bump iops from the minimum for now and see if it helps. ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/545

**What testing is done?** 
