### PR TITLE
AWS EBS CSI Driver Helm chart to inject environment variables

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.9.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.9.14
+version: 0.9.15
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -88,6 +88,12 @@ spec:
             - name: AWS_REGION
               value: {{ .Values.region }}
             {{- end }}
+            {{- if .Values.controller.extraVars }}
+            {{- range $key, $val :=  .Values.controller.extraVars }}
+            - name: {{ $key }}
+              value: "{{ $val }}"
+            {{- end }}
+            {{- end }}
 {{- if .Values.proxy.http_proxy }}
             - name: HTTP_PROXY
               value: {{ .Values.proxy.http_proxy | quote }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -107,6 +107,10 @@ k8sTagClusterId: ""
 # region: us-east-1
 region: ""
 
+# Additonal environment variables for the controller
+controller:
+  extraVars: {}
+
 node:
   priorityClassName: ""
   nodeSelector: {}


### PR DESCRIPTION
Fixes issue #722

Allows setting environment variables in values. For example: 

```
controller:
  extraVars:
    AWS_STS_REGIONAL_ENDPOINTS: regional
```

I need this in order to run in an environment with no internet access

