### PR TITLE
Don't exit script prematurely if test fails

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -120,8 +120,10 @@ fi
 loudecho "Testing focus ${GINKGO_FOCUS}"
 eval "EXPANDED_TEST_EXTRA_FLAGS=$TEST_EXTRA_FLAGS"
 set -x
+set +e
 ${GINKGO_BIN} -p -nodes="${GINKGO_NODES}" -v --focus="${GINKGO_FOCUS}" --skip="${GINKGO_SKIP}" "${TEST_PATH}" -- -kubeconfig="${KUBECONFIG}" -report-dir="${ARTIFACTS}" -gce-zone="${ZONES%,*}" "${EXPANDED_TEST_EXTRA_FLAGS}"
 TEST_PASSED=$?
+set -e
 set +x
 loudecho "TEST_PASSED: ${TEST_PASSED}"
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**  The logging change I added in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/789 is worthless if the test fails and script exits prematurely. Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-efs-csi-driver/370/pull-aws-efs-csi-driver-e2e/1372684986401951744

(Mixed feelings about bash right now but I don't want to literally go in a circle and revamp the scripts all over again :cry:)

/cc @ayberk

TODO for myself: cherrypick in to efs copy of these scripts.
**What testing is done?** 
