### PR TITLE
add options to enable aws sdk debug log and add more logs when driver…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 
 	"k8s.io/klog"
@@ -35,6 +34,7 @@ func main() {
 		driver.WithMode(options.DriverMode),
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),
 		driver.WithKubernetesClusterID(options.ControllerOptions.KubernetesClusterID),
+		driver.WithAwsSdkDebugLog(options.ControllerOptions.AwsSdkDebugLog),
 	)
 	if err != nil {
 		klog.Fatalln(err)

--- a/cmd/options/controller_options.go
+++ b/cmd/options/controller_options.go
@@ -33,10 +33,13 @@ type ControllerOptions struct {
 	ExtraVolumeTags map[string]string
 	// ID of the kubernetes cluster.
 	KubernetesClusterID string
+	// flag to enable sdk debug log
+	AwsSdkDebugLog bool
 }
 
 func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.Var(cliflag.NewMapStringString(&s.ExtraTags), "extra-tags", "Extra tags to attach to each dynamically provisioned resource. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.Var(cliflag.NewMapStringString(&s.ExtraVolumeTags), "extra-volume-tags", "DEPRECATED: Please use --extra-tags instead. Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.StringVar(&s.KubernetesClusterID, "k8s-tag-cluster-id", "", "ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).")
+	fs.BoolVar(&s.AwsSdkDebugLog, "aws-sdk-debug-log", false, "To enable the aws sdk debug log level (default to false).")
 }

--- a/cmd/options/controller_options_test.go
+++ b/cmd/options/controller_options_test.go
@@ -38,6 +38,11 @@ func TestControllerOptions(t *testing.T) {
 			found: true,
 		},
 		{
+			name:  "lookup aws-sdk-debug-log",
+			flag:  "aws-sdk-debug-log",
+			found: true,
+		},
+		{
 			name:  "fail for non-desired flag",
 			flag:  "some-other-flag",
 			found: false,

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -46,6 +46,8 @@ func TestGetOptions(t *testing.T) {
 			extraTagKey: extraTagValue,
 		}
 
+		awsSdkDebugFlagName := "aws-sdk-debug-log"
+		awsSdkDebugFlagValue := true
 		VolumeAttachLimitFlagName := "volume-attach-limit"
 		var VolumeAttachLimit int64 = 42
 
@@ -58,6 +60,7 @@ func TestGetOptions(t *testing.T) {
 		}
 		if withControllerOptions {
 			args = append(args, "-"+extraTagsFlagName+"="+extraTagKey+"="+extraTagValue)
+			args = append(args, "-"+awsSdkDebugFlagName+"="+strconv.FormatBool(awsSdkDebugFlagValue))
 		}
 		if withNodeOptions {
 			args = append(args, "-"+VolumeAttachLimitFlagName+"="+strconv.FormatInt(VolumeAttachLimit, 10))
@@ -86,6 +89,13 @@ func TestGetOptions(t *testing.T) {
 			}
 			if !reflect.DeepEqual(options.ControllerOptions.ExtraTags, extraTags) {
 				t.Fatalf("expected extra tags to be %q but it is %q", extraTags, options.ControllerOptions.ExtraTags)
+			}
+			awsDebugLogFlag := flagSet.Lookup(awsSdkDebugFlagName)
+			if awsDebugLogFlag == nil {
+				t.Fatalf("expected %q flag to be added but it is not", awsSdkDebugFlagName)
+			}
+			if options.ControllerOptions.AwsSdkDebugLog != awsSdkDebugFlagValue {
+				t.Fatalf("expected sdk debug flag to be %v but it is %v", awsSdkDebugFlagValue, options.ControllerOptions.AwsSdkDebugLog)
 			}
 		}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -154,6 +154,11 @@ helm upgrade --install aws-ebs-csi-driver \
     --set enableVolumeSnapshot=true \
     aws-ebs-csi-driver/aws-ebs-csi-driver
 ```
+
+#### Deploy driver with debug mode
+To view driver debug logs, run the CSI driver with `-v=5` command line option
+To enable aws sdk debug logs, run the CSI driver with `--aws-sdk-debug-log=true` command line option.
+
 ## Examples
 Make sure you follow the [Prerequisites](README.md#Prerequisites) before the examples:
 * [Dynamic Provisioning](../examples/kubernetes/dynamic-provisioning)

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -68,6 +68,22 @@ func TestCreateDisk(t *testing.T) {
 			expErr: nil,
 		},
 		{
+			name:       "success: normal with gp2 options",
+			volumeName: "vol-test-name",
+			diskOptions: &DiskOptions{
+				CapacityBytes: util.GiBToBytes(1),
+				VolumeType:    VolumeTypeGP2,
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+			},
+			expCreateVolumeInput: &ec2.CreateVolumeInput{},
+			expDisk: &Disk{
+				VolumeID:         "vol-test",
+				CapacityGiB:      1,
+				AvailabilityZone: defaultZone,
+			},
+			expErr: nil,
+		},
+		{
 			name:       "success: normal with io2 options",
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
@@ -530,6 +546,12 @@ func TestAttachDisk(t *testing.T) {
 			volumeID: "vol-test-1234",
 			nodeID:   "node-1234",
 			expErr:   fmt.Errorf(""),
+		},
+		{
+			name:     "fail: AttachVolume returned error volumeInUse",
+			volumeID: "vol-test-1234",
+			nodeID:   "node-1234",
+			expErr:   awserr.New("VolumeInUse", "Volume is in use", nil),
 		},
 	}
 

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -194,7 +194,7 @@ func (d *deviceManager) release(device *Device) error {
 		return fmt.Errorf("release on device %q assigned to different volume: %q vs %q", device.Path, device.VolumeID, existingVolumeID)
 	}
 
-	klog.V(5).Infof("Releasing in-process attachment entry: %v -> volume %s", device.Path, device.VolumeID)
+	klog.V(5).Infof("[Debug] Releasing in-process attachment entry: %v -> volume %s", device.Path, device.VolumeID)
 	d.inFlight.Del(nodeID, name)
 
 	return nil

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -50,8 +50,8 @@ func TestNewControllerService(t *testing.T) {
 		testErr    = errors.New("test error")
 		testRegion = "test-region"
 
-		getNewCloudFunc = func(expectedRegion string) func(region string) (cloud.Cloud, error) {
-			return func(region string) (cloud.Cloud, error) {
+		getNewCloudFunc = func(expectedRegion string, awsSdkDebugLog bool) func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
+			return func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
 				if region != expectedRegion {
 					t.Fatalf("expected region %q but got %q", expectedRegion, region)
 				}
@@ -63,30 +63,30 @@ func TestNewControllerService(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		region                string
-		newCloudFunc          func(string) (cloud.Cloud, error)
+		newCloudFunc          func(string, bool) (cloud.Cloud, error)
 		newMetadataFuncErrors bool
 		expectPanic           bool
 	}{
 		{
 			name:         "AWS_REGION variable set, newCloud does not error",
 			region:       "foo",
-			newCloudFunc: getNewCloudFunc("foo"),
+			newCloudFunc: getNewCloudFunc("foo", false),
 		},
 		{
 			name:   "AWS_REGION variable set, newCloud errors",
 			region: "foo",
-			newCloudFunc: func(region string) (cloud.Cloud, error) {
+			newCloudFunc: func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
 				return nil, testErr
 			},
 			expectPanic: true,
 		},
 		{
 			name:         "AWS_REGION variable not set, newMetadata does not error",
-			newCloudFunc: getNewCloudFunc(testRegion),
+			newCloudFunc: getNewCloudFunc(testRegion, false),
 		},
 		{
 			name:                  "AWS_REGION variable not set, newMetadata errors",
-			newCloudFunc:          getNewCloudFunc(testRegion),
+			newCloudFunc:          getNewCloudFunc(testRegion, false),
 			newMetadataFuncErrors: true,
 			expectPanic:           true,
 		},

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -65,10 +65,11 @@ type DriverOptions struct {
 	mode                Mode
 	volumeAttachLimit   int64
 	kubernetesClusterID string
+	awsSdkDebugLog      bool
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
-	klog.Infof("Driver: %v Version: %v", DriverName, driverVersion)
+	klog.V(4).Infof("Driver: %v Version: %v", DriverName, driverVersion)
 
 	driverOptions := DriverOptions{
 		endpoint: DefaultCSIEndpoint,
@@ -138,12 +139,11 @@ func (d *Driver) Run() error {
 		return fmt.Errorf("unknown mode: %s", d.options.mode)
 	}
 
-	klog.Infof("Listening for connections on address: %#v", listener.Addr())
+	klog.V(4).Infof("Listening for connections on address: %#v", listener.Addr())
 	return d.srv.Serve(listener)
 }
 
 func (d *Driver) Stop() {
-	klog.Infof("Stopping server")
 	d.srv.Stop()
 }
 
@@ -183,5 +183,11 @@ func WithVolumeAttachLimit(volumeAttachLimit int64) func(*DriverOptions) {
 func WithKubernetesClusterID(clusterID string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.kubernetesClusterID = clusterID
+	}
+}
+
+func WithAwsSdkDebugLog(enableSdkDebugLog bool) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.awsSdkDebugLog = enableSdkDebugLog
 	}
 }

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -85,3 +85,12 @@ func TestWithClusterID(t *testing.T) {
 		t.Fatalf("expected kubernetesClusterID option got set to %s but is set to %s", id, options.kubernetesClusterID)
 	}
 }
+
+func TestWithAwsSdkDebugLog(t *testing.T) {
+	var enableSdkDebugLog bool = true
+	options := &DriverOptions{}
+	WithAwsSdkDebugLog(enableSdkDebugLog)(options)
+	if options.awsSdkDebugLog != enableSdkDebugLog {
+		t.Fatalf("expected awsSdkDebugLog option got set to %v but is set to %v", enableSdkDebugLog, options.awsSdkDebugLog)
+	}
+}

--- a/pkg/driver/node_linux.go
+++ b/pkg/driver/node_linux.go
@@ -69,7 +69,7 @@ func findNvmeVolume(findName string) (device string, err error) {
 	stat, err := os.Lstat(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			klog.V(5).Infof("nvme path %q not found", p)
+			klog.V(5).Infof("[Debug] nvme path %q not found", p)
 			return "", fmt.Errorf("nvme path %q not found", p)
 		}
 		return "", fmt.Errorf("error getting stat of %q: %v", p, err)

--- a/pkg/mounter/safe_mounter_windows.go
+++ b/pkg/mounter/safe_mounter_windows.go
@@ -171,7 +171,7 @@ func (mounter *CSIProxyMounter) MakeDir(pathname string) error {
 	}
 	_, err := mounter.FsClient.Mkdir(context.Background(), mkdirReq)
 	if err != nil {
-		klog.Infof("Error: %v", err)
+		klog.V(4).Infof("Error: %v", err)
 		return err
 	}
 

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -366,7 +366,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
-		cloud, err := awscloud.NewCloud(region)
+		cloud, err := awscloud.NewCloud(region, false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -84,7 +84,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region)
+		cloud, err = awscloud.NewCloud(region, false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}


### PR DESCRIPTION
… start up

**Is this a bug fix or adding new feature?**
Fixes #216 
**What is this PR about? / Why do we need it?**
Add a new driver level option -aws-sdk-debug-log, if set to true, aws go sdk will add debug log to the std output.
Sample for debug log
```
2021/04/15 00:41:50 DEBUG: Send Request ec2/DescribeVolumes failed, attempt 0/8, error RequestError: send request failed
caused by: Post "https://ec2.us-west-2.amazonaws.com/": dial tcp 54.240.253.45:443: i/o timeout
2021/04/15 00:41:50 DEBUG: Request ec2/DescribeVolumes Details:
```
Also adjust and update the klog level across driver.
**What testing is done?** 
unit test
e2e test