### PR TITLE
Bump cloudbuild timeout to 1800s

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1200s
+timeout: 1800s
 steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
     entrypoint: ./hack/prow.sh


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** bug

**What is this PR about? / Why do we need it?**  The initial v0.9.0 build failed because of 20m* timeout: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1356735403712843776

Try bumping it to 30m*

If works, will make same PR against master.

**What testing is done?** 

I'll push a v0.9.0-rc.0 tag to test the build. 