### PR TITLE
Update snapshot controller resources

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/statefulset.yaml
+++ b/charts/aws-ebs-csi-driver/templates/statefulset.yaml
@@ -39,6 +39,9 @@ spec:
       containers:
         - name: snapshot-controller
           image: {{ printf "%s:%s" .Values.snapshotController.repository .Values.snapshotController.tag }}
+          {{- with .Values.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           env:
 {{- if .Values.proxy.http_proxy }}
           - name: HTTP_PROXY


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

- Fix to apply resource constraints to snapshot controller

**What is this PR about? / Why do we need it?**

- See #637 and #640 

**What testing is done?** 

- Updated resources for snapshot controller stateful set and deployed in EKS. Pods were deployed without any issues. Ran `kubectl get po -A -o json | grep -B 3 -i '"resources": {},'` to verify the resources have been properly populated to the pods.
