### PR TITLE
Prefix helm chart releases with "helm-chart-"

### DIFF
--- a/.github/workflows/cr.yaml
+++ b/.github/workflows/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "helm-chart-{{ .Name }}-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'charts/**'
+      - "charts/**"
 
 jobs:
   release:
@@ -22,4 +22,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          config: .github/workflows/cr.yaml


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/643

**What is this PR about? / Why do we need it?** Since chart version follows driver version but not really, to avoid confusion & ambiguity I want to prefix helm chart releases and tags with "helm-chart-". Open to suggestions of other names or references to best practices here.

**What testing is done?** tsted in my fork (took couple of tries):

https://github.com/wongma7/aws-ebs-csi-driver/runs/1658660168
https://github.com/wongma7/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-0.7.4

