### PR TITLE
Set up QEMU to build for arm64

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -18,12 +18,14 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Build debian target
         run: |
           docker buildx build \
             -t $DEB_BUILD_TAG \
             --platform=linux/arm64,linux/amd64 \
-            --output="type=image,push=false" .
+            --output="type=image,push=false" . \
             --target=debian-base
       - name: Build amazonlinux target
         run: |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**fix

**What is this PR about? / Why do we need it?** arm image build failed because I forgot to add support for building multi platform via qemu https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/1519273877

**What testing is done?**  the docker buildx build commands work locally after I install qemu.
