### PR TITLE
Update test k8s version to 1.18.16

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -40,7 +40,7 @@ AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_NAME=${IMAGE_NAME:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${DRIVER_NAME}}
 IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
 
-K8S_VERSION=${K8S_VERSION:-1.18.10}
+K8S_VERSION=${K8S_VERSION:-1.18.16}
 KOPS_VERSION=${KOPS_VERSION:-1.18.2}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_FEATURE_GATES_FILE=${KOPS_FEATURE_GATES_FILE:-./hack/feature-gates.yaml}


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Updating the k8s version e2e tests are running so we get the inline fix: https://github.com/kubernetes/kubernetes/pull/96821

See k8s [Changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.18.md#changelog-since-v11815).