### PR TITLE
Update kustomization.yaml for ECR-hosted images

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+- ../../../base
 images:
 - name: amazon/aws-ebs-csi-driver
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver


### PR DESCRIPTION
Corrected base path to reflect that this file is in the ecr sub-directory, so needs an extra "../"

**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**
Base path in kustomization.yaml for ECR is incorrect because it is in a sub-directory. Need to add an extra "../"

**What testing is done?** 
Tested successfully by customer.