### PR TITLE
Remove helm chart step from release github workflow and github registry step from container images workflow

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -44,28 +44,6 @@ jobs:
             TAG=$BRANCH
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-      - name: Push debian target to GitHub
-        run: |
-          DEB_PUSH_TAG="docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG"
-          docker buildx build \
-            -t $DEB_PUSH_TAG \
-            --platform=linux/arm64,linux/amd64 \
-            --output="type=image,push=true" . \
-            --target=debian-base
-      - name: Push amazonlinux target to GitHub
-        run: |
-          AL2_PUSH_TAG="docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG-amazonlinux"
-          docker buildx build \
-            -t $AL2_PUSH_TAG \
-            --platform=linux/arm64,linux/amd64 \
-            --output="type=image,push=true" . \
-            --target=amazonlinux
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,17 +3,12 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 jobs:
   build:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      - name: Create Helm chart
-        run: |
-          tar cvzf helm-chart.tgz aws-ebs-csi-driver
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** Since now there is a separate workflow for releasing helm charts https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/workflows/helm-chart-release.yaml, the steps in github release workflow are redundant and don't work.

~Container images workflow doesn't work either since it logs into ghcr.io but then tries to push to   docker.pkg.github.com like before: https://docs.github.com/en/free-pro-team@latest/packages/guides/migrating-to-github-container-registry-for-docker-images~

Since nobody uses the github registry (github reports 0 downloads) and I am not sure if ghcr.io is okay to use, I'll fix it later and backfill the v0.8.0 image manually if necessary
**What testing is done?** 
