### PR TITLE
add a document separator for storageclass template file

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.storageClasses }}
+---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
not a new feature

**What is this PR about? / Why do we need it?**
adds a document separator for storageclass template file

**What testing is done?** 
tested using helm template
