### PR TITLE
Aws client config: increase MaxRetries

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -235,6 +235,8 @@ func newEC2Cloud(region string) (Cloud, error) {
 	awsConfig := &aws.Config{
 		Region:                        aws.String(region),
 		CredentialsChainVerboseErrors: aws.Bool(true),
+		// Set MaxRetries to a high value. It will be "ovewritten" if context deadline comes sooner.
+		MaxRetries: aws.Int(8),
 	}
 
 	endpoint := os.Getenv("AWS_EC2_ENDPOINT")


### PR DESCRIPTION
This commit increase the number of retries to a high number (8) so
that the AWS framework retries failing requests until the request
context times-out.

By default, when throttled, the aws client retries a given request
3 times with exponentially increasing delay between retries.
The default number of retries is still low enough that requests are
only going to be retried for a few seconds.
Instead of retrying for a few seconds, we should retry until the
request context times out.

This should reduce the occurence of #754

**Is this a bug fix or adding new feature?**
Mitigation for #754

**What is this PR about? / Why do we need it?*
[waitForVolume](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/pkg/cloud/cloud.go#L804) has a checkTime of 1 minute but current AWS client only retries requests for a few seconds.

This PR is about increasing the number of retries the AWS client performs before giving up so that `waitForVolume` actually waits a full minute or until the request context deadline is reached.

This is important because as explained in #754 a throttled / failed request will result in a leaked volume so we want to reduce the change of it happening.

**What testing is done?** 
`make test`