### PR TITLE
release-0.8: Fix overlays not being updated for gcr migration 

### DIFF
--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+  - ../../base
 images:
-- name: amazon/aws-ebs-csi-driver
-  newTag: latest
-  newName: chengpan/aws-ebs-csi-driver
+  - name: gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
+    newTag: latest

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,16 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../base
+  - ../../base
 images:
-- name: amazon/aws-ebs-csi-driver
-  newTag: v0.7.1
-- name: quay.io/k8scsi/csi-provisioner
-  newTag: v1.5.0
-- name: quay.io/k8scsi/csi-attacher
-  newTag: v1.2.0
-- name: quay.io/k8scsi/livenessprobe
-  newTag: v1.1.0
-- name: quay.io/k8scsi/csi-node-driver-registrar
-  newTag: v1.1.0
-
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newTag: v0.8.0
+  - name: quay.io/k8scsi/csi-provisioner
+    newTag: v1.5.0
+  - name: quay.io/k8scsi/csi-attacher
+    newTag: v1.2.0
+  - name: quay.io/k8scsi/livenessprobe
+    newTag: v1.1.0
+  - name: quay.io/k8scsi/csi-node-driver-registrar
+    newTag: v1.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1
 #### Deploy driver
 If you want to deploy the stable driver without alpha features:
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-0.8"
 ```
 
 If you want to deploy the driver with alpha features:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/bug
**What is this PR about? / Why do we need it?** cherry-pick of https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/649 on release-0.8. Else kubectl kustomize stable overlay commands pointing to this branch ( which they should, to avoid churn/breakage from master branch, hence "stable") will not work.

**What testing is done?** 

/hold
