### PR TITLE
Add cloudbuild.yaml for image pushing to gcr

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,17 @@
+timeout: 1200s
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG
+      - --target=debian-base
+      - .
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux
+      - --target=amazon
+      - .
+images:
+  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG"
+  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** new.

**What is this PR about? / Why do we need it?** To eventually publish release images to the community gcr https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io, need a cloudbuild.yaml to push staging images to gcr.io/k8s-staging-provider-aws https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing 

**What testing is done?** It looks like the only way to test this end to end is after making a PR in test-infra to add a ProwJob to run this build https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing#prow-config-template
