### PR TITLE
Add support for existing service accounts

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.8.1
+version: 0.8.2
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: ebs-csi-controller-sa
+    name: {{ .Values.serviceAccount.controller.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: ebs-csi-controller-sa
+    name: {{ .Values.serviceAccount.controller.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: ebs-csi-controller-sa
+    name: {{ .Values.serviceAccount.controller.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshot-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshot-controller.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: ebs-snapshot-controller
+    name: {{ .Values.serviceAccount.snapshot.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: ebs-csi-controller-sa
+    name: {{ .Values.serviceAccount.controller.name }}
     namespace: kube-system
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -26,7 +26,7 @@ spec:
         {{- with .Values.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
-      serviceAccountName: ebs-csi-controller-sa
+      serviceAccountName: {{ .Values.serviceAccount.controller.name }}
       priorityClassName: system-cluster-critical
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}

--- a/charts/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
+++ b/charts/aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: ebs-snapshot-controller
+    name: {{ .Values.serviceAccount.snapshot.name }}
     namespace: kube-system
 roleRef:
   kind: Role

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.serviceAccount.controller.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ebs-csi-controller-sa
+  name: {{ .Values.serviceAccount.controller.name }}
   namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
@@ -13,3 +14,4 @@ metadata:
   #annotations:
   #  eks.amazonaws.com/role-arn: arn:aws:iam::586565787010:role/ebs-csi-role
   {{- end }}
+{{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-snapshot-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-snapshot-controller.yaml
@@ -1,13 +1,15 @@
 {{- if .Values.enableVolumeSnapshot }}
+{{- if .Values.serviceAccount.snapshot.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ebs-snapshot-controller
+  name: {{ .Values.serviceAccount.snapshot.name }}
   namespace: kube-system
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.snapshot.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/charts/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         app: ebs-snapshot-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: ebs-snapshot-controller
+      serviceAccountName: {{ .Values.serviceAccount.snapshot.name }}
       containers:
         - name: snapshot-controller
           image: quay.io/k8scsi/snapshot-controller:v2.1.1

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -91,6 +91,10 @@ node:
 
 serviceAccount:
   controller:
+    create: true # A service account will be created for you if set to true. Set to false if you want to use your own.
+    name: ebs-csi-controller-sa # Name of the service-account to be used/created.
     annotations: {}
   snapshot:
+    create: true
+    name: ebs-snapshot-controller
     annotations: {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
Fixes #485

**What testing is done?** 
```
ip-172-31-62-224  aws-ebs-csi-driver git:(service_account) ✗ 01/12 2:41 helm template charts/aws-ebs-csi-driver
---
# Source: aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: ebs-csi-controller-sa
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
---
# Source: aws-ebs-csi-driver/templates/serviceaccount-snapshot-controller.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: ebs-snapshot-controller
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
---
# Source: aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-external-attacher-role
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: [""]
    resources: ["persistentvolumes"]
    verbs: ["get", "list", "watch", "update", "patch"]
  - apiGroups: [""]
    resources: ["nodes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: ["csi.storage.k8s.io"]
    resources: ["csinodeinfos"]
    verbs: ["get", "list", "watch"]
  - apiGroups: ["storage.k8s.io"]
    resources: ["volumeattachments"]
    verbs: ["get", "list", "watch", "update", "patch"]
---
# Source: aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-external-provisioner-role
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: [""]
    resources: ["persistentvolumes"]
    verbs: ["get", "list", "watch", "create", "delete"]
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs: ["get", "list", "watch", "update"]
  - apiGroups: ["storage.k8s.io"]
    resources: ["storageclasses"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["list", "watch", "create", "update", "patch"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshots"]
    verbs: ["get", "list"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshotcontents"]
    verbs: ["get", "list"]
  - apiGroups: ["storage.k8s.io"]
    resources: ["csinodes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["nodes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: ["coordination.k8s.io"]
    resources: ["leases"]
    verbs: ["get", "watch", "list", "delete", "update", "create"]
---
# Source: aws-ebs-csi-driver/templates/clusterrole-snapshot-controller.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-snapshot-controller-role
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: [""]
    resources: ["persistentvolumes"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["persistentvolumeclaims"]
    verbs: ["get", "list", "watch", "update"]
  - apiGroups: ["storage.k8s.io"]
    resources: ["storageclasses"]
    verbs: ["get", "list", "watch"]
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["list", "watch", "create", "update", "patch"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshotclasses"]
    verbs: ["get", "list", "watch"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshotcontents"]
    verbs: ["create", "get", "list", "watch", "update", "delete"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshots"]
    verbs: ["get", "list", "watch", "update"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshots/status"]
    verbs: ["update"]
---
# Source: aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-external-snapshotter-role
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["list", "watch", "create", "update", "patch"]
  - apiGroups: [""]
    resources: ["secrets"]
    verbs: ["get", "list"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshotclasses"]
    verbs: ["get", "list", "watch"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshotcontents"]
    verbs: ["create", "get", "list", "watch", "update", "delete"]
  - apiGroups: ["snapshot.storage.k8s.io"]
    resources: ["volumesnapshotcontents/status"]
    verbs: ["update"]
---
# Source: aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-csi-attacher-binding
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
subjects:
  - kind: ServiceAccount
    name: ebs-csi-controller-sa
    namespace: kube-system
roleRef:
  kind: ClusterRole
  name: ebs-external-attacher-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-csi-provisioner-binding
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
subjects:
  - kind: ServiceAccount
    name: ebs-csi-controller-sa
    namespace: kube-system
roleRef:
  kind: ClusterRole
  name: ebs-external-provisioner-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: aws-ebs-csi-driver/templates/clusterrolebinding-snapshot-controller.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-csi-snapshot-controller-binding
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
subjects:
  - kind: ServiceAccount
    name: ebs-snapshot-controller
    namespace: kube-system
roleRef:
  kind: ClusterRole
  name: ebs-snapshot-controller-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-csi-snapshotter-binding
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
subjects:
  - kind: ServiceAccount
    name: ebs-csi-controller-sa
    namespace: kube-system
roleRef:
  kind: ClusterRole
  name: ebs-external-snapshotter-role
  apiGroup: rbac.authorization.k8s.io
---
# Source: aws-ebs-csi-driver/templates/role-snapshot-controller-leaderelection.yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-snapshot-controller-leaderelection
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: ["coordination.k8s.io"]
    resources: ["leases"]
    verbs: ["get", "watch", "list", "delete", "update", "create"]
---
# Source: aws-ebs-csi-driver/templates/rolebinding-snapshot-controller-leaderelection.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ebs-snapshot-controller-leaderelection
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
subjects:
  - kind: ServiceAccount
    name: ebs-snapshot-controller
    namespace: kube-system
roleRef:
  kind: Role
  name: ebs-snapshot-controller-leaderelection
  apiGroup: rbac.authorization.k8s.io
---
# Source: aws-ebs-csi-driver/templates/node.yaml
# Node Service
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: ebs-csi-node
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app: ebs-csi-node
      app.kubernetes.io/name: aws-ebs-csi-driver
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      labels:
        app: ebs-csi-node
        app.kubernetes.io/name: aws-ebs-csi-driver
        app.kubernetes.io/instance: RELEASE-NAME
        helm.sh/chart: aws-ebs-csi-driver-0.7.1
        app.kubernetes.io/version: "0.8.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: eks.amazonaws.com/compute-type
                operator: NotIn
                values:
                - fargate
      nodeSelector:
        kubernetes.io/os: linux
      hostNetwork: true
      priorityClassName: system-node-critical
      tolerations:
        - operator: Exists
      containers:
        - name: ebs-plugin
          securityContext:
            privileged: true
          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0
          args:
            - node
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=5
          env:
            - name: CSI_ENDPOINT
              value: unix:/csi/csi.sock
          volumeMounts:
            - name: kubelet-dir
              mountPath: /var/lib/kubelet
              mountPropagation: "Bidirectional"
            - name: plugin-dir
              mountPath: /csi
            - name: device-dir
              mountPath: /dev
          ports:
            - name: healthz
              containerPort: 9808
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /healthz
              port: healthz
            initialDelaySeconds: 10
            timeoutSeconds: 3
            periodSeconds: 10
            failureThreshold: 5
        - name: node-driver-registrar
          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
          args:
            - --csi-address=$(ADDRESS)
            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
            - --v=5
          lifecycle:
            preStop:
              exec:
                command: ["/bin/sh", "-c", "rm -rf /registration/ebs.csi.aws.com-reg.sock /csi/csi.sock"]
          env:
            - name: ADDRESS
              value: /csi/csi.sock
            - name: DRIVER_REG_SOCK_PATH
              value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
          volumeMounts:
            - name: plugin-dir
              mountPath: /csi
            - name: registration-dir
              mountPath: /registration
        - name: liveness-probe
          image: quay.io/k8scsi/livenessprobe:v2.1.0
          args:
            - --csi-address=/csi/csi.sock
          volumeMounts:
            - name: plugin-dir
              mountPath: /csi
      volumes:
        - name: kubelet-dir
          hostPath:
            path: /var/lib/kubelet
            type: Directory
        - name: plugin-dir
          hostPath:
            path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
            type: DirectoryOrCreate
        - name: registration-dir
          hostPath:
            path: /var/lib/kubelet/plugins_registry/
            type: Directory
        - name: device-dir
          hostPath:
            path: /dev
            type: Directory
---
# Source: aws-ebs-csi-driver/templates/controller.yaml
# Controller Service
kind: Deployment
apiVersion: apps/v1
metadata:
  name: ebs-csi-controller
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 2
  selector:
    matchLabels:
      app: ebs-csi-controller
      app.kubernetes.io/name: aws-ebs-csi-driver
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      labels:
        app: ebs-csi-controller
        app.kubernetes.io/name: aws-ebs-csi-driver
        app.kubernetes.io/instance: RELEASE-NAME
        helm.sh/chart: aws-ebs-csi-driver-0.7.1
        app.kubernetes.io/version: "0.8.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      nodeSelector:
        kubernetes.io/os: linux
      serviceAccountName: ebs-csi-controller-sa
      priorityClassName: system-cluster-critical
      tolerations:
        - operator: Exists
      containers:
        - name: ebs-plugin
          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.8.0
          imagePullPolicy: IfNotPresent
          args:
            - controller
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=5
          env:
            - name: CSI_ENDPOINT
              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
            - name: AWS_ACCESS_KEY_ID
              valueFrom:
                secretKeyRef:
                  name: aws-secret
                  key: key_id
                  optional: true
            - name: AWS_SECRET_ACCESS_KEY
              valueFrom:
                secretKeyRef:
                  name: aws-secret
                  key: access_key
                  optional: true
          volumeMounts:
            - name: socket-dir
              mountPath: /var/lib/csi/sockets/pluginproxy/
          ports:
            - name: healthz
              containerPort: 9808
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /healthz
              port: healthz
            initialDelaySeconds: 10
            timeoutSeconds: 3
            periodSeconds: 10
            failureThreshold: 5
        - name: csi-provisioner
          image: quay.io/k8scsi/csi-provisioner:v1.6.0
          args:
            - --csi-address=$(ADDRESS)
            - --v=5
            - --enable-leader-election
            - --leader-election-type=leases
          env:
            - name: ADDRESS
              value: /var/lib/csi/sockets/pluginproxy/csi.sock
          volumeMounts:
            - name: socket-dir
              mountPath: /var/lib/csi/sockets/pluginproxy/
        - name: csi-attacher
          image: quay.io/k8scsi/csi-attacher:v2.2.0
          args:
            - --csi-address=$(ADDRESS)
            - --v=5
            - --leader-election=true
          env:
            - name: ADDRESS
              value: /var/lib/csi/sockets/pluginproxy/csi.sock
          volumeMounts:
            - name: socket-dir
              mountPath: /var/lib/csi/sockets/pluginproxy/
        - name: csi-snapshotter
          image: quay.io/k8scsi/csi-snapshotter:v2.1.1
          args:
            - --csi-address=$(ADDRESS)
            - --leader-election=true
          env:
            - name: ADDRESS
              value: /var/lib/csi/sockets/pluginproxy/csi.sock
          volumeMounts:
            - name: socket-dir
              mountPath: /var/lib/csi/sockets/pluginproxy/
        - name: liveness-probe
          image: quay.io/k8scsi/livenessprobe:v2.1.0
          args:
            - --csi-address=/csi/csi.sock
          volumeMounts:
            - name: socket-dir
              mountPath: /csi
      volumes:
        - name: socket-dir
          emptyDir: {}
---
# Source: aws-ebs-csi-driver/templates/statefulset.yaml
#Snapshot controller
kind: StatefulSet
apiVersion: apps/v1
metadata:
  name: ebs-snapshot-controller
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  serviceName: ebs-snapshot-controller
  replicas: 1
  selector:
    matchLabels:
      app: ebs-snapshot-controller
      app.kubernetes.io/name: aws-ebs-csi-driver
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      labels:
        app: ebs-snapshot-controller
        app.kubernetes.io/name: aws-ebs-csi-driver
        app.kubernetes.io/instance: RELEASE-NAME
        helm.sh/chart: aws-ebs-csi-driver-0.7.1
        app.kubernetes.io/version: "0.8.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: ebs-snapshot-controller
      containers:
        - name: snapshot-controller
          image: quay.io/k8scsi/snapshot-controller:v2.1.1
          args:
            - --v=5
            - --leader-election=false
---
# Source: aws-ebs-csi-driver/templates/csidriver.yaml
apiVersion: storage.k8s.io/v1beta1
kind: CSIDriver
metadata:
  name: ebs.csi.aws.com
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: RELEASE-NAME
    helm.sh/chart: aws-ebs-csi-driver-0.7.1
    app.kubernetes.io/version: "0.8.0"
    app.kubernetes.io/managed-by: Helm
spec:
  attachRequired: true
  podInfoOnMount: false
```