### PR TITLE
Refactor inFlight key to add lock per volumeId

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -205,11 +205,11 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	// check if a request is already in-flight because the CreateVolume API is not idempotent
-	if ok := d.inFlight.Insert(req); !ok {
+	if ok := d.inFlight.Insert(req.String()); !ok {
 		msg := fmt.Sprintf("Create volume request for %s is already in progress", volName)
 		return nil, status.Error(codes.Aborted, msg)
 	}
-	defer d.inFlight.Delete(req)
+	defer d.inFlight.Delete(req.String())
 
 	// create a new volume
 	zone := pickAvailabilityZone(req.GetAccessibilityRequirements())

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -1534,8 +1534,8 @@ func TestCreateVolume(t *testing.T) {
 				mockCloud.EXPECT().GetDiskByName(gomock.Eq(ctx), gomock.Eq(req.Name), gomock.Eq(stdVolSize)).Return(nil, cloud.ErrNotFound)
 
 				inFlight := internal.NewInFlight()
-				inFlight.Insert(req)
-				defer inFlight.Delete(req)
+				inFlight.Insert(req.String())
+				defer inFlight.Delete(req.String())
 
 				awsDriver := controllerService{
 					cloud:         mockCloud,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #307 
Fixes #370 
**What is this PR about? / Why do we need it?**
Handle concurrency for node operations (stage/unstage publish/unpublish)
According to https://github.com/container-storage-interface/spec/blob/master/spec.md#concurrency driver's InFlight cache should track in-flight request per volumeId instead of per request to ensure no more than one request per volume at a given time.
