### PR TITLE
Use the old topology key for e2e tests

### DIFF
--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -51,6 +51,7 @@ func (d *ebsCSIDriver) GetDynamicProvisionStorageClass(parameters map[string]str
 			{
 				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 					{
+						// TODO we should use the new topology key eventually
 						Key:    ebscsidriver.TopologyKey,
 						Values: allowedTopologyValues,
 					},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/bug

**What is this PR about? / Why do we need it?**
e2e tests assumes only one topology key, so checks are hardcoded with the first element of each slice. Due to the recent addition of the well-known label as topology key, these checks might fail based on the ordering of the slice. This PR fixes it.

**What testing is done?** 
Tested on my account and verified it works and does what I expect it to do.