### PR TITLE
[helm/CSIDriver] Switch to non-deprecated apiVersion

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.10.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 0.10.1
+version: 0.10.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: aws-ebs-csi-driver/templates/csidriver.yaml
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Improvement

**What is this PR about? / Why do we need it?**
In this commit, we switch CSIDriver resources to the latest stable
apiVersion so to surpass warning messages on deploying and also prepare
chart for future k8s version where storage/v1beta1 will be removed.

**What testing is done?** 
Already deployed this change on k8s cluster v1.18+