### PR TITLE
Add a prerequisite to dynamic provisioning

### DIFF
--- a/examples/kubernetes/dynamic-provisioning/README.md
+++ b/examples/kubernetes/dynamic-provisioning/README.md
@@ -5,7 +5,7 @@ This example shows how to create a EBS volume and consume it from container dyna
 
 1. Kubernetes 1.13+ (CSI 1.0).
 
-1. The [aws-ebs-csi-driver driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) is installed.
+2. The [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) is installed with `--set enableVolumeScheduling=true`.
 
 ## Usage
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New documentation

**What is this PR about? / Why do we need it?**
Emphasise that enableVolumeScheduling should be equal to true, in order to provision EBS volumes dynamically.