### PR TITLE
Provide "Iops" field when resizing io1 and io2 volumes

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -912,6 +912,11 @@ func (c *cloud) ResizeDisk(ctx context.Context, volumeID string, newSizeBytes in
 		Size:     aws.Int64(newSizeGiB),
 	}
 
+	switch aws.StringValue(volume.VolumeType) {
+	case VolumeTypeIO1, VolumeTypeIO2:
+		req.Iops = volume.Iops
+	}
+
 	klog.Infof("expanding volume %q to size %d", volumeID, newSizeGiB)
 	response, err := c.ec2.ModifyVolumeWithContext(ctx, req)
 	if err != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/622

**What is this PR about? / Why do we need it?**

Adds `Iops` field set to the current volume's `Iops` field to avoid `InvalidParameterCombination: The parameter iops must be specified for io1 volumes.` error from AWS API.

**What testing is done?**

Manual testing in a Kubernetes cluster.
