### PR TITLE
Bump back CSIDriver to beta1 version

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1
+apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com


### PR DESCRIPTION
v1 went GA in 1.18. This chart is >= 1.17.
In 1.17 CSIDriver is only available in v1beta1

fixes #887

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
