### PR TITLE
Fix outdated ecr login command

### DIFF
--- a/hack/run-e2e-test
+++ b/hack/run-e2e-test
@@ -80,7 +80,7 @@ if docker images | grep "${IMAGE_NAME}" | grep "${IMAGE_TAG}"; then
 else
   set -e
   loudecho "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
-  eval "$(aws ecr get-login --region "${REGION}" --no-include-email)"
+  aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}".dkr.ecr."${REGION}".amazonaws.com
   docker build -t "${IMAGE_NAME}":"${IMAGE_TAG}" .
   docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
 fi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
fix
**What is this PR about? / Why do we need it?**
REF:
https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html

get-login doesn't exist anymore
**What testing is done?** 
New command works for me