### PR TITLE
Suffix amazonlinux image with -amazonlinux and push debian image to GitHub

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,53 +1,79 @@
 name: Container Images
 
-on: push
+on:
+  push:
+
 jobs:
-  build:
+  buildx:
     # this is to prevent the job to run at forked projects
     if: github.repository == 'kubernetes-sigs/aws-ebs-csi-driver'
+    env:
+      IMAGE: aws-ebs-csi-driver
+      DEB_BUILD_TAG: aws-ebs-csi-driver:debian
+      AL2_BUILD_TAG: aws-ebs-csi-driver:amazonlinux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
-      with:
-        buildx-version: latest
-        qemu-version: latest
-    - name: Build container image
-      run: |
-        docker buildx build \
-          -t aws-ebs-csi-driver \
-          --platform=linux/arm64,linux/amd64 \
-          --output="type=image,push=false" . \
-          --target=amazonlinux
-    - name: Push to Github registry
-      run: |
-        USER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
-        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-        IMAGE=aws-ebs-csi-driver
-        if [ "$BRANCH" = "master" ]; then
-          TAG="latest"
-        else
-          TAG=$BRANCH
-        fi
-        docker login docker.pkg.github.com -u $USER -p ${{ secrets.REGISTRY_TOKEN }}
-        docker build -t aws-ebs-csi-driver . --target amazonlinux
-        docker tag aws-ebs-csi-driver docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
-        docker push docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG
-    - name: Push to Dockerhub registry
-      run: |
-        BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
-        REPO=amazon/aws-ebs-csi-driver
-        if [ "$BRANCH" = "master" ]; then
-          TAG="latest"
-        else
-          TAG=$BRANCH
-        fi
-        docker login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }}
-        docker buildx build \
-          -t $REPO:$TAG \
-          --platform=linux/arm64,linux/amd64 \
-          --output="type=image,push=true" . \
-          --target=amazonlinux
-
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build debian target
+        run: |
+          docker buildx build \
+            -t $DEB_BUILD_TAG \
+            --platform=linux/arm64,linux/amd64 \
+            --output="type=image,push=false" .
+            --target=debian-base
+      - name: Build amazonlinux target
+        run: |
+          docker buildx build \
+            -t $AL2_BUILD_TAG \
+            --platform=linux/arm64,linux/amd64 \
+            --output="type=image,push=false" . \
+            --target=amazonlinux
+      - name: Set environment variables
+        run: |
+          BRANCH=$(echo $GITHUB_REF | cut -d'/' -f3)
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          if [ "$BRANCH" = "master" ]; then
+            TAG="latest"
+          else
+            TAG=$BRANCH
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Push debian target to GitHub
+        run: |
+          DEB_PUSH_TAG="docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG"
+          docker buildx build \
+            -t $DEB_PUSH_TAG \
+            --platform=linux/arm64,linux/amd64 \
+            --output="type=image,push=true" . \
+            --target=debian-base
+      - name: Push amazonlinux target to GitHub
+        run: |
+          AL2_PUSH_TAG="docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG-amazonlinux"
+          docker buildx build \
+            -t $AL2_PUSH_TAG \
+            --platform=linux/arm64,linux/amd64 \
+            --output="type=image,push=true" . \
+            --target=amazonlinux
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push amazonlinux target to Docker Hub
+        run: |
+          AL2_PUSH_TAG="amazon/$IMAGE:$TAG-amazonlinux"
+          docker buildx build \
+            -t $AL2_PUSH_TAG \
+            --platform=linux/arm64,linux/amd64 \
+            --output="type=image,push=true" . \
+            --target=amazonlinux


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**fix

**What is this PR about? / Why do we need it?**To match cloudbuild.yaml https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/cloudbuild.yaml and in preparation for the next release v0.8.0, amazonlinux based images will be suffixed with -amazonlinux, like v0.8.0-amazonlinux. And debian based images will become the "default" unsuffixed v0.8.0.

At the same time, I noticed crazy-max/ghaction-docker-buildx@v3 was deprecated https://github.com/crazy-max/ghaction-docker-buildx so I rewrote the action to use docker's official github actions.

**What testing is done?** Not sure if testing is possible? given the extensive rewrite I want to test the new scrijpt but it doesn't seem possible without actually triggering the action. So I will check if the latest tag was successfully pushed after this PR and if not will need a follow-up...