### PR TITLE
Call hack/prow.sh from cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,37 +1,9 @@
 timeout: 1200s
 steps:
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - run
-      - --rm
-      - --privileged
-      - multiarch/qemu-user-static
-      - --reset
-      - -p
-      - "yes"
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
+    entrypoint: ./hack/prow.sh
     env:
-      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - GIT_TAG=${_GIT_TAG}
+      - PULL_BASE_REF=${_PULL_BASE_REF}
+      - REGISTRY_NAME=gcr.io/${_STAGING_PROJECT}
       - HOME=/root
-    args:
-      - buildx
-      - build
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest
-      - --platform=linux/arm64,linux/amd64
-      - --output="type=image,push=true"
-      - .
-      - --target=debian-base
-  - name: gcr.io/cloud-builders/docker
-    env:
-      - DOCKER_CLI_EXPERIMENTAL=enabled
-      - HOME=/root
-    args:
-      - buildx
-      - build
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux
-      - --platform=linux/arm64,linux/amd64
-      - --output="type=image,push=true"
-      - .
-      - --target=amazonlinux

--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+loudecho() {
+  echo "###"
+  echo "## ${1}"
+  echo "#"
+}
+
+loudecho "Register gcloud as a Docker credential helper."
+# Required for "docker buildx build --push".
+# See https://github.com/kubernetes-csi/csi-release-tools/blob/master/prow.sh#L1243
+gcloud auth configure-docker
+
+loudecho "Set up Docker Buildx"
+# See https://github.com/docker/setup-buildx-action
+# and https://github.com/kubernetes-csi/csi-release-tools/blob/master/build.make#L132
+DOCKER_CLI_EXPERIMENTAL=enabled
+export DOCKER_CLI_EXPERIMENTAL
+trap "docker buildx rm multiarchimage-buildertest" EXIT
+docker buildx create --use --name multiarchimage-buildertest
+
+loudecho "Set up QEMU"
+# See https://github.com/docker/setup-qemu-action
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+loudecho "Build and push debian target"
+docker buildx build \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:"${GIT_TAG}" \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:latest \
+  --platform=linux/arm64,linux/amd64 \
+  --progress=plain \
+  --push=true \
+  --target=debian-base \
+  .
+
+loudecho "Build and push amazonlinux target"
+docker buildx build \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:"${GIT_TAG}"-amazonlinux \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:latest-amazonlinux \
+  --platform=linux/arm64,linux/amd64 \
+  --progress=plain \
+  --push=true \
+  --target=amazonlinux \
+  .


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix gcr builds

**What is this PR about? / Why do we need it?** gcr builds are broken in attempt to fix multiarch build. 

I stopped short of migrating to csi-release-tools entirely, that would take more work. However I copied parts from it and linked to those parts.

**What testing is done?** Same as with previous PRs: Unfortunately I cannot test end-to-end without actually merging, the container release prow job runs on master and release* branches. I did briefly test the script on release-test branch with manual pushes before prow caught on and marked it protected....

Script works locally.
`env REGISTRY_NAME=public.ecr.aws/b5w6x5z2 GIT_TAG=asdf ./hack/prow.sh`

DEBIAN x86-64
```
$ sudo ctr image pull public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf
$ sudo ctr run --net-host --rm -t public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf asdf sh
# apt update && apt install file -y && file /bin/aws-ebs-csi-driver
/bin/aws-ebs-csi-driver: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=kAW_W3MP2F-SyISEkr-W/qEsEhwoBGlBqbFS0hG3t/REDBNNkQ3nfX4Tmp1I6c/V5-AYyKy-A6YG_3PdjzI, stripped
```

DEBIAN aarch64
```
$ sudo ctr image pull --platform linux/arm64 public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf
$ sudo ctr run --platform linux/arm64 --net-host --rm -t public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf asdf sh
# apt update && apt install file -y && file /bin/aws-ebs-csi-driver
/bin/aws-ebs-csi-driver: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=QvjkG7Q5dGFfqnCxoDs7/C0h4mNzh8pZyVakWrh8W/EJ8uqhT-5pYDQUP_FBMB/aFe_kvszu9EcCFF1EOUX, stripped
```

AL2 x86-64
```
$ sudo ctr image pull public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf-amazonlinux
$ sudo ctr run --net-host --rm -t public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf-amazonlinux asdf sh
sh-4.2# yum install file -y && file /bin/aws-ebs-csi-driver
/bin/aws-ebs-csi-driver: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```

AL2 aarch64
```
$ sudo ctr image pull --platform linux/arm64 public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf-amazonlinux
$ sudo ctr run --platform linux/arm64 --net-host --rm -t public.ecr.aws/b5w6x5z2/aws-ebs-csi-driver:asdf-amazonlinux asdf sh
sh-4.2# yum install file -y && file /bin/aws-ebs-csi-driver
/bin/aws-ebs-csi-driver: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
```