### PR TITLE
Increase timout for cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 1800s
+timeout: 3600s
 steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
     entrypoint: ./hack/prow.sh


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Trying to unblock the release. We still need to investigate why builds have been failing since 01/11.