### PR TITLE
More controll over snapshot-controller scheduling

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.1
+version: 0.9.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/charts/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -21,6 +21,22 @@ spec:
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.snapshot.name }}
+      nodeSelector:
+        kubernetes.io/os: linux
+        {{- with .Values.nodeSelector }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      priorityClassName: system-cluster-critical
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+        {{- if .Values.tolerateAllTaints }}
+        - operator: Exists
+        {{- end }}
+        {{- with .Values.tolerations }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
       containers:
         - name: snapshot-controller
           image: k8s.gcr.io/sig-storage/snapshot-controller:v3.0.3


### PR DESCRIPTION
Apply nodeSelector, affinity, tolerations and priorityClassName to snapshoter. This PR brings the `snapshot-controller` StatefulSet on par with the `ebs-csi-controller` Deployment, applying the same scheduling settings to it. This is important
for clusters where cluster-addons (like the aws-ebs-csi-driver) are scheduled to dedicated node groups, which are
isolated from other (general purpose) node groups.