### PR TITLE
add toleration time to NoExecute effect --- Enable in next release

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.13
+version: 0.9.14
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -33,6 +33,12 @@ spec:
       tolerations:
         {{- if .Values.tolerateAllTaints }}
         - operator: Exists
+        {{- else }}
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
         {{- end }}
         {{- with .Values.tolerations }}
 {{ toYaml . | indent 8 }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -39,6 +39,12 @@ spec:
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
+        {{- else }}
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
         {{- end }}
         {{- with .Values.node.tolerations }}
 {{ toYaml . | indent 8 }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -25,7 +25,11 @@ spec:
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
       containers:
         - name: ebs-plugin
           image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v0.9.0

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -34,7 +34,11 @@ spec:
       serviceAccountName: ebs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
         - operator: Exists
+          effect: NoExecute
+          tolerationSeconds: 300
       containers:
         - name: ebs-plugin
           securityContext:

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,8 @@ If your cluster is v1.14+, you can skip this step. Install the `CSINodeInfo` CRD
 ```sh
 kubectl create -f https://raw.githubusercontent.com/kubernetes/csi-api/release-1.13/pkg/crd/manifests/csinodeinfo.yaml
 ```
+#### Config node toleration settings
+By default, driver can be deployed on any nodes, to have driver tolerate taint `CriticalAddonsOnly`, please set helm `Value.node.tolerateAllTaints` and `Value.tolerateAllTaints` to false before deployment
 
 #### Deploy driver
 Please see the compatibility matrix above before you deploy the driver


### PR DESCRIPTION
Continue from #775 
Is this a bug fix or adding new feature?
Fixes #588
What is this PR about? / Why do we need it?
Not tolerate NoSchedule effect and add default 300s tolerationSeconds to all the NoExecute taints.

As we discussed, will default to tolerateAllTaints for now, will disable this in next release.