### PR TITLE
hack/e2e: Support passing helm values as values.yaml and make other similar files optional

### DIFF
--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -24,3 +24,24 @@ GINKGO_FOCUS=Dynamic.\*xfs.\*should.store.data \
 GINKGO_NODES=1 \
 ./hack/e2e/run.sh
 ```
+
+# git read-tree
+
+Reference: https://stackoverflow.com/questions/23937436/add-subdirectory-of-remote-repo-with-git-subtree
+
+How to consume this directory by read-treeing the ebs repo:
+
+```
+git remote add ebs git@github.com:kubernetes-sigs/aws-ebs-csi-driver.git
+git fetch ebs
+git read-tree --prefix=hack/e2e/ -u ebs/master:hack/e2e
+```
+
+To commit changes and submit them as a PR back to the ebs repo:
+
+```
+git diff ebs/master:hack/e2e HEAD:hack/e2e > /tmp/hack_e2e.diff
+cd $GOPATH/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+git apply --reject --directory hack/e2e /tmp/hack_e2e.diff
+git commit
+```

--- a/hack/e2e/kops.sh
+++ b/hack/e2e/kops.sh
@@ -52,8 +52,8 @@ function kops_create_cluster() {
 
   CLUSTER_YAML_PATH=${TEST_DIR}/${CLUSTER_NAME}.yaml
   ${KOPS_BIN} get cluster --state "${KOPS_STATE_FILE}" "${CLUSTER_NAME}" -o yaml > "${CLUSTER_YAML_PATH}"
-  cat "${KOPS_FEATURE_GATES_FILE}" >> "${CLUSTER_YAML_PATH}"
-  cat "${KOPS_ADDITIONAL_POLICIES_FILE}" >> "${CLUSTER_YAML_PATH}"
+  [ -r "$KOPS_FEATURE_GATES_FILE" ] && cat "${KOPS_FEATURE_GATES_FILE}" >> "${CLUSTER_YAML_PATH}"
+  [ -r "$KOPS_ADDITIONAL_POLICIES_FILE" ] && cat "${KOPS_ADDITIONAL_POLICIES_FILE}" >> "${CLUSTER_YAML_PATH}"
   ${KOPS_BIN} replace --state "${KOPS_STATE_FILE}" -f "${CLUSTER_YAML_PATH}"
   ${KOPS_BIN} update cluster --state "${KOPS_STATE_FILE}" "${CLUSTER_NAME}" --yes
 

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -46,6 +46,8 @@ KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_FEATURE_GATES_FILE=${KOPS_FEATURE_GATES_FILE:-./hack/feature-gates.yaml}
 KOPS_ADDITIONAL_POLICIES_FILE=${KOPS_ADDITIONAL_POLICIES_FILE:-./hack/additional-policies.yaml}
 
+HELM_VALUES_FILE=${HELM_VALUES_FILE:-./hack/values.yaml}
+
 TEST_PATH=${TEST_PATH:-"./tests/e2e/..."}
 KUBECONFIG=${KUBECONFIG:-"${HOME}/.kube/config"}
 ARTIFACTS=${ARTIFACTS:-"${TEST_DIR}/artifacts"}
@@ -103,14 +105,12 @@ fi
 loudecho "Deploying driver"
 "${HELM_BIN}" upgrade --install "${DRIVER_NAME}" \
   --namespace kube-system \
-  --set enableVolumeScheduling=true \
-  --set enableVolumeResizing=true \
-  --set enableVolumeSnapshot=true \
   --set image.repository="${IMAGE_NAME}" \
   --set image.tag="${IMAGE_TAG}" \
+  -f "${HELM_VALUES_FILE}" \
   ./charts/"${DRIVER_NAME}"
 
-if [[ -n "${EBS_SNAPSHOT_CRD}" ]]; then
+if [[ -r "${EBS_SNAPSHOT_CRD}" ]]; then
   loudecho "Deploying snapshot CRD"
   kubectl apply -f "$EBS_SNAPSHOT_CRD"
   # TODO deploy snapshot controller too instead of including in helm chart

--- a/hack/values.yaml
+++ b/hack/values.yaml
@@ -1,0 +1,3 @@
+enableVolumeScheduling: true
+enableVolumeResizing: true
+enableVolumeSnapshot: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix

**What is this PR about? / Why do we need it?** Minor changes to make the scripts more configurable and usable by EFS driver. https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/354 

It seems like git read tree is the simplest way to consume these scripts from EFS. subtree is more complicated because hack/e2e is a subdirectory of this repo and not its own repo

**What testing is done?** CI of PR https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/354  and CI of this PR.

