### PR TITLE
Update livenessprobe image version from 2.1.0 to 2.2.0

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.9
+version: 0.9.10
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -21,7 +21,7 @@ sidecars:
     tag: "v3.0.3"
   livenessProbeImage:
     repository: k8s.gcr.io/sig-storage/livenessprobe
-    tag: "v2.1.0"
+    tag: "v2.2.0"
   resizerImage:
     repository: k8s.gcr.io/sig-storage/csi-resizer
     tag: "v1.0.0"

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -92,7 +92,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -89,7 +89,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.2.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -10,6 +10,6 @@ images:
   - name: k8s.gcr.io/sig-storage/csi-attacher
     newTag: v3.0.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
-    newTag: v2.1.0
+    newTag: v2.2.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newTag: v2.0.1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix #749 

**What is this PR about? / Why do we need it?**
Upgrade livenessprobe to patch memory leak 

**What testing is done?** 
helm install in k8s cluster