### PR TITLE
Update ecr overlay image tag

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+- ../../../base
 images:
 - name: amazon/aws-ebs-csi-driver
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-  newTag: v0.7.0
+  newTag: v0.7.1
 - name: quay.io/k8scsi/csi-provisioner
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
   newTag: v1.5.0


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Updates the ecr overlay to use the latest 0.7.1 version. Also fixes the base path (see #625).

