### PR TITLE
Fix overlays not being updated for gcr migration

### DIFF
--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+  - ../../base
 images:
-- name: amazon/aws-ebs-csi-driver
-  newTag: latest
-  newName: chengpan/aws-ebs-csi-driver
+  - name: gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
+    newTag: latest

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,16 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+  - ../../base
 images:
-- name: amazon/aws-ebs-csi-driver
-  newTag: v0.7.1
-- name: quay.io/k8scsi/csi-provisioner
-  newTag: v1.5.0
-- name: quay.io/k8scsi/csi-attacher
-  newTag: v1.2.0
-- name: quay.io/k8scsi/livenessprobe
-  newTag: v1.1.0
-- name: quay.io/k8scsi/csi-node-driver-registrar
-  newTag: v1.1.0
-
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newTag: v0.8.0
+  - name: quay.io/k8scsi/csi-provisioner
+    newTag: v1.5.0
+  - name: quay.io/k8scsi/csi-attacher
+    newTag: v1.2.0
+  - name: quay.io/k8scsi/livenessprobe
+    newTag: v1.1.0
+  - name: quay.io/k8scsi/csi-node-driver-registrar
+    newTag: v1.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1
 #### Deploy driver
 If you want to deploy the stable driver without alpha features:
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-0.8"
 ```
 
 If you want to deploy the driver with alpha features:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/bug

**What is this PR about? / Why do we need it?**
Fixing some oversights/neglect/mistakes from gcr migration. See: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/646

**What testing is done?** 
```
kubectl apply -k ./deploy/kubernetes/overlays/stable
k get deployment -n kube-system ebs-csi-controller
NAME                 READY   UP-TO-DATE   AVAILABLE   AGE
ebs-csi-controller   2/2     2            2           19d
k get deployment -n kube-system ebs-csi-controller -o jsonpath="{.spec.template.spec.containers[0].image}"
k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0^J  
kubectl apply -k ./deploy/kubernetes/overlays/dev
k get deployment -n kube-system ebs-csi-controller -o jsonpath="{.spec.template.spec.containers[0].image}"
k8s.gcr.io/provider-aws/aws-ebs-csi-driver:latest
```