### PR TITLE
Add empty StorageClasses to static example

### DIFF
--- a/examples/kubernetes/static-provisioning/specs/example.yaml
+++ b/examples/kubernetes/static-provisioning/specs/example.yaml
@@ -8,6 +8,7 @@ spec:
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
+  storageClassName: ""
   csi:
     driver: ebs.csi.aws.com
     volumeHandle: vol-05786ec9ec9526b67
@@ -28,6 +29,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  storageClassName: ""
   resources:
     requests:
       storage: 50Gi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** fix from https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/423 . without this change, pvc may bind to default storageclass pv which is NOT intended!

**What testing is done?** 
