### PR TITLE
Only initialize the in-cluster kube client when metadata service is actually unavailable

### DIFF
--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -75,15 +75,18 @@ func (m *Metadata) GetOutpostArn() arn.ARN {
 func NewMetadata() (MetadataService, error) {
 	sess := session.Must(session.NewSession(&aws.Config{}))
 	svc := ec2metadata.New(sess)
-	// creates the in-cluster config
-	config, err := rest.InClusterConfig()
-	if err != nil && !svc.Available() {
-		return nil, err
-	}
-	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil && !svc.Available() {
-		return nil, err
+	var clientset *kubernetes.Clientset
+	if !svc.Available() {
+		// creates the in-cluster config
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		// creates the clientset
+		clientset, err = kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, err
+		}
 	}
 	metadataService, err := NewMetadataService(svc, clientset)
 	if err != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Follow-up PR to this previous PR that fixed instance metadata retrieval when the EC2 metadata service is unavailable:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/855

In our cluster configuration, we run this such that an in-cluster configuration is not available, as we do not give these pods a service account. However, the pods do have access to the EC2 metadata service, as we run the pods with `hostNetwork: true`. When the in-cluster configuration is unavailable, this cause a crash at startup that cannot be avoided, even when setting the `AWS_REGION` environment variable. 

Resolves https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/876

**What testing is done?** 

Unit tests all still pass, and integration tests already exist for this code path. Tested and working in a real cluster when deployed without a serviceAccount. 