### PR TITLE
[helm] Add support for managing StorageClass

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.storageClass.create }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs-sc
+{{- if .Values.storageClass.default }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+{{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -92,3 +92,9 @@ serviceAccount:
     annotations: {}
   snapshot:
     annotations: {}
+
+storageClass:
+  # If true, StorageClass will be created with AWS EBS CSI driver as provisioner.
+  create: false
+  # If true, created StorageClass will be annotated as default one.
+  default: false


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This PR adds new feature.

**What is this PR about? / Why do we need it?**
This PR adds support for creating StorageClass to Helm chart, so
so after installing it, there is no need to manually create a
StorageClass object. Usually deploying CSI driver and storage class is
administrator role and consuming it is up to the user, so I think
shifting this responsibility to Helm chart make sense.

Right now this is implemented without support for any parameters. I
believe they can be added on demand.

Closes #605

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

**What testing is done?** 
`helm template` + we use the same manifests in https://github.com/kinvolk/lokomotive.