### PR TITLE
Fix daemonset liveness image to multiarch version for ARM kustomization

### DIFF
--- a/deploy/kubernetes/base/arm64/node.yaml
+++ b/deploy/kubernetes/base/arm64/node.yaml
@@ -88,7 +88,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

I think this is a bug fix.

**What is this PR about? / Why do we need it?**

The ARM-supporting kustomization base still missed the correct (multiarch) liveness sidecar image for the Node service.

The Helm chart already gets the [default](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v0.9.0/charts/aws-ebs-csi-driver/values.yaml) correctly.