### PR TITLE
deploy CSIDriver object api version dynamically based on kubeVersion

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1
+apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -1,5 +1,6 @@
 ---
 # Source: aws-ebs-csi-driver/templates/csidriver.yaml
+# v1 is not supported for Kubernetes version < 1.18 Update to v1beta1 if version is not compatible
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:


### PR DESCRIPTION
Is this a bug fix or adding new feature?
Fixes #887
What is this PR about? / Why do we need it?
storage.k8s.io/v1beta1 CSIDriver is deprecated in v1.19+, unavailable in v1.22+;
CSIDriver is general available in storage.k8s.io/v1 since v1.19
Instead of using v1beta1 version for all helm deployment, check the kubeVersion first in helm deployment and use v1 for clusterVersion >=1.19 and v1beta1 for clusterVersion >=1.17 and < 1.19

What testing is done?
Tested in 1.17, 1.18, 1.19 cluster