### PR TITLE
Push amazonlinux target to Docker Hub

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -19,7 +19,8 @@ jobs:
         docker buildx build \
           -t aws-ebs-csi-driver \
           --platform=linux/arm64,linux/amd64 \
-          --output="type=image,push=false" .
+          --output="type=image,push=false" . \
+          --target=amazonlinux
     - name: Push to Github registry
       run: |
         USER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
@@ -31,7 +32,7 @@ jobs:
           TAG=$BRANCH
         fi
         docker login docker.pkg.github.com -u $USER -p ${{ secrets.REGISTRY_TOKEN }}
-        docker build -t aws-ebs-csi-driver .
+        docker build -t aws-ebs-csi-driver . --target amazonlinux
         docker tag aws-ebs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
         docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
     - name: Push to Dockerhub registry
@@ -47,5 +48,6 @@ jobs:
         docker buildx build \
           -t $REPO:$TAG \
           --platform=linux/arm64,linux/amd64 \
-          --output="type=image,push=true" .
+          --output="type=image,push=true" . \
+          --target=amazonlinux
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** Until I get approval to push debian based image to Docker Hub, need to revert to AL2. As discussed in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/551, there are good reasons to base on debian instead, but at least for the next release I don't have much choice!

**What testing is done?** 
This buildx command worked locally

```
~/g/s/g/k/aws-ebs-csi-driver (al2|✔) [1] $ docker buildx build \
                                                     -t a:b \
                                                     --output="type=image,push=false" . \
                                                     --target=amazonlinux
[+] Building 122.5s (13/13) FINISHED                                                         
 => [internal] load .dockerignore                                                       0.0s
 => => transferring context: 2B                                                         0.0s
 => [internal] load build definition from Dockerfile                                    0.0s
 => => transferring dockerfile: 1.30kB                                                  0.0s
 => [internal] load metadata for docker.io/library/golang:1.14.1-stretch                1.8s
 => [internal] load metadata for docker.io/library/amazonlinux:2                        0.0s
 => [builder 1/4] FROM docker.io/library/golang:1.14.1-stretch@sha256:cc6f9cb946dd58  105.8s
 => => resolve docker.io/library/golang:1.14.1-stretch@sha256:cc6f9cb946dd589890fe6b3d  0.0s
 => => sha256:c8f0469eac1d2752a5570e53dceb8b65d0d1508e3ca0ce6d2d100ce4 5.46kB / 5.46kB  0.0s
 => => sha256:fbfe0f13ac4531fb6d077fda0e94ced4b9ed8a354c54b4efced9b7 10.80MB / 10.80MB  4.2s
 => => sha256:6254ff6d0e6052b7bead70e37703002eda28ac40f9a1167ea9bf813b 4.34MB / 4.34MB  1.1s
 => => sha256:cc6f9cb946dd589890fe6b3d271ab31070bdd2b5ab90635a4d572fbe 1.42kB / 1.42kB  0.0s
 => => sha256:b0299a07363dfa30eec0fa84d2a336f5b6d433903e0e5a3a7fc81980 1.80kB / 1.80kB  0.0s
 => => sha256:56da78ce36e97a8ba1f860575bb1422d1cb6ab4dade70b06ddf16 45.38MB / 45.38MB  36.5s
 => => sha256:e0e1e13bd9f6c381f158a5366b3eff242e8b4a4decfa940e915b1 50.07MB / 50.07MB  36.9s
 => => sha256:cc3442cfd6ffb734399b2c329c1f475ed6d8ebacc22ea93c05b7b 57.72MB / 57.72MB  51.8s
 => => sha256:fcbc8403d2d8c52ac6ea104b4f1bbd1c7f41f18b18a30c3bc1 123.63MB / 123.63MB  101.5s
 => => extracting sha256:56da78ce36e97a8ba1f860575bb1422d1cb6ab4dade70b06ddf1651302dde  1.4s
 => => sha256:e90c64a86c3054289a67eb82e93b08fb9761c83b11f4a90ca2f72b0e80f 125B / 125B  37.1s
 => => extracting sha256:fbfe0f13ac4531fb6d077fda0e94ced4b9ed8a354c54b4efced9b7755d3f3  0.3s
 => => extracting sha256:6254ff6d0e6052b7bead70e37703002eda28ac40f9a1167ea9bf813bf9c17  0.1s
 => => extracting sha256:e0e1e13bd9f6c381f158a5366b3eff242e8b4a4decfa940e915b1d5705ef4  1.8s 
 => => extracting sha256:cc3442cfd6ffb734399b2c329c1f475ed6d8ebacc22ea93c05b7bb5a6dbb8  1.6s 
 => => extracting sha256:fcbc8403d2d8c52ac6ea104b4f1bbd1c7f41f18b18a30c3bc170878b7fae6  3.8s 
 => => extracting sha256:e90c64a86c3054289a67eb82e93b08fb9761c83b11f4a90ca2f72b0e80ff8  0.0s 
 => [amazonlinux 1/3] FROM docker.io/library/amazonlinux:2                              0.0s 
 => => resolve docker.io/library/amazonlinux:2                                          0.0s 
 => [internal] load build context                                                       1.3s
 => => transferring context: 99.52MB                                                    1.3s
 => [amazonlinux 2/3] RUN yum install ca-certificates e2fsprogs xfsprogs util-linux -  16.1s
 => [builder 2/4] WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver         0.4s
 => [builder 3/4] COPY . .                                                              1.6s
 => [builder 4/4] RUN make                                                             10.1s
 => [amazonlinux 3/3] COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-c  0.1s
 => exporting to image                                                                  2.5s 
 => => exporting layers                                                                 2.5s 
 => => writing image sha256:c3d0bf4e1a76e5e227fa1566effcc268ddc08e727790f175c4f25859e5  0.0s 
 => => naming to docker.io/library/a:b                                                  0.0s
```