### PR TITLE
Fix stray argument in cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,7 +22,6 @@ steps:
       - --output="type=image,push=true"
       - .
       - --target=debian-base
-      - HOME=/root
   - name: gcr.io/cloud-builders/docker
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** this explains the 

```
ERROR: (gcloud.builds.submit) build 91a9a509-a135-44aa-a439-af84587bbd96 completed with status "FAILURE"
Step #1: "docker buildx build" requires exactly 1 argument. 
```
error.

I still intend to move to a model where the cloudbuild calls a script similar to https://github.com/kubernetes-csi/csi-release-tools/blob/master/prow.sh#L1243 https://github.com/kubernetes-csi/csi-release-tools/blob/master/build.make#L132 (ty to person who pointed me to these : ) ) , it will be easier to maintain than wrestling with cloudbuild syntax, and anyway the github  workflow could call the same script so we don't have to maintain two copies of the same code. This is just a nobrainer quickfix.

**What testing is done?** 
