### PR TITLE
Allow all fields to be set on StorageClasses

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.3
+version: 0.9.4
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -4,12 +4,5 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ .name }}
 provisioner: ebs.csi.aws.com
-volumeBindingMode: {{ default "WaitForFirstConsumer" .volumeBindingMode }}
-{{- if hasKey . "reclaimPolicy" }}
-reclaimPolicy: {{ .reclaimPolicy }}
-{{- end }}
-{{- with .parameters }}
-parameters:
-{{ toYaml . | indent 2 }}
-{{- end }}
+{{ omit (dict "volumeBindingMode" "WaitForFirstConsumer" | merge .) "name" | toYaml }}
 {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
A new feature

**What is this PR about? / Why do we need it?**

The StorageClasses created by the Helm chart can currently only be configured with `volumeBindingMode`, `reclaimPolicy`, and `parameters`. We have `allowVolumeExpansion: true` set on ours, so we couldn't migrate them to be provisioned by the chart.

This PR allows any field permitted by the API to be specified.

**What testing is done?** 

I've templated the chart with a variety of StorageClasses and validated that the output manifests are correct.
