### PR TITLE
Fix target name in cloudbuild.yaml from amazon to amazonlinux

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
       - build
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux
-      - --target=amazon
+      - --target=amazonlinux
       - .
 images:
   - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix.

inaugural gcr jobs failed https://prow.k8s.io/?job=aws-ebs-csi-driver-push-images
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1334990729704902656

**What is this PR about? / Why do we need it?**
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/workflows/container-image.yaml#L23
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/Dockerfile#L20
amazonlinux is the right target name.
**What testing is done?** 