### PR TITLE
delete leaked volume if driver don't know the volume status

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -343,6 +343,13 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 	}
 
 	if err := c.waitForVolume(ctx, volumeID); err != nil {
+		// To avoid leaking volume, we should delete the volume just created
+		// TODO: Need to figure out how to handle DeleteDisk failed scenario instead of just log the error
+		if _, error := c.DeleteDisk(ctx, volumeID); error != nil {
+			klog.Errorf("%v failed to be deleted, this may cause volume leak", volumeID)
+		} else {
+			klog.V(5).Infof("%v is deleted because it is not in desired state within retry limit", volumeID)
+		}
 		return nil, fmt.Errorf("failed to get an available volume in EC2: %v", err)
 	}
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #754 
**What is this PR about? / Why do we need it?**
Delete volume if the driver don't know about the volume status after creation
**What testing is done?** 
Could see this log after denying DescribeVolume api call manually
```volume is deleted because it is not in desired state within retry limit```
Added unit test