### PR TITLE
Bump/reconcile sidecar versions in helm/kustomize

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -15,7 +15,7 @@ sidecars:
     tag: "v2.1.1"
   attacherImage:
     repository: k8s.gcr.io/sig-storage/csi-attacher
-    tag: "v3.0.0"
+    tag: "v3.1.0"
   snapshotterImage:
     repository: k8s.gcr.io/sig-storage/csi-snapshotter
     tag: "v3.0.3"
@@ -27,7 +27,7 @@ sidecars:
     tag: "v1.0.0"
   nodeDriverRegistrarImage:
     repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.0.1"
+    tag: "v2.1.0"
 
 snapshotController:
   repository: k8s.gcr.io/sig-storage/snapshot-controller

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,20 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../../base
+  - ../../../base
 images:
-- name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-  newTag: v0.9.0
-- name: k8s.gcr.io/sig-storage/csi-provisioner
-  newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-  newTag: v2.0.3-eks-1-18-1
-- name: k8s.gcr.io/sig-storage/csi-attacher
-  newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-  newTag: v3.0.1-eks-1-18-1
-- name: k8s.gcr.io/sig-storage/livenessprobe
-  newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-  newTag: v2.1.0-eks-1-18-1
-- name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-  newTag: v2.0.1-eks-1-18-1
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
+    newTag: v0.9.0
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.1.1-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-attacher
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+    newTag: v3.1.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newTag: v2.2.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -6,10 +6,10 @@ images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
     newTag: v0.10.1
   - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newTag: v2.0.2
+    newTag: v2.1.1
   - name: k8s.gcr.io/sig-storage/csi-attacher
-    newTag: v3.0.0
+    newTag: v3.1.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
     newTag: v2.2.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.0.1
+    newTag: v2.1.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** sidecar versions are different depending on installation method, fix it.

**What is this PR about? / Why do we need it?**
|||
|-|-| 
|csi-provisioner|v2.1.1| 
|csi-attacher|v3.1.0| 
|livenessprobe|v2.2.0| 
|csi-node-driver-registrar|v2.1.0| 
|csi-snapshotter (helm only https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/797)|v3.0.3|
|csi-resizer (helm only, update overdue, https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/797)|v1.0.0|

**What testing is done?** 

CI will test helm installation.
