### PR TITLE
Fix error message when IOPSPerGB is missing in io1 volumes

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -183,6 +183,12 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
+	if volumeType == cloud.VolumeTypeIO1 {
+		if iopsPerGB == 0 {
+			return nil, status.Errorf(codes.InvalidArgument, "The parameter IOPSPerGB must be specified for io1 volumes")
+		}
+	}
+
 	snapshotID := ""
 	volumeSource := req.GetVolumeContentSource()
 	if volumeSource != nil {


### PR DESCRIPTION
Explicitly return specific message in this case, otherwise the cloud returns generic `The parameter iops must be specified for io1 volumes`, which mentions `iops`, but the parameter that the user needs to set is `IOPSPerGB`.

Fixes: #766