### PR TITLE
release-0.8: Arm overlay

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -17,4 +17,4 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -122,7 +122,6 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --leader-election=true
-            - --leader-election-type=leases
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -15,19 +15,19 @@ sidecars:
     tag: "v1.6.0"
   attacherImage:
     repository: quay.io/k8scsi/csi-attacher
-    tag: "v1.2.0"
+    tag: "v2.2.0"
   snapshotterImage:
     repository: quay.io/k8scsi/csi-snapshotter
     tag: "v2.1.1"
   livenessProbeImage:
     repository: quay.io/k8scsi/livenessprobe
-    tag: "v1.1.0"
+    tag: "v2.1.0"
   resizerImage:
     repository: quay.io/k8scsi/csi-resizer
-    tag: "v0.3.0"
+    tag: "v0.5.0"
   nodeDriverRegistrarImage:
     repository: quay.io/k8scsi/csi-node-driver-registrar
-    tag: "v1.1.0"
+    tag: "v1.3.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/kubernetes/base/clusterrole-attacher.yaml
+++ b/deploy/kubernetes/base/clusterrole-attacher.yaml
@@ -9,7 +9,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
@@ -18,4 +18,4 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
+    verbs: ["get", "list", "watch", "update", "patch"]

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -80,12 +80,11 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.0
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --leader-election=true
-            - --leader-election-type=leases
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -93,7 +92,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.1.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -68,7 +68,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -88,7 +88,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.1.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/overlays/stable/arm64/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/arm64/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../../base
+images:
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newTag: v0.8.0
+  - name: quay.io/k8scsi/csi-provisioner
+    newName: raspbernetes/csi-external-provisioner
+    newTag: "1.6.0"
+  - name: quay.io/k8scsi/csi-attacher
+    newName: raspbernetes/csi-external-attacher
+    newTag: "2.2.0"
+  - name: quay.io/k8scsi/livenessprobe
+    newName: k8s.gcr.io/sig-storage/livenessprobe
+    newTag: "v2.1.0"
+  - name: quay.io/k8scsi/csi-node-driver-registrar
+    newName: raspbernetes/csi-node-driver-registrar
+    newTag: "1.3.0"

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 bases:
 - ../../../base
 images:
-- name: amazon/aws-ebs-csi-driver
+- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
   newTag: v0.7.1
 - name: quay.io/k8scsi/csi-provisioner

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -8,8 +8,8 @@ images:
   - name: quay.io/k8scsi/csi-provisioner
     newTag: v1.5.0
   - name: quay.io/k8scsi/csi-attacher
-    newTag: v1.2.0
+    newTag: v2.2.0
   - name: quay.io/k8scsi/livenessprobe
-    newTag: v1.1.0
+    newTag: v2.1.0
   - name: quay.io/k8scsi/csi-node-driver-registrar
-    newTag: v1.1.0
+    newTag: v1.3.0

--- a/tester/multi-az-config.yaml
+++ b/tester/multi-az-config.yaml
@@ -89,7 +89,7 @@ install: |
 
 uninstall: |
   echo "Removing driver"
-  bin/helm del --purge aws-ebs-csi-driver
+  bin/helm delete aws-ebs-csi-driver
 
 test: |
   go get github.com/onsi/ginkgo/ginkgo

--- a/tester/single-az-config.yaml
+++ b/tester/single-az-config.yaml
@@ -92,7 +92,7 @@ install: |
 
 uninstall: |
   echo "Removing driver"
-  bin/helm del --purge aws-ebs-csi-driver
+  bin/helm delete aws-ebs-csi-driver
 
 test: |
   go get github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** cherry-pick of https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/653.

Since our kustomize templates are branched (they cannot be versioned like helm charts) changes to them have to be backported to the branch so that 

kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-0.8"

works and stays stable.

**What testing is done?** 
