### PR TITLE
cloudbuild: Set _STAGING_PROJECT

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,3 +7,5 @@ steps:
       - PULL_BASE_REF=${_PULL_BASE_REF}
       - REGISTRY_NAME=gcr.io/${_STAGING_PROJECT}
       - HOME=/root
+substitutions:
+  _STAGING_PROJECT: "k8s-staging-provider-aws"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug fix

**What is this PR about? / Why do we need it?** This variable needs to be set, same as here: https://github.com/kubernetes-csi/csi-release-tools/blob/master/cloudbuild.yaml#L48.
Else the build errors like:

invalid tag "gcr.io//aws-ebs-csi-driver:v20201219-aws-ebs-csi-driver-0.7.1-8-g1bb8ba8": invalid reference format 
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1340088065888096256

**What testing is done?** 
