### PR TITLE
Allow the driver to perform AWS STS AssumeRole when talking to AWS APIs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,6 +35,7 @@ func main() {
 		driver.WithMode(options.DriverMode),
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),
 		driver.WithKubernetesClusterID(options.ControllerOptions.KubernetesClusterID),
+		driver.WithAssumeRoleArn(options.ControllerOptions.AssumeRoleArn),
 	)
 	if err != nil {
 		klog.Fatalln(err)

--- a/cmd/options/controller_options.go
+++ b/cmd/options/controller_options.go
@@ -33,10 +33,13 @@ type ControllerOptions struct {
 	ExtraVolumeTags map[string]string
 	// ID of the kubernetes cluster.
 	KubernetesClusterID string
+	// AWS Assume Role ARN
+	AssumeRoleArn string
 }
 
 func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.Var(cliflag.NewMapStringString(&s.ExtraTags), "extra-tags", "Extra tags to attach to each dynamically provisioned resource. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.Var(cliflag.NewMapStringString(&s.ExtraVolumeTags), "extra-volume-tags", "DEPRECATED: Please use --extra-tags instead. Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.StringVar(&s.KubernetesClusterID, "k8s-tag-cluster-id", "", "ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).")
+	fs.StringVar(&s.AssumeRoleArn, "assume-role-arn", "", "IAM ARN for the controller to assume-role into (optional). If unset, uses whatever credentials available to the aws-sdk.")
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ curl https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master
 kubectl apply -f secret.yaml
 ```
 * Using IAM [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) - grant all the worker nodes with [proper permission](./example-iam-policy.json) by attaching policy to the instance profile of the worker.
+* Using [STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) - Allows the driver to switch into a different AWS IAM, using a potentially different AWS account and/or user.
 
 #### Deploy CRD (optional)
 If your cluster is v1.14+, you can skip this step. Install the `CSINodeInfo` CRD on the cluster:

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1273,3 +1273,35 @@ func (m *eqCreateSnapshotInputMatcher) Matches(x interface{}) bool {
 func (m *eqCreateSnapshotInputMatcher) String() string {
 	return m.expected.String()
 }
+
+func TestNewEC2Cloud(t *testing.T) {
+	type args struct {
+		region        string
+		assumeRoleArn string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Cloud
+		wantErr error
+	}{
+		{
+			name:    "invalid ARN should error",
+			args:    args{region: "fake", assumeRoleArn: "Bogus ARN"},
+			want:    nil,
+			wantErr: fmt.Errorf("Provided ARN: 'Bogus ARN' isn't valid. Make sure it starts with 'arn:' and has the correct number of colons"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newEC2Cloud(tt.args.region, tt.args.assumeRoleArn)
+			if !reflect.DeepEqual(err, tt.wantErr) {
+				t.Errorf("newEC2Cloud() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newEC2Cloud() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -80,7 +80,7 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 		region = metadata.GetRegion()
 	}
 
-	cloud, err := NewCloudFunc(region)
+	cloud, err := NewCloudFunc(region, driverOptions.assumeRoleArn)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -49,8 +49,8 @@ func TestNewControllerService(t *testing.T) {
 		testErr    = errors.New("test error")
 		testRegion = "test-region"
 
-		getNewCloudFunc = func(expectedRegion string) func(region string) (cloud.Cloud, error) {
-			return func(region string) (cloud.Cloud, error) {
+		getNewCloudFunc = func(expectedRegion string, assumeRoleArn string) func(region string, assumeRoleArn string) (cloud.Cloud, error) {
+			return func(region string, assumeRoleArn string) (cloud.Cloud, error) {
 				if region != expectedRegion {
 					t.Fatalf("expected region %q but got %q", expectedRegion, region)
 				}
@@ -62,30 +62,30 @@ func TestNewControllerService(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		region                string
-		newCloudFunc          func(string) (cloud.Cloud, error)
+		newCloudFunc          func(string, string) (cloud.Cloud, error)
 		newMetadataFuncErrors bool
 		expectPanic           bool
 	}{
 		{
 			name:         "AWS_REGION variable set, newCloud does not error",
 			region:       "foo",
-			newCloudFunc: getNewCloudFunc("foo"),
+			newCloudFunc: getNewCloudFunc("foo", ""),
 		},
 		{
 			name:   "AWS_REGION variable set, newCloud errors",
 			region: "foo",
-			newCloudFunc: func(region string) (cloud.Cloud, error) {
+			newCloudFunc: func(region string, assumeRoleArn string) (cloud.Cloud, error) {
 				return nil, testErr
 			},
 			expectPanic: true,
 		},
 		{
 			name:         "AWS_REGION variable not set, newMetadata does not error",
-			newCloudFunc: getNewCloudFunc(testRegion),
+			newCloudFunc: getNewCloudFunc(testRegion, ""),
 		},
 		{
 			name:                  "AWS_REGION variable not set, newMetadata errors",
-			newCloudFunc:          getNewCloudFunc(testRegion),
+			newCloudFunc:          getNewCloudFunc(testRegion, ""),
 			newMetadataFuncErrors: true,
 			expectPanic:           true,
 		},

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -62,6 +62,7 @@ type DriverOptions struct {
 	mode                Mode
 	volumeAttachLimit   int64
 	kubernetesClusterID string
+	assumeRoleArn       string
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -180,5 +181,11 @@ func WithVolumeAttachLimit(volumeAttachLimit int64) func(*DriverOptions) {
 func WithKubernetesClusterID(clusterID string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.kubernetesClusterID = clusterID
+	}
+}
+
+func WithAssumeRoleArn(assumeRoleArn string) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.assumeRoleArn = assumeRoleArn
 	}
 }

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -366,7 +366,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
-		cloud, err := awscloud.NewCloud(region)
+		cloud, err := awscloud.NewCloud(region, "")
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -84,7 +84,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region)
+		cloud, err = awscloud.NewCloud(region, "")
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}


### PR DESCRIPTION
RFC: I would like to be able to assume into a different role than what the existing instance profile has, and also not use static IAM creds. This new feature allows the driver to assume role based on a `AWS_STS_ROLE` variable, and maintain fresh creds.

I wasn't sure how else to do this without modifying the code. The AWS golang sdk doesn't seem to have the built-in capability without a code change.

Testing done: Compiled and run on environment. Permission errors before, no permission errors after.

If this change is desired (and I'm not doing it wrong), I can add docs to the readme as an alternative way to get creds, update the helm charts for a new variable to be passed in, etc.