### PR TITLE
release-0.8: Use buildx in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,21 +1,11 @@
 timeout: 1200s
 steps:
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest
-      - --target=debian-base
-      - .
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux
-      - --tag=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux
-      - --target=amazonlinux
-      - .
-images:
-  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG"
-  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest"
-  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:$_GIT_TAG-amazonlinux"
-  - "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:latest-amazonlinux"
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
+    entrypoint: ./hack/prow.sh
+    env:
+      - GIT_TAG=${_GIT_TAG}
+      - PULL_BASE_REF=${_PULL_BASE_REF}
+      - REGISTRY_NAME=gcr.io/${_STAGING_PROJECT}
+      - HOME=/root
+substitutions:
+  _STAGING_PROJECT: "k8s-staging-provider-aws"

--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+loudecho() {
+  echo "###"
+  echo "## ${1}"
+  echo "#"
+}
+
+loudecho "Register gcloud as a Docker credential helper."
+# Required for "docker buildx build --push".
+# See https://github.com/kubernetes-csi/csi-release-tools/blob/master/prow.sh#L1243
+gcloud auth configure-docker
+
+loudecho "Set up Docker Buildx"
+# See https://github.com/docker/setup-buildx-action
+# and https://github.com/kubernetes-csi/csi-release-tools/blob/master/build.make#L132
+DOCKER_CLI_EXPERIMENTAL=enabled
+export DOCKER_CLI_EXPERIMENTAL
+trap "docker buildx rm multiarchimage-buildertest" EXIT
+docker buildx create --use --name multiarchimage-buildertest
+
+loudecho "Set up QEMU"
+# See https://github.com/docker/setup-qemu-action
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+loudecho "Build and push debian target"
+docker buildx build \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:"${GIT_TAG}" \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:latest \
+  --platform=linux/arm64,linux/amd64 \
+  --progress=plain \
+  --push=true \
+  --target=debian-base \
+  .
+
+loudecho "Build and push amazonlinux target"
+docker buildx build \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:"${GIT_TAG}"-amazonlinux \
+  --tag="${REGISTRY_NAME}"/aws-ebs-csi-driver:latest-amazonlinux \
+  --platform=linux/arm64,linux/amd64 \
+  --progress=plain \
+  --push=true \
+  --target=amazonlinux \
+  .


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?**
This is 5 commits squashed together. Squashed because they aren't useful on their own, they were each guess-and-test attempts at fixing prow cloudbuild job to produce multiarch images.

```
git cherry-pick 99c4c0a
git cherry-pick dff4ef1
git cherry-pick 5beb246
git cherry-pick 35e0ede
git cherry-pick e5b1c58
```
Corresponding PRs:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/658
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/659
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/661
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/666
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/668

**What testing is done?** This cloudbuild is working in master branch.https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1341469173284343808
