### PR TITLE
Emit AWS API operation duration/error/throttle metrics

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -67,6 +67,9 @@ spec:
             {{- if .Values.k8sTagClusterId }}
             - --k8s-tag-cluster-id={{ .Values.k8sTagClusterId }}
             {{- end }}
+            {{- if .Values.controller.httpEndpoint }}
+            - --http-endpoint={{ .Values.controller.httpEndpoint }}
+            {{- end }}
             - --logtostderr
             - --v=5
           env:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -109,6 +109,7 @@ region: ""
 
 # Additonal environment variables for the controller
 controller:
+  httpEndpoint: ""
   extraVars: {}
 
 node:

--- a/cmd/options/server_options.go
+++ b/cmd/options/server_options.go
@@ -26,8 +26,11 @@ import (
 type ServerOptions struct {
 	// Endpoint is the endpoint that the driver server should listen on.
 	Endpoint string
+	// HttpEndpoint is the endpoint that the HTTP server for metrics should listen on.
+	HttpEndpoint string
 }
 
 func (s *ServerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.Endpoint, "endpoint", driver.DefaultCSIEndpoint, "Endpoint for the CSI driver server")
+	fs.StringVar(&s.HttpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for metrics will listen (example: `:8080`). The default is empty string, which means the server is disabled.")
 }

--- a/pkg/cloud/aws_metrics.go
+++ b/pkg/cloud/aws_metrics.go
@@ -1,0 +1,74 @@
+// +build !providerless
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	awsAPIMetric = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Name:           "cloudprovider_aws_api_request_duration_seconds",
+			Help:           "Latency of AWS API calls",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"request"})
+
+	awsAPIErrorMetric = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "cloudprovider_aws_api_request_errors",
+			Help:           "AWS API errors",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"request"})
+
+	awsAPIThrottlesMetric = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "cloudprovider_aws_api_throttled_requests_total",
+			Help:           "AWS API throttled requests",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation_name"})
+)
+
+func recordAWSMetric(actionName string, timeTaken float64, err error) {
+	if err != nil {
+		awsAPIErrorMetric.With(metrics.Labels{"request": actionName}).Inc()
+	} else {
+		awsAPIMetric.With(metrics.Labels{"request": actionName}).Observe(timeTaken)
+	}
+}
+
+func recordAWSThrottlesMetric(operation string) {
+	awsAPIThrottlesMetric.With(metrics.Labels{"operation_name": operation}).Inc()
+}
+
+var registerOnce sync.Once
+
+func RegisterMetrics() {
+	registerOnce.Do(func() {
+		legacyregistry.MustRegister(awsAPIMetric)
+		legacyregistry.MustRegister(awsAPIErrorMetric)
+		legacyregistry.MustRegister(awsAPIThrottlesMetric)
+	})
+}

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+
+	"k8s.io/klog"
+)
+
+// RecordRequestsComplete is added to the Complete chain; called after any request
+func RecordRequestsHandler(r *request.Request) {
+	recordAWSMetric(operationName(r), time.Since(r.Time).Seconds(), r.Error)
+}
+
+// RecordThrottlesAfterRetry is added to the AfterRetry chain; called after any error
+func RecordThrottledRequestsHandler(r *request.Request) {
+	if r.IsErrorThrottle() {
+		recordAWSThrottlesMetric(operationName(r))
+		klog.Warningf("Got RequestLimitExceeded error on AWS request (%s)",
+			describeRequest(r))
+	}
+}
+
+// Return the operation name, for use in log messages and metrics
+func operationName(r *request.Request) string {
+	name := "N/A"
+	if r.Operation != nil {
+		name = r.Operation.Name
+	}
+	return name
+}
+
+// Return a user-friendly string describing the request, for use in log messages
+func describeRequest(r *request.Request) string {
+	service := r.ClientInfo.ServiceName
+	return service + "::" + operationName(r)
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** fix https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/806

**What is this PR about? / Why do we need it?** This publishes API metrics equivalent to those that the ebs plugin/aws cloud provider embedded in kube-controller-manager publishes today, like describeinstances/describevolume call durations, error counts, and throttle error counts.

I'm not well-versed in how people intend to consume the metrics so this PR is barebones, for now it just exposes them over port 80 using "k8s.io/component-base/metrics/legacyregistry"

DIFFERENCES between my implementation and the cloud provider one:

- I implement a `Complete` handler and refer to request.Operation.Name when emitting metrics. As opposed to wrapping every call and referring to a custom request name.
  - consequence: instead of emitting e.g. cloudprovider_aws_api_request_duration_seconds_bucket{request="describe_instance" , I emit cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances"
- I use SDK's IsErrorThrottle function to decide whether to emit a throttle metric whereas cloudprovider only treats RequestLimitExceeded as throttles.
  - consequence: I don't think it matters for DescribeVolumes/DescribeInstances.
- I did not change our retry logic. Unlike cloudprovider one that has process-wide retry, ours is per-request. So since the quantity of requests will differ so will the metrics, meaning people will have to adjust their alarms?
  - consequence: hard to say for certain without testing under conditions where lots of api calls fail and need to be retried. But generally I feel safer relying on SDK retry logic.

**What testing is done?** 

kubectl port-forward deployment/ebs-csi-controller 8080:80 -n kube-system

excerpt:
```
# HELP cloudprovider_aws_api_request_duration_seconds [ALPHA] Latency of AWS API calls
# TYPE cloudprovider_aws_api_request_duration_seconds histogram
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.005"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.01"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.025"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.05"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.1"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.25"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="0.5"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="1"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="2.5"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="5"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="10"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeInstances",le="+Inf"} 1
cloudprovider_aws_api_request_duration_seconds_sum{request="DescribeInstances"} 0.204679971
cloudprovider_aws_api_request_duration_seconds_count{request="DescribeInstances"} 1
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.005"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.01"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.025"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.05"} 0
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.1"} 3
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.25"} 4
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="0.5"} 4
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="1"} 4
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="2.5"} 4
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="5"} 4
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="10"} 4
cloudprovider_aws_api_request_duration_seconds_bucket{request="DescribeVolumes",le="+Inf"} 4
cloudprovider_aws_api_request_duration_seconds_sum{request="DescribeVolumes"} 0.35412039799999995
```