### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,9 +1,17 @@
+# v0.8.1
+
+## Notable changes
+- Images in k8s.gcr.io are multiarch.
+
+### Bug fixes
+* release-0.8: Use buildx in cloudbuild ([#670](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/670), [@wongma7](https://github.com/wongma7))
+
 # v0.8.0
 
 ## Notable changes
 - gp3 is now the default volume type. gp3 is **not** supported on outposts. Outpost customers need to use a different type for their volumes.
 - Images will be built on a Debian base by default. Images built on Amazon Linux will still be available but with the tag suffix `-amazonlinux`.
-- Images will be published to k8s.gcr.io in addition to ECR, GitHub, and Docker Hub.
+- Images will be published to k8s.gcr.io in addition to ECR and Docker Hub.
 
 ### New features
 * Chart option to disable default toleration of all taints ([#526](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/526), [@risinger](https://github.com/risinger))

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 IMAGE?=amazon/aws-ebs-csi-driver
-VERSION=v0.8.0
+VERSION=v0.8.1
 VERSION_AMAZONLINUX=$(VERSION)-amazonlinux
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.8.0"
+appVersion: "0.8.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.7.1
+version: 0.8.1
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  tag: "v0.8.0"
+  tag: "v0.8.1"
   pullPolicy: IfNotPresent
 
 sidecars:

--- a/deploy/kubernetes/overlays/stable/arm64/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/arm64/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../../base
+  - ../../../base
 images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-    newTag: v0.8.0
+    newTag: v0.8.1
   - name: quay.io/k8scsi/csi-provisioner
     newName: raspbernetes/csi-external-provisioner
     newTag: "1.6.0"

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,7 +4,7 @@ bases:
   - ../../base
 images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-    newTag: v0.8.0
+    newTag: v0.8.1
   - name: quay.io/k8scsi/csi-provisioner
     newTag: v1.5.0
   - name: quay.io/k8scsi/csi-attacher

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 | AWS EBS CSI Driver \ CSI Version       | v0.3.0| v1.0.0 | v1.1.0 |
 |----------------------------------------|-------|--------|--------|
 | master branch                          | no    | no     | yes    |
-| v0.8.0                                 | no    | no     | yes    |
+| v0.8.x                                 | no    | no     | yes    |
 | v0.7.1                                 | no    | no     | yes    |
 | v0.6.0                                 | no    | no     | yes    |
 | v0.5.0                                 | no    | no     | yes    |
@@ -51,7 +51,7 @@ Following sections are Kubernetes specific. If you are Kubernetes user, use foll
 | AWS EBS CSI Driver \ Kubernetes Version| v1.12 | v1.13 | v1.14 | v1.15 | v1.16 | v1.17 | v1.18+ |
 |----------------------------------------|-------|-------|-------|-------|-------|-------|-------|
 | master branch                          | no    | no+   | yes   | yes   | yes   | yes   | yes   |
-| v0.8.0                                 | no    | no+   | yes   | yes   | yes   | yes   | yes   |
+| v0.8.x                                 | no    | no+   | yes   | yes   | yes   | yes   | yes   |
 | v0.7.1                                 | no    | no+   | yes   | yes   | yes   | yes   | yes   |
 | v0.6.0                                 | no    | no+   | yes   | yes   | yes   | yes   | yes   |
 | v0.5.0                                 | no    | no+   | yes   | yes   | yes   | yes   | yes   |
@@ -66,7 +66,7 @@ Following sections are Kubernetes specific. If you are Kubernetes user, use foll
 |AWS EBS CSI Driver Version | Image                                            |
 |---------------------------|--------------------------------------------------|
 |master branch              |amazon/aws-ebs-csi-driver:latest                  |
-|v0.8.0                     |k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0 |
+|v0.8.1                     |k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.1 |
 |v0.7.1                     |amazon/aws-ebs-csi-driver:v0.7.1                  |
 |v0.6.0                     |amazon/aws-ebs-csi-driver:v0.6.0                  |
 |v0.5.0                     |amazon/aws-ebs-csi-driver:v0.5.0                  |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** new

**What is this PR about? / Why do we need it?** Need a new release for multiarchness since v0.8.0 mutliarch is broken: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/656

**What testing is done?** 0.8.1 has the same tag as 0.8.1-rc.0 which I tested for multiarchness following the same steps as in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/666

TODO: I will need to cherry-pick the kustomize changes into the release-0.8 branch.

Known issue:

Since I already tagged v0.8.1 before updating the Makefile in this PR, the "version" output in the v0.8.1 image is still going to show v0.8.0. In future, this PR should come first THEN it should be tagged, even if it means YAMLS will refer to images that haven't been pushed it.

