### PR TITLE
Fix the name of the snapshot controller leader election RoleBinding

### DIFF
--- a/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
+++ b/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
@@ -3,7 +3,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: snapshot-controller-leaderelection
+  name: ebs-snapshot-controller-leaderelection
   namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
@@ -13,7 +13,7 @@ subjects:
     namespace: kube-system
 roleRef:
   kind: Role
-  name: snapshot-controller-leaderelection
+  name: ebs-snapshot-controller-leaderelection
   apiGroup: rbac.authorization.k8s.io
 
 {{- end }}

--- a/deploy/kubernetes/overlays/alpha/rbac_add_snapshot_controller_leaderelection_rolebinding.yaml
+++ b/deploy/kubernetes/overlays/alpha/rbac_add_snapshot_controller_leaderelection_rolebinding.yaml
@@ -3,7 +3,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: snapshot-controller-leaderelection
+  name: ebs-snapshot-controller-leaderelection
   namespace: kube-system
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
@@ -13,5 +13,5 @@ subjects:
     namespace: kube-system
 roleRef:
   kind: Role
-  name: snapshot-controller-leaderelection
+  name: ebs-snapshot-controller-leaderelection
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Before, the RoleBinding was named snapshot-controller-leaderelection. It
also incorrectly referenced the snapshot-controller-leaderelection Role
instead of the ebs-snapshot-controller-leaderelection Role defined by
the Helm chart

By default, the objects for the snapshot controller from
kubernetes-csi/external-snapshotter [1] are installed into the default
namespace. The manifests, however, recommend installing the objects in
the kube-system namespace instead. One of the objects is a RoleBinding
named snapshot-controller-leaderelection. When installing the snapshot
controller from the external-snapshotter repo into the kube-system
namespace, the AWS EBS CSI driver Helm chart fails to install with the
following error because the RoleBindings conflict:

`Error: rendered manifests contain a resource that already exists. Unable to continue with install: RoleBinding "snapshot-controller-leaderelection" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "aws-ebs-csi-driver"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"`

If the snapshot controller from the external-snapshotter repo is
installed into the default namespace, the AWS EBS CSI driver Helm chart
installs (and seems to work) without issue even though the
snapshot-controller-leaderelection Role in the kube-system namespace
does not exist

[1] https://github.com/kubernetes-csi/external-snapshotter/tree/v3.0.1/deploy/kubernetes/snapshot-controller

**What testing is done?** 

Installed the modified Helm chart and validated that the snapshot controller is able to snapshot volumes, etc