### PR TITLE
Bump all e2e test clusters to latest version 1.18.9

### DIFF
--- a/tester/migration-test-config.yaml
+++ b/tester/migration-test-config.yaml
@@ -4,7 +4,7 @@ cluster:
     zones: us-west-2a
     nodeCount: 3
     nodeSize: c5.large
-    kubernetesVersion: 1.15.3
+    kubernetesVersion: 1.18.9
     featureGates: |2
         kubeAPIServer:
           featureGates:
@@ -94,7 +94,7 @@ install: |
       --set image.tag=$IMAGE_TAG \
       ./aws-ebs-csi-driver
 
-uninstall: | 
+uninstall: |
   echo "Removing driver"
   helm del --purge aws-ebs-csi-driver
 

--- a/tester/multi-az-config.yaml
+++ b/tester/multi-az-config.yaml
@@ -4,7 +4,7 @@ cluster:
     zones: us-west-2a,us-west-2b,us-west-2c
     nodeCount: 3
     nodeSize: c5.large
-    kubernetesVersion: 1.16.0
+    kubernetesVersion: 1.18.9
     featureGates: |2
         kubeAPIServer:
           featureGates:
@@ -87,7 +87,7 @@ install: |
 
   kubectl get po -n kube-system
 
-uninstall: | 
+uninstall: |
   echo "Removing driver"
   bin/helm del --purge aws-ebs-csi-driver
 

--- a/tester/single-az-config.yaml
+++ b/tester/single-az-config.yaml
@@ -4,7 +4,7 @@ cluster:
     zones: us-west-2a
     nodeCount: 3
     nodeSize: c5.large
-    kubernetesVersion: 1.16.0
+    kubernetesVersion: 1.18.9
     featureGates: |2
         kubeAPIServer:
           featureGates:
@@ -90,7 +90,7 @@ install: |
 
   kubectl get po -n kube-system
 
-uninstall: | 
+uninstall: |
   echo "Removing driver"
   bin/helm del --purge aws-ebs-csi-driver
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** routine bump

**What is this PR about? / Why do we need it?** We should be continuously testing new driver versions against new kubernetes versions.

**What testing is done?** N/A, will see if CI passes and adjust accordingly.
