### PR TITLE
handling describe instances consistency issue

### DIFF
--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
 	cloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 )
@@ -229,15 +230,16 @@ func (mr *MockCloudMockRecorder) ResizeDisk(arg0, arg1, arg2 interface{}) *gomoc
 }
 
 // WaitForAttachmentState mocks base method.
-func (m *MockCloud) WaitForAttachmentState(arg0 context.Context, arg1, arg2 string) error {
+func (m *MockCloud) WaitForAttachmentState(arg0 context.Context, arg1, arg2, arg3, arg4 string, arg5 bool) (*ec2.VolumeAttachment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForAttachmentState", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "WaitForAttachmentState", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].(*ec2.VolumeAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // WaitForAttachmentState indicates an expected call of WaitForAttachmentState.
-func (mr *MockCloudMockRecorder) WaitForAttachmentState(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockCloudMockRecorder) WaitForAttachmentState(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAttachmentState", reflect.TypeOf((*MockCloud)(nil).WaitForAttachmentState), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForAttachmentState", reflect.TypeOf((*MockCloud)(nil).WaitForAttachmentState), arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
@@ -153,8 +154,8 @@ func (c *fakeCloudProvider) DetachDisk(ctx context.Context, volumeID, nodeID str
 	return nil
 }
 
-func (c *fakeCloudProvider) WaitForAttachmentState(ctx context.Context, volumeID, state string) error {
-	return nil
+func (c *fakeCloudProvider) WaitForAttachmentState(ctx context.Context, volumeID, expectedState string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*ec2.VolumeAttachment, error) {
+	return nil, nil
 }
 
 func (c *fakeCloudProvider) GetDiskByName(ctx context.Context, name string, capacityBytes int64) (*cloud.Disk, error) {

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -17,11 +17,12 @@ package e2e
 import (
 	"context"
 	"fmt"
-	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
-	k8srestclient "k8s.io/client-go/rest"
 	"math/rand"
 	"os"
 	"strings"
+
+	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
+	k8srestclient "k8s.io/client-go/rest"
 
 	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
@@ -113,7 +114,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 
 	AfterEach(func() {
 		if !skipManuallyDeletingVolume {
-			err := cloud.WaitForAttachmentState(context.Background(), volumeID, "detached")
+			_, err := cloud.WaitForAttachmentState(context.Background(), volumeID, "detached", "", "", false)
 			if err != nil {
 				Fail(fmt.Sprintf("could not detach volume %q: %v", volumeID, err))
 			}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
fixes #389 

**What is this PR about? / Why do we need it?**
the describeInstances API follows an eventual consistency model. the csi driver should handle the fact that it may get inconsistent responses from this API

**What testing is done?** 
manual testing trying to reproduce