### PR TITLE
update IAM policy sample and add new driver level tag

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -4,23 +4,118 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:AttachVolume",
         "ec2:CreateSnapshot",
-        "ec2:CreateTags",
-        "ec2:CreateVolume",
-        "ec2:DeleteSnapshot",
-        "ec2:DeleteTags",
-        "ec2:DeleteVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:ModifyVolume",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications",
-        "ec2:DetachVolume",
-        "ec2:ModifyVolume"
+        "ec2:DescribeVolumesModifications"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/CSIVolumeName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
     }
   ]
 }

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -110,6 +110,8 @@ const (
 	KubernetesTagKeyPrefix = "kubernetes.io"
 	// AWSTagKeyPrefix is the prefix of the key value that is reserved for AWS.
 	AWSTagKeyPrefix = "aws:"
+	//AwsEbsDriverTagKey is the tag to identify if a volume/snapshot is managed by ebs csi driver
+	AwsEbsDriverTagKey = "ebs.csi.aws.com/cluster"
 )
 
 var (

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -57,7 +57,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(1),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 			},
 			expCreateVolumeInput: &ec2.CreateVolumeInput{},
 			expDisk: &Disk{
@@ -72,7 +72,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(1),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO2,
 				IOPSPerGB:     100,
 			},
@@ -91,7 +91,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(1),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeGP3,
 				IOPS:          3000,
 				Throughput:    125,
@@ -111,7 +111,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: expZone,
 			},
 			expDisk: &Disk{
@@ -127,7 +127,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: expZone,
 				Encrypted:        true,
 				KmsKeyID:         "arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
@@ -145,7 +145,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: expZone,
 				OutpostArn:       "arn:aws:outposts:us-west-2:111111111111:outpost/op-0aaa000a0aaaa00a0",
 			},
@@ -163,7 +163,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: expZone,
 			},
 			expDisk: &Disk{
@@ -180,7 +180,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name-error",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: expZone,
 			},
 			expCreateVolumeInput: &ec2.CreateVolumeInput{},
@@ -193,7 +193,7 @@ func TestCreateDisk(t *testing.T) {
 			volState:   "creating",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: "",
 			},
 			expCreateVolumeInput: &ec2.CreateVolumeInput{},
@@ -207,7 +207,7 @@ func TestCreateDisk(t *testing.T) {
 			volState:   "creating",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: "",
 			},
 			cleanUpFailedVolume:  true,
@@ -219,7 +219,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:    util.GiBToBytes(1),
-				Tags:             map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				AvailabilityZone: expZone,
 				SnapshotID:       "snapshot-test",
 			},
@@ -236,7 +236,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:          util.GiBToBytes(4),
-				Tags:                   map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:                   map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:             VolumeTypeIO1,
 				IOPSPerGB:              1,
 				AllowIOPSPerGBIncrease: true,
@@ -256,7 +256,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(4),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO1,
 				IOPSPerGB:     1,
 			},
@@ -273,7 +273,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(4),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO1,
 				IOPSPerGB:     10000,
 			},
@@ -292,7 +292,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(4000),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO1,
 				IOPSPerGB:     10000,
 			},
@@ -311,7 +311,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes:          util.GiBToBytes(4),
-				Tags:                   map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:                   map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:             VolumeTypeIO2,
 				IOPSPerGB:              1,
 				AllowIOPSPerGBIncrease: true,
@@ -331,7 +331,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(4),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO2,
 				IOPSPerGB:     1,
 			},
@@ -348,7 +348,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(4),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO2,
 				IOPSPerGB:     10000,
 			},
@@ -367,7 +367,7 @@ func TestCreateDisk(t *testing.T) {
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{
 				CapacityBytes: util.GiBToBytes(4000),
-				Tags:          map[string]string{VolumeNameTagKey: "vol-test"},
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
 				VolumeType:    VolumeTypeIO2,
 				IOPSPerGB:     100000,
 			},
@@ -799,6 +799,7 @@ func TestCreateSnapshot(t *testing.T) {
 			snapshotOptions: &SnapshotOptions{
 				Tags: map[string]string{
 					SnapshotNameTagKey: "snap-test-name",
+					AwsEbsDriverTagKey: "true",
 					"extra-tag-key":    "extra-tag-value",
 				},
 			},
@@ -812,6 +813,10 @@ func TestCreateSnapshot(t *testing.T) {
 							{
 								Key:   aws.String(SnapshotNameTagKey),
 								Value: aws.String("snap-test-name"),
+							},
+							{
+								Key:   aws.String(AwsEbsDriverTagKey),
+								Value: aws.String("true"),
 							},
 							{
 								Key:   aws.String("extra-tag-key"),
@@ -1094,6 +1099,7 @@ func TestGetSnapshotByName(t *testing.T) {
 			snapshotOptions: &SnapshotOptions{
 				Tags: map[string]string{
 					SnapshotNameTagKey: "snap-test-name",
+					AwsEbsDriverTagKey: "true",
 					"extra-tag-key":    "extra-tag-value",
 				},
 			},
@@ -1149,6 +1155,7 @@ func TestGetSnapshotByID(t *testing.T) {
 			snapshotOptions: &SnapshotOptions{
 				Tags: map[string]string{
 					SnapshotNameTagKey: "snap-test-name",
+					AwsEbsDriverTagKey: "true",
 					"extra-tag-key":    "extra-tag-value",
 				},
 			},

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -54,6 +54,8 @@ var (
 	}
 )
 
+const isManagedByDriver = "true"
+
 // controllerService represents the controller service of CSI driver
 type controllerService struct {
 	cloud         cloud.Cloud
@@ -140,7 +142,8 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		isEncrypted            bool
 		kmsKeyID               string
 		volumeTags             = map[string]string{
-			cloud.VolumeNameTagKey: volName,
+			cloud.VolumeNameTagKey:   volName,
+			cloud.AwsEbsDriverTagKey: isManagedByDriver,
 		}
 	)
 
@@ -497,6 +500,7 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 
 	snapshotTags := map[string]string{
 		cloud.SnapshotNameTagKey: snapshotName,
+		cloud.AwsEbsDriverTagKey: isManagedByDriver,
 	}
 	if d.driverOptions.kubernetesClusterID != "" {
 		resourceLifecycleTag := ResourceLifecycleTagPrefix + d.driverOptions.kubernetesClusterID

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -1320,8 +1320,9 @@ func TestCreateVolume(t *testing.T) {
 				diskOptions := &cloud.DiskOptions{
 					CapacityBytes: stdVolSize,
 					Tags: map[string]string{
-						cloud.VolumeNameTagKey: volumeName,
-						extraVolumeTagKey:      extraVolumeTagValue,
+						cloud.VolumeNameTagKey:   volumeName,
+						cloud.AwsEbsDriverTagKey: "true",
+						extraVolumeTagKey:        extraVolumeTagValue,
 					},
 				}
 
@@ -1381,9 +1382,10 @@ func TestCreateVolume(t *testing.T) {
 				diskOptions := &cloud.DiskOptions{
 					CapacityBytes: stdVolSize,
 					Tags: map[string]string{
-						cloud.VolumeNameTagKey: volumeName,
-						expectedOwnerTag:       expectedOwnerTagValue,
-						expectedNameTag:        expectedNameTagValue,
+						cloud.VolumeNameTagKey:   volumeName,
+						cloud.AwsEbsDriverTagKey: "true",
+						expectedOwnerTag:         expectedOwnerTagValue,
+						expectedNameTag:          expectedNameTagValue,
 					},
 				}
 
@@ -1447,10 +1449,11 @@ func TestCreateVolume(t *testing.T) {
 				diskOptions := &cloud.DiskOptions{
 					CapacityBytes: stdVolSize,
 					Tags: map[string]string{
-						cloud.VolumeNameTagKey:  volumeName,
-						expectedPVCNameTag:      pvcName,
-						expectedPVCNamespaceTag: pvcNamespace,
-						expectedPVNameTag:       pvName,
+						cloud.VolumeNameTagKey:   volumeName,
+						cloud.AwsEbsDriverTagKey: "true",
+						expectedPVCNameTag:       pvcName,
+						expectedPVCNamespaceTag:  pvcNamespace,
+						expectedPVNameTag:        pvName,
 					},
 				}
 
@@ -2021,6 +2024,7 @@ func TestCreateSnapshot(t *testing.T) {
 				snapshotOptions := &cloud.SnapshotOptions{
 					Tags: map[string]string{
 						cloud.SnapshotNameTagKey: snapshotName,
+						cloud.AwsEbsDriverTagKey: "true",
 						expectedOwnerTag:         expectedOwnerTagValue,
 						expectedNameTag:          expectedNameTagValue,
 					},
@@ -2076,6 +2080,7 @@ func TestCreateSnapshot(t *testing.T) {
 				snapshotOptions := &cloud.SnapshotOptions{
 					Tags: map[string]string{
 						cloud.SnapshotNameTagKey: snapshotName,
+						cloud.AwsEbsDriverTagKey: "true",
 						extraVolumeTagKey:        extraVolumeTagValue,
 					},
 				}

--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -50,8 +50,11 @@ func validateExtraTags(tags map[string]string) error {
 		if k == cloud.VolumeNameTagKey {
 			return fmt.Errorf("Tag key '%s' is reserved", cloud.VolumeNameTagKey)
 		}
+		if k == cloud.AwsEbsDriverTagKey {
+			return fmt.Errorf("Tag key '%s' is reserved", cloud.AwsEbsDriverTagKey)
+		}
 		if k == cloud.SnapshotNameTagKey {
-			return fmt.Errorf("Tag key '%s' is reserved", cloud.VolumeNameTagKey)
+			return fmt.Errorf("Tag key '%s' is reserved", cloud.SnapshotNameTagKey)
 		}
 		if strings.HasPrefix(k, cloud.KubernetesTagKeyPrefix) {
 			return fmt.Errorf("Tag key prefix '%s' is reserved", cloud.KubernetesTagKeyPrefix)

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -79,6 +79,13 @@ func TestValidateExtraVolumeTags(t *testing.T) {
 			expErr: fmt.Errorf("Tag key '%s' is reserved", cloud.VolumeNameTagKey),
 		},
 		{
+			name: "invalid tag: reserved driver key",
+			tags: map[string]string{
+				cloud.AwsEbsDriverTagKey: "false",
+			},
+			expErr: fmt.Errorf("Tag key '%s' is reserved", cloud.AwsEbsDriverTagKey),
+		},
+		{
 			name: "invalid tag: reserved Kubernetes key prefix",
 			tags: map[string]string{
 				cloud.KubernetesTagKeyPrefix + "/cluster": "extra-tag-value",

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -81,7 +81,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			CapacityBytes:    defaultDiskSizeBytes,
 			VolumeType:       defaultVoluemType,
 			AvailabilityZone: availabilityZone,
-			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName},
+			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		var err error
 		cloud, err = awscloud.NewCloud(region)
@@ -101,7 +101,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 		pvTestDriver = driver.InitEbsCSIDriver()
 		By(fmt.Sprintf("Successfully provisioned EBS volume: %q\n", volumeID))
 		snapshotOptions := &awscloud.SnapshotOptions{
-			Tags: map[string]string{awscloud.SnapshotNameTagKey: dummySnapshotName},
+			Tags: map[string]string{awscloud.SnapshotNameTagKey: dummySnapshotName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		snapshot, err := cloud.CreateSnapshot(context.Background(), volumeID, snapshotOptions)
 		if err != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fixes #571
**What is this PR about? / Why do we need it?**
Update sample IAM policy to scope down the resource restriction. The sample IAM policy is still open enough to cover all driver use cases, dynamic provisioning/static provisioning/snapshot/volume resizing etc. 
It can be scope down further if above use cases are not apply to your cluster at all. (Like only allow driver to attach/detach the volume created by driver if you are not using static provisioning feature)
Add a new tag  `ebs.csi.aws.com/cluster` to identify all the resources created by driver.
**What testing is done?** 
e2e test/ unit test/ manually test