### PR TITLE
Fix missing import

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	dm "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/devicemanager"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** not sure how https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/842 passed tests at all but an import is missing.

**What testing is done?** 
