### PR TITLE
Update README.md

### DIFF
--- a/examples/kubernetes/snapshot/README.md
+++ b/examples/kubernetes/snapshot/README.md
@@ -10,7 +10,8 @@ This driver implements basic volume snapshotting functionality using the [extern
 
 1. The `VolumeSnapshotDataSource` must be set in `--feature-gates=` in the `kube-apiserver`.
 
-1. The [aws-ebs-csi-driver driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) is installed.
+1. The [aws-ebs-csi-driver driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) with alpha features is installed.
+1. If your cluster does not come pre-installed with Snapshot Beta CRDs, install the [Snapshot Beta CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd)
 
 ### Usage
 

--- a/examples/kubernetes/snapshot/README.md
+++ b/examples/kubernetes/snapshot/README.md
@@ -8,10 +8,12 @@ This driver implements basic volume snapshotting functionality using the [extern
 
 1. Kubernetes 1.13+ (CSI 1.0).
 
-1. The `VolumeSnapshotDataSource` must be set in `--feature-gates=` in the `kube-apiserver`.
+1. The `VolumeSnapshotDataSource` must be set in `--feature-gates=` in the `kube-apiserver`. This feature is enabled by default from Kubernetes v1.17+. 
 
-1. The [aws-ebs-csi-driver driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) with alpha features is installed.
-1. If your cluster does not come pre-installed with Snapshot Beta CRDs, install the [Snapshot Beta CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd)
+1. Install Snapshot Beta CRDs, Common Snapshot Controller, & CSI Driver (with alpha features) per CSI Snapshotter [Doc](https://github.com/kubernetes-csi/external-snapshotter#usage)
+
+
+
 
 ### Usage
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
No
**What is this PR about? / Why do we need it?**
Volume Snapshots README.md is missing steps to install Volume Snapshot beta CRDs (volumesnapshotclass, volumesnapshotcontents, volumesnapshots). Following the Volume Snapshot example alone does not work. Need to update the document. See below for more info.
**What testing is done?** 

Following the guide without having CRDs EBS CSI Driver fails with "VolumeSnapshotClass not in "snapshot.storage.k8s.io/v1beta1""(see [issue](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/537#issuecomment-692076110)). Moreover the EBS CSI Driver with Alpha features is the correct driver that need to be installed. Installing the stable version of the ebs csi driver will not include external snapshotter sidecar, snapshot controller  or service account/RBAC. Pull request is to mention this in the Volume Snapshot example README. 

