### PR TITLE
fix deploy stable ecr error kustomization file

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -6,15 +6,15 @@ images:
 - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
   newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
   newTag: v0.9.0
-- name: quay.io/k8scsi/csi-provisioner
+- name: k8s.gcr.io/sig-storage/csi-provisioner
   newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
   newTag: v2.0.3-eks-1-18-1
-- name: quay.io/k8scsi/csi-attacher
+- name: k8s.gcr.io/sig-storage/csi-attacher
   newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
   newTag: v3.0.1-eks-1-18-1
-- name: quay.io/k8scsi/livenessprobe
+- name: k8s.gcr.io/sig-storage/livenessprobe
   newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
   newTag: v2.1.0-eks-1-18-1
-- name: quay.io/k8scsi/csi-node-driver-registrar
+- name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
   newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
   newTag: v2.0.1-eks-1-18-1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a bug about ecr deploy error kustomization file

**What is this PR about? / Why do we need it?**
If do not fix this error, we can not deployed with this kustomization file.

**What testing is done?** 
I have tested in my eks cluster.