### PR TITLE
Add latest tags to cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,14 +4,18 @@ steps:
     args:
       - build
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG
+      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest
       - --target=debian-base
       - .
   - name: gcr.io/cloud-builders/docker
     args:
       - build
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux
+      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux
       - --target=amazon
       - .
 images:
   - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG"
+  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest"
   - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux"
+  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** the postsubmit should also push a latest tag to the staging gcr.

This is mostly for debugging purposes like to test that this cloudbuild even succeeds once I add a postsubmit to execute it. Also could be useful for dev purposes to have an image in staging gcr.

**What testing is done?** None yet, need that prow postsubmit to actually test this 
