### PR TITLE
Fixed image tag for helm chart values

### DIFF
--- a/aws-ebs-csi-driver/values.yaml
+++ b/aws-ebs-csi-driver/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: amazon/aws-ebs-csi-driver
-  tag: "v0.6.0"
+  tag: "v0.7.0"
   pullPolicy: IfNotPresent
 
 sidecars:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixing image tag - see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/584

**What is this PR about? / Why do we need it?**

**What testing is done?** 
