### PR TITLE
[helm] add tag options and update csi-provisioner

### DIFF
--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.6.0
+version: 0.6.1
 kubeVersion: ">=1.13.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/aws-ebs-csi-driver/templates/controller.yaml
+++ b/aws-ebs-csi-driver/templates/controller.yaml
@@ -50,6 +50,9 @@ spec:
             {{- if .Values.extraVolumeTags }}
               {{- include "aws-ebs-csi-driver.extra-volume-tags" . | nindent 12 }}
             {{- end }}
+            {{- if .Values.k8sTagClusterId }}
+            - --k8s-tag-cluster-id={{ .Values.k8sTagClusterId }}
+            {{- end }}
             - --logtostderr
             - --v=5
           env:
@@ -96,6 +99,9 @@ spec:
             - --v=5
             {{- if .Values.enableVolumeScheduling }}
             - --feature-gates=Topology=true
+            {{- end}}
+            {{- if .Values.extraCreateMetadata }}
+            - --extra-create-metadata
             {{- end}}
             - --enable-leader-election
             - --leader-election-type=leases

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -12,7 +12,7 @@ image:
 sidecars:
   provisionerImage:
     repository: quay.io/k8scsi/csi-provisioner
-    tag: "v1.5.0"
+    tag: "v1.6.0"
   attacherImage:
     repository: quay.io/k8scsi/csi-attacher
     tag: "v1.2.0"

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -69,6 +69,12 @@ affinity: {}
 #   key2: value2
 extraVolumeTags: {}
 
+# If set, add pv/pvc metadata to plugin create requests as parameters.
+extraCreateMetadata: false
+
+# ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).
+k8sTagClusterId: ""
+
 # AWS region to use. If not specified then the region will be looked up via the AWS EC2 metadata
 # service.
 # ---


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature
**What is this PR about? / Why do we need it?**
Add options to create EBS volume tags that the in-tree plugin creates
**What testing is done?** 
Tested within our EKS 1.17 cluster, confirmed that new volumes have correct names/tags.