### PR TITLE
Update ECR overlay

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,16 +5,16 @@ bases:
 images:
 - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-  newTag: v0.7.1
+  newTag: v0.9.0
 - name: quay.io/k8scsi/csi-provisioner
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-  newTag: v1.5.0
+  newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+  newTag: v2.0.3-eks-1-18-1
 - name: quay.io/k8scsi/csi-attacher
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
-  newTag: v1.2.0
+  newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+  newTag: v3.0.1-eks-1-18-1
 - name: quay.io/k8scsi/livenessprobe
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-liveness-probe
-  newTag: v1.1.0
+  newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+  newTag: v2.1.0-eks-1-18-1
 - name: quay.io/k8scsi/csi-node-driver-registrar
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-  newTag: v1.1.0
+  newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+  newTag: v2.0.1-eks-1-18-1


### PR DESCRIPTION
It's been a while since we updated the ECR overlay. This PR

- Updates the driver version to 0.9.0
- Uses the new public ECR for sidecars

**What testing is done?** 
Deployed to my own cluster and verified it runs.