### PR TITLE
Fix-helm-private-registry-issues

### DIFF
--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.6.0
+version: 0.6.1
 kubeVersion: ">=1.13.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/aws-ebs-csi-driver/templates/controller.yaml
+++ b/aws-ebs-csi-driver/templates/controller.yaml
@@ -21,6 +21,12 @@ spec:
       annotations: {{ toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
         {{- with .Values.nodeSelector }}

--- a/aws-ebs-csi-driver/templates/node.yaml
+++ b/aws-ebs-csi-driver/templates/node.yaml
@@ -20,6 +20,12 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -20,10 +20,16 @@ spec:
         app: ebs-snapshot-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       serviceAccountName: ebs-snapshot-controller
       containers:
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.1.1
+          image: {{ printf "%s:%s" .Values.snapshotController.image.repository .Values.snapshotController.image.tag }}
           args:
             - --v=5
             - --leader-election=false

--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -29,6 +29,11 @@ sidecars:
     repository: quay.io/k8scsi/csi-node-driver-registrar
     tag: "v1.1.0"
 
+snapshotController:
+  image:
+    repository: quay.io/k8scsi/snapshot-controller
+    tag: "v2.1.1"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This is a bug fix, the image pull secret is not taken into consideration

**What is this PR about? / Why do we need it?**

Currently, when using a private registry, it's not possible to use the imagePullSecret because the variable wasn't used in the controller.yaml, node.yaml and statefulset.yaml

**What testing is done?** 

Deploying using a private registry and secret
