### PR TITLE
Add well-known topology label

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -569,13 +569,22 @@ func pickAvailabilityZone(requirement *csi.TopologyRequirement) string {
 		return ""
 	}
 	for _, topology := range requirement.GetPreferred() {
-		zone, exists := topology.GetSegments()[TopologyKey]
+		zone, exists := topology.GetSegments()[WellKnownTopologyKey]
+		if exists {
+			return zone
+		}
+
+		zone, exists = topology.GetSegments()[TopologyKey]
 		if exists {
 			return zone
 		}
 	}
 	for _, topology := range requirement.GetRequisite() {
-		zone, exists := topology.GetSegments()[TopologyKey]
+		zone, exists := topology.GetSegments()[WellKnownTopologyKey]
+		if exists {
+			return zone
+		}
+		zone, exists = topology.GetSegments()[TopologyKey]
 		if exists {
 			return zone
 		}
@@ -615,7 +624,7 @@ func newCreateVolumeResponse(disk *cloud.Disk) *csi.CreateVolumeResponse {
 		}
 	}
 
-	segments := map[string]string{TopologyKey: disk.AvailabilityZone}
+	segments := map[string]string{TopologyKey: disk.AvailabilityZone, WellKnownTopologyKey: disk.AvailabilityZone}
 
 	arn, err := arn.Parse(disk.OutpostArn)
 

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -242,11 +242,12 @@ func TestCreateVolume(t *testing.T) {
 					AccessibleTopology: []*csi.Topology{
 						{
 							Segments: map[string]string{
-								TopologyKey:     expZone,
-								AwsAccountIDKey: outpostArn.AccountID,
-								AwsOutpostIDKey: outpostArn.Resource,
-								AwsRegionKey:    outpostArn.Region,
-								AwsPartitionKey: outpostArn.Partition,
+								TopologyKey:          expZone,
+								WellKnownTopologyKey: expZone,
+								AwsAccountIDKey:      outpostArn.AccountID,
+								AwsOutpostIDKey:      outpostArn.Resource,
+								AwsRegionKey:         outpostArn.Region,
+								AwsPartitionKey:      outpostArn.Partition,
 							},
 						},
 					},
@@ -1230,7 +1231,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeContext: map[string]string{},
 					AccessibleTopology: []*csi.Topology{
 						{
-							Segments: map[string]string{TopologyKey: expZone},
+							Segments: map[string]string{TopologyKey: expZone, WellKnownTopologyKey: expZone},
 						},
 					},
 				}
@@ -1724,6 +1725,33 @@ func TestPickAvailabilityZone(t *testing.T) {
 		requirement *csi.TopologyRequirement
 		expZone     string
 	}{
+		{
+			name: "Return WellKnownTopologyKey if present from preferred",
+			requirement: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{TopologyKey: ""},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{TopologyKey: expZone, WellKnownTopologyKey: "foobar"},
+					},
+				},
+			},
+			expZone: "foobar",
+		},
+		{
+			name: "Return WellKnownTopologyKey if present from requisite",
+			requirement: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{TopologyKey: expZone, WellKnownTopologyKey: "foobar"},
+					},
+				},
+			},
+			expZone: "foobar",
+		},
 		{
 			name: "Pick from preferred",
 			requirement: &csi.TopologyRequirement{

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -41,11 +41,14 @@ const (
 
 const (
 	DriverName      = "ebs.csi.aws.com"
-	TopologyKey     = "topology." + DriverName + "/zone"
 	AwsPartitionKey = "topology." + DriverName + "/partition"
 	AwsAccountIDKey = "topology." + DriverName + "/account-id"
 	AwsRegionKey    = "topology." + DriverName + "/region"
 	AwsOutpostIDKey = "topology." + DriverName + "/outpost-id"
+
+	WellKnownTopologyKey = "topology.kubernetes.io/zone"
+	// DEPRECATED Use the WellKnownTopologyKey instead
+	TopologyKey = "topology." + DriverName + "/zone"
 )
 
 type Driver struct {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -487,8 +487,11 @@ func (d *nodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	klog.V(4).Infof("NodeGetInfo: called with args %+v", *req)
 
+	zone := d.metadata.GetAvailabilityZone()
+
 	segments := map[string]string{
-		TopologyKey: d.metadata.GetAvailabilityZone(),
+		TopologyKey:          zone,
+		WellKnownTopologyKey: zone,
 	}
 
 	outpostArn := d.metadata.GetOutpostArn()

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1470,6 +1470,9 @@ func TestNodeGetInfo(t *testing.T) {
 			if at.Segments[TopologyKey] != tc.availabilityZone {
 				t.Fatalf("Expected topology %q, got %q", tc.availabilityZone, at.Segments[TopologyKey])
 			}
+			if at.Segments[WellKnownTopologyKey] != tc.availabilityZone {
+				t.Fatalf("Expected well-known topology %q, got %q", tc.availabilityZone, at.Segments[WellKnownTopologyKey])
+			}
 
 			if at.Segments[AwsAccountIDKey] != tc.outpostArn.AccountID {
 				t.Fatalf("Expected AwsAccountId %q, got %q", tc.outpostArn.AccountID, at.Segments[AwsAccountIDKey])


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature

**What is this PR about? / Why do we need it?**
See #729. This is the first part where we start writing the label and also give priority to it when reading topology labels. This change is completely backward-compatible with no change in behavior as far as users are concerned.

**What testing is done?** 
Unit tests
Single AZ e2e (there was one failed case that should be unrelated, probably flake)
