### PR TITLE
[chart] Allow resources override for node DaemonSet + priorityClassName

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.4
+version: 0.9.5
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -27,7 +27,7 @@ spec:
 {{ toYaml . | indent 8 }}
         {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.controller.name }}
-      priorityClassName: system-cluster-critical
+      priorityClassName: {{ .Values.priorityClassName | default "system-cluster-critical" }}
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -80,8 +80,14 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          {{- if .Values.node.resources }}
+          {{- with .Values.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
         - name: node-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrarImage.repository .Values.sidecars.nodeDriverRegistrarImage.tag }}
@@ -103,8 +109,14 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          {{- if .Values.node.resources }}
+          {{- with .Values.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbeImage.repository .Values.sidecars.livenessProbeImage.tag }}
@@ -113,8 +125,14 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          {{- if .Values.node.resources }}
+          {{- with .Values.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
       volumes:
         - name: kubelet-dir

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
       hostNetwork: true
       serviceAccountName: {{ .Values.serviceAccount.node.name }}
-      priorityClassName: system-node-critical
+      priorityClassName: {{ .Values.node.priorityClassName | default "system-cluster-critical" }}
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists

--- a/charts/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/charts/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
         {{- with .Values.nodeSelector }}
 {{ toYaml . | indent 8 }}
         {{- end }}
-      priorityClassName: system-cluster-critical
+      priorityClassName: {{ .Values.priorityClassName | default "system-cluster-critical" }}
       {{- with .Values.affinity }}
       affinity: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -91,6 +91,7 @@ node:
   podAnnotations: {}
   tolerateAllTaints: true
   tolerations: []
+  resources: {}
 
 serviceAccount:
   controller:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -60,11 +60,10 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+priorityClassName: ""
 nodeSelector: {}
-
 tolerateAllTaints: true
 tolerations: []
-
 affinity: {}
 
 # Extra volume tags to attach to each dynamically provisioned volume.
@@ -87,6 +86,7 @@ k8sTagClusterId: ""
 region: ""
 
 node:
+  priorityClassName: ""
   nodeSelector: {}
   podAnnotations: {}
   tolerateAllTaints: true


### PR DESCRIPTION
CSI controller and node have different needs in a manner of capacity so
in this commit we enable users to define specific resources for the node
component. This will allow users not to reserve not needed resources on
all of their instances as node is a DaemonSet and may not need as much
CPU/Memory as the controller Pods.

**Is this a bug fix or adding new feature?**
Adding a feature of overriding resource for the node

**What is this PR about? / Why do we need it?**
Mitigate overprovisioning capacity for node component

**What testing is done?** 
Tested on our internal clusters