### PR TITLE
[Helm] Add image pull secret to controller deployment and Node statefuleset 

### DIFF
--- a/aws-ebs-csi-driver/Chart.yaml
+++ b/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.6.1
+version: 0.7.0
 kubeVersion: ">=1.13.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/aws-ebs-csi-driver/templates/controller.yaml
+++ b/aws-ebs-csi-driver/templates/controller.yaml
@@ -36,6 +36,9 @@ spec:
       {{- with .Values.tolerations }}
 {{ toYaml . | indent 8 }}
       {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       containers:
         - name: ebs-plugin
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/aws-ebs-csi-driver/templates/node.yaml
+++ b/aws-ebs-csi-driver/templates/node.yaml
@@ -38,6 +38,9 @@ spec:
         {{- with .Values.node.tolerations }}
 {{ toYaml . | indent 8 }}
         {{- end }}
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
+    {{- end }}
       containers:
         - name: ebs-plugin
           securityContext:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature/ bug fix?

**What is this PR about? / Why do we need it?**
Support passing in image pull secrets. This is now particularly important because DockerHub is now rate limiting image pull requests, so it's important to be able to pass an image pull secret to bypass/increase the limit. 

**What testing is done?** 
I've generated the templates and deployed it in our EKS clusters .