### PR TITLE
release-0.8: Remove helm chart step from release github workflow and github registry step from container images workflow

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -44,28 +44,6 @@ jobs:
             TAG=$BRANCH
           fi
           echo "TAG=$TAG" >> $GITHUB_ENV
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-      - name: Push debian target to GitHub
-        run: |
-          DEB_PUSH_TAG="docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG"
-          docker buildx build \
-            -t $DEB_PUSH_TAG \
-            --platform=linux/arm64,linux/amd64 \
-            --output="type=image,push=true" . \
-            --target=debian-base
-      - name: Push amazonlinux target to GitHub
-        run: |
-          AL2_PUSH_TAG="docker.pkg.github.com/$GITHUB_REPOSITORY/$IMAGE:$TAG-amazonlinux"
-          docker buildx build \
-            -t $AL2_PUSH_TAG \
-            --platform=linux/arm64,linux/amd64 \
-            --output="type=image,push=true" . \
-            --target=amazonlinux
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,17 +3,12 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 jobs:
   build:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v1
-      - name: Create Helm chart
-        run: |
-          tar cvzf helm-chart.tgz aws-ebs-csi-driver
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** cherry pick of https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/644 on 0.8 branch, else future cherry picks to 0.8 branch will have broken github release workflows

**What testing is done?** 
