### PR TITLE
WIP: [do not merge] Resize ext4 filesystem on NodeStage

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/util/resizefs/resizefs_linux.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/resizefs/resizefs_linux.go
@@ -20,6 +20,8 @@ package resizefs
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"k8s.io/klog"
 	"k8s.io/utils/mount"
@@ -58,6 +60,122 @@ func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (boo
 		return resizefs.xfsResize(deviceMountPath)
 	}
 	return false, fmt.Errorf("ResizeFS.Resize - resize of format %s is not supported for device %s mounted at %s", format, devicePath, deviceMountPath)
+}
+
+func (resizefs *ResizeFs) ResizeIfNecessary(devicePath string, deviceMountPath string) (bool, error) {
+	resize, err := resizefs.needResize(devicePath, deviceMountPath)
+	if err != nil {
+		return false, err
+	}
+	if resize {
+		klog.V(2).Infof("Volume %s needs resizing", devicePath)
+		return resizefs.Resize(devicePath, deviceMountPath)
+	}
+	return false, nil
+}
+
+func (resizefs *ResizeFs) getDeviceSize(devicePath string) (uint64, error) {
+	output, err := resizefs.mounter.Exec.Command("blockdev", "--getsize64", devicePath).CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+	if err != nil {
+		return 0, fmt.Errorf("failed to read size of device %s: %s: %s", devicePath, err, outStr)
+	}
+	size, err := strconv.ParseUint(outStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse size of device %s %s: %s", devicePath, outStr, err)
+	}
+	return size, nil
+}
+
+func (resizefs *ResizeFs) getExtSize(devicePath string) (uint64, uint64, error) {
+	output, err := resizefs.mounter.Exec.Command("dumpe2fs", "-h", devicePath).CombinedOutput()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read size of filesystem on %s: %s: %s", devicePath, err, string(output))
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var blockSize, blockCount uint64
+
+	for _, line := range lines {
+		tokens := strings.Split(line, ":")
+		if len(tokens) != 2 {
+			continue
+		}
+		key, value := strings.TrimSpace(tokens[0]), strings.TrimSpace(tokens[1])
+		if key == "Block count" {
+			blockCount, err = strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to parse block count %s: %s", value, err)
+			}
+		}
+		if key == "Block size" {
+			blockSize, err = strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to parse block size %s: %s", value, err)
+			}
+		}
+	}
+	if blockSize == 0 {
+		return 0, 0, fmt.Errorf("could not find block size of device %s", devicePath)
+	}
+	if blockCount == 0 {
+		return 0, 0, fmt.Errorf("could not find block count of device %s", devicePath)
+	}
+	return blockSize, blockSize * blockCount, nil
+}
+
+func (resizefs *ResizeFs) getXFSSize(devicePath string) (uint64, uint64, error) {
+	// TODO: implement parsing of xfs_info <path>
+	// meta-data=/dev/loop0             isize=512    agcount=4, agsize=655424 blks
+	//          =                       sectsz=512   attr=2, projid32bit=1
+	//          =                       crc=1        finobt=0 spinodes=0
+	// data     =                       bsize=4096   blocks=2621696, imaxpct=25
+	//          =                       sunit=0      swidth=0 blks
+	// naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
+	// log      =internal               bsize=4096   blocks=2560, version=2
+	//          =                       sectsz=512   sunit=0 blks, lazy-count=1
+	// realtime =none                   extsz=4096   blocks=0, rtextents=0
+	//
+	// Need to parse "bsize=<xxx>" and "blocks=<yyy>" in "data =" segment.
+	// There is no machine-friendly output.
+
+	return 0, 0, fmt.Errorf("unimplemented")
+}
+
+func (resizefs *ResizeFs) needResize(devicePath string, deviceMountPath string) (bool, error) {
+	deviceSize, err := resizefs.getDeviceSize(devicePath)
+	if err != nil {
+		return false, err
+	}
+	var fsSize, blockSize uint64
+	format, err := resizefs.mounter.GetDiskFormat(devicePath)
+	if err != nil {
+		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
+		return false, formatErr
+	}
+
+	// If disk has no format, there is no need to resize the disk because mkfs.*
+	// by default will use whole disk anyways.
+	if format == "" {
+		return false, nil
+	}
+
+	klog.V(3).Infof("ResizeFS.needResize - checking mounted volume %s", devicePath)
+	switch format {
+	case "ext3", "ext4":
+		blockSize, fsSize, err = resizefs.getExtSize(devicePath)
+	case "xfs":
+		blockSize, fsSize, err = resizefs.getXFSSize(deviceMountPath)
+	}
+	if err != nil {
+		return false, err
+	}
+	// Tolerate one block difference, just in case of rounding errors somewhere.
+	klog.V(5).Infof("Volume %s: device size=%d, filesystem size=%d, block size=%d", devicePath, deviceSize, fsSize, blockSize)
+	if deviceSize <= fsSize+blockSize {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (resizefs *ResizeFs) extResize(devicePath string) (bool, error) {

--- a/vendor/k8s.io/kubernetes/pkg/util/resizefs/resizefs_unsupported.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/resizefs/resizefs_unsupported.go
@@ -38,3 +38,7 @@ func NewResizeFs(mounter *mount.SafeFormatAndMount) *ResizeFs {
 func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (bool, error) {
 	return false, fmt.Errorf("Resize is not supported for this build")
 }
+
+func (resizefs *ResizeFs) ResizeIfNecessary(devicePath string, deviceMountPath string) (bool, error) {
+	return false, fmt.Errorf("Resize is not supported for this build")
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind feature

**What is this PR about? / Why do we need it?**
This PR illustrates changes needed on a CSI driver side to implement proposal in https://github.com/container-storage-interface/spec/pull/452#issuecomment-708536715 (see the comment, not the PR!)

NodeStageVolume now checks, if resize of a filesystem is needed, and resizes it automatically if so. This makes NodeExpandVolume more or less redundant (for AWS EBS). 

I've implemented only ext3/ext4 resize, xfs is to be done (`xfs_info` parser must be implemented). Alternatively, a CSI driver could *always* call `resize2fs` / `xfs_growfs` after mount, they should be idempotent and NOOP if a filesystem is already on its maximum size.

**!!! Not to be merged !!!** For exploration purposes only.