### PR TITLE
Add overlay for ECR images

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+images:
+- name: amazon/aws-ebs-csi-driver
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
+  newTag: v0.6.0
+- name: quay.io/k8scsi/csi-provisioner
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
+  newTag: v1.5.0
+- name: quay.io/k8scsi/csi-attacher
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
+  newTag: v1.2.0
+- name: quay.io/k8scsi/livenessprobe
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
+  newTag: v1.1.0
+- name: quay.io/k8scsi/csi-node-driver-registrar
+  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+  newTag: v1.1.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
N/A

**What is this PR about? / Why do we need it?**
Adds a new kustomization layout that uses the images from ECR instead of quay and docker hub. Fixes #554.
