### PR TITLE
Add China region ECR for deployment

### DIFF
--- a/deploy/kubernetes/overlays/stable-cn/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-cn/kustomization.yaml
@@ -7,14 +7,14 @@ images:
     newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/aws-ebs-csi-driver
     newTag: v0.10.1
   - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/csi-provisioner
-    newTag: v2.1.1
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.1.1-eks-1-18-3
   - name: k8s.gcr.io/sig-storage/csi-attacher
-    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/csi-attacher
-    newTag: v3.1.0
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+    newTag: v3.1.0-eks-1-18-3
   - name: k8s.gcr.io/sig-storage/livenessprobe
-    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/livenessprobe
-    newTag: v2.2.0
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newTag: v2.2.0-eks-1-18-3
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/csi-node-driver-registrar
-    newTag: v2.1.0
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable-cn/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-cn/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+images:
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/aws-ebs-csi-driver
+    newTag: v0.10.1
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
+    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/csi-provisioner
+    newTag: v2.1.1
+  - name: k8s.gcr.io/sig-storage/csi-attacher
+    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/csi-attacher
+    newTag: v3.1.0
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/livenessprobe
+    newTag: v2.2.0
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newName: 918309763551.dkr.ecr.cn-north-1.amazonaws.com.cn/eks/csi-node-driver-registrar
+    newTag: v2.1.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Fix China region image issue [#743](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/743) [#598](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/598#issuecomment-769589515)

**What is this PR about? / Why do we need it?**
Add kustomization.yaml for China region since the k8s.gcr.io can't be accessed from China.
Also the following deployment guide mentioned in [AWS Knowledge Center](https://aws.amazon.com/cn/premiumsupport/knowledge-center/eks-persistent-storage/) is invalid:
`kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable-cn/?ref=master"`

**What testing is done?** 
Tested in cn-north-1 and the csi driver deployed successfully.