### PR TITLE
Bump chart version

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "0.9.1"
+appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.0
+version: 0.9.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:


### PR DESCRIPTION
Last PR I approved didn't update the chart version (appVersion was updated instead). This fixes that so we can release the chart.

See #697