### PR TITLE
Sets the imagePullSecrets if the value is set in the chart

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.8
+version: 0.9.9
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -174,6 +174,12 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -134,6 +134,12 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/charts/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/charts/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -43,4 +43,10 @@ spec:
           args:
             - --v=5
             - --leader-election=false
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #613 

**What is this PR about? / Why do we need it?**
Sets the `imagePullSecrets` if the value is set in the chart

**What testing is done?** 
Rendered the chart with & without `imagePullSecrets` set and validated the yaml with `kubeval`