### PR TITLE
feat: Add option to provision StorageClasses

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
 version: 0.9.0

--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -1,0 +1,15 @@
+{{- range .Values.storageClasses }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ .name }}
+provisioner: ebs.csi.aws.com
+volumeBindingMode: {{ default "WaitForFirstConsumer" .volumeBindingMode }}
+{{- if hasKey . "reclaimPolicy" }}
+reclaimPolicy: {{ .reclaimPolicy }}
+{{- end }}
+{{- with .parameters }}
+parameters:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -101,3 +101,13 @@ serviceAccount:
     create: true
     name: ebs-snapshot-controller
     annotations: {}
+
+storageClasses: []
+# Add StorageClass resources like:
+# - name: ebs-sc
+#   # defaults to WaitForFirstConsumer
+#   volumeBindingMode: WaitForFirstConsumer
+#   # defaults to Delete
+#   reclaimPolicy: Retain
+#   parameters:
+#     encrypted: "true"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature in the helm chart

**What is this PR about? / Why do we need it?**
Most application charts don't usually create `StorageClass`es. They create PVCs.

**What testing is done?** 
Installed the chart with the following custom values:

```yaml
enableVolumeResizing: true
enableVolumeScheduling: true
enableVolumeSnapshot: true

serviceAccount:
  controller:
    name: ebs-csi-controller
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::123:role/cluster-name-kube-system-ebs-csi-controller
  snapshot:
    create: false
    name: ebs-csi-controller
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::123:role/cluster-name-kube-system-ebs-csi-controller

storageClasses:
- name: ebs-sc
  parameters:
    encrypted: "true"
```

Then tried creating a PVC and a pod that used it:

```yaml
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim
spec:
  storageClassName: ebs-sc
  accessModes:
    - "ReadWriteOnce"
  resources:
    requests:
      storage: 5Gi
---
apiVersion: v1
kind: Pod
metadata:
  name: ebs-app
spec:
  containers:
    - name: app
      image: centos
      command: ["/bin/sh"]
      args: ["-c", "while true; do echo $(date -u) >> /data/out; sleep 5; done"]
      volumeMounts:
        - name: persistent-storage
          mountPath: /data
  volumes:
    - name: persistent-storage
      persistentVolumeClaim:
        claimName: ebs-claim
```

Verified the following:

PV was provisioned.
New EBS gp3 volume was created as expected.
