### PR TITLE
Set CSIMigrationAWSComplete for migration tests

### DIFF
--- a/tester/migration-test-config.yaml
+++ b/tester/migration-test-config.yaml
@@ -13,6 +13,7 @@ cluster:
             CSIBlockVolume: "true"
             CSIMigration: "true"
             CSIMigrationAWS: "true"
+            CSIMigrationAWSComplete: "true"
             ExpandCSIVolumes: "true"
             VolumeSnapshotDataSource: "true"
             CSIInlineVolume: "true"
@@ -23,6 +24,7 @@ cluster:
             CSIBlockVolume: "true"
             CSIMigration: "true"
             CSIMigrationAWS: "true"
+            CSIMigrationAWSComplete: "true"
             ExpandCSIVolumes: "true"
             CSIInlineVolume: "true"
         kubelet:
@@ -32,6 +34,7 @@ cluster:
             CSIBlockVolume: "true"
             CSIMigration: "true"
             CSIMigrationAWS: "true"
+            CSIMigrationAWSComplete: "true"
             ExpandCSIVolumes: "true"
             CSIInlineVolume: "true"
     iamPolicies: |2


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** IDK if checking metrics' plugin_name https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/560#issuecomment-698543689 is a valid way of testing whether migration is working or not, better to set CSIMigrationAWSComplete to turn off the in-tree plugin entirely.

**What testing is done?** N/A, the migration suite is currently failing
