### PR TITLE
Add readiness probe so controller does not report "Ready" prematurely

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.11
+version: 0.9.13
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -106,6 +106,14 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -65,6 +65,14 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.2
           args:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #548 

**What is this PR about? / Why do we need it?**
This change reuses the liveness probe endpoint for a readiness probe, so that the csi controller's status can be reported accurately. Currently, if the ec2 instance metadata is unavailable, the csi controller deployment reports as ready, tries to fetch the metadata, panics when it cannot, and then stops reporting as ready. With this change, the controller deployment will not report ready from the get-go, and as a result will not report an inaccurate status if the instance metadata is unavailable.

**What testing is done?** 
Manually tested this using both kubectl and helm. Applied a global network policy to block access to the ec2 instance metadata, then created an ebs csi driver deployment. Visually confirmed with `kubectl get deployments -n kube-system` that the behavior changed and the controller no longer reported as ready before entering the `CrashLoopBackOff` state.