### PR TITLE
Use buildx in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,18 +2,26 @@ timeout: 1200s
 steps:
   - name: gcr.io/cloud-builders/docker
     args:
+      - buildx
       - build
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest
-      - --target=debian-base
+      - --platform=linux/arm64,linux/amd64
+      - --output="type=image,push=false"
       - .
+      - --target=debian-base
+      - HOME=/root
   - name: gcr.io/cloud-builders/docker
     args:
+      - buildx
       - build
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux
       - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux
-      - --target=amazonlinux
+      - --platform=linux/arm64,linux/amd64
+      - --output="type=image,push=false"
       - .
+      - --target=amazonlinux
+      - HOME=/root
 images:
   - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG"
   - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?**
cloudbuild is not magic, if arm64 images are desired then buildx must b ecalled

**What testing is done?** 
command works locally, don't have access to cloudbuild to test it in cloudbuild
