### PR TITLE
Refactor metadata.go to test that k8s client is initialized iff ec2 metadata is unavailable

### DIFF
--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog"
 )
 
+// Metadata is info about the ec2 instance on which the driver is running
 type Metadata struct {
 	InstanceID       string
 	InstanceType     string
@@ -72,84 +73,58 @@ func (m *Metadata) GetOutpostArn() arn.ARN {
 	return m.OutpostArn
 }
 
-func NewMetadata() (MetadataService, error) {
+type EC2MetadataClient func() (EC2Metadata, error)
+
+var DefaultEC2MetadataClient = func() (EC2Metadata, error) {
 	sess := session.Must(session.NewSession(&aws.Config{}))
 	svc := ec2metadata.New(sess)
-	var clientset *kubernetes.Clientset
-	if !svc.Available() {
-		// creates the in-cluster config
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			return nil, err
-		}
-		// creates the clientset
-		clientset, err = kubernetes.NewForConfig(config)
-		if err != nil {
-			return nil, err
-		}
-	}
-	metadataService, err := NewMetadataService(svc, clientset)
-	if err != nil {
-		return nil, fmt.Errorf("error getting information from metadata service or node object: %w", err)
-	}
-	return metadataService, err
+	return svc, nil
 }
 
-// NewMetadataService returns a new MetadataServiceImplementation.
-func NewMetadataService(svc EC2Metadata, clientset kubernetes.Interface) (MetadataService, error) {
+type KubernetesAPIClient func() (kubernetes.Interface, error)
+
+var DefaultKubernetesAPIClient = func() (kubernetes.Interface, error) {
+	// creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+func NewMetadataService(ec2MetadataClient EC2MetadataClient, k8sAPIClient KubernetesAPIClient) (MetadataService, error) {
+	klog.Infof("retrieving instance data from ec2 metadata")
+	svc, err := ec2MetadataClient()
 	if !svc.Available() {
-		klog.Warningf("EC2 instance metadata is not available")
-		nodeName := os.Getenv("CSI_NODE_NAME")
-		if nodeName == "" {
-			return nil, fmt.Errorf("instance metadata is unavailable and CSI_NODE_NAME env var not set")
-		}
-
-		// get node with k8s API
-		node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		providerID := node.Spec.ProviderID
-		if providerID == "" {
-			return nil, fmt.Errorf("node providerID empty, cannot parse")
-		}
-
-		awsRegionRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9]"
-		awsAvailabilityZoneRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9][a-z]"
-		awsInstanceIDRegex := "i-[a-z0-9]+$"
-
-		re := regexp.MustCompile(awsRegionRegex)
-		region := re.FindString(providerID)
-		if region == "" {
-			return nil, fmt.Errorf("did not find aws region in node providerID string")
-		}
-
-		re = regexp.MustCompile(awsAvailabilityZoneRegex)
-		availabilityZone := re.FindString(providerID)
-		if availabilityZone == "" {
-			return nil, fmt.Errorf("did not find aws availability zone in node providerID string")
-		}
-
-		re = regexp.MustCompile(awsInstanceIDRegex)
-		instanceID := re.FindString(providerID)
-		if instanceID == "" {
-			return nil, fmt.Errorf("did not find aws instance ID in node providerID string")
-		}
-
-		metadata := Metadata{
-			InstanceID:       instanceID,
-			InstanceType:     "", // we have no way to find this, so we leave it empty
-			Region:           region,
-			AvailabilityZone: availabilityZone,
-		}
-
-		return &metadata, nil
+		klog.Warning("ec2 metadata is not available")
+	} else if err != nil {
+		klog.Warningf("error creating ec2 metadata client: %v", err)
+	} else {
+		klog.Infof("ec2 metadata is available")
+		return EC2MetadataInstanceInfo(svc)
 	}
 
+	klog.Infof("retrieving instance data from kubernetes api")
+	clientset, err := k8sAPIClient()
+	if err != nil {
+		klog.Warningf("error creating kubernetes api client: %v", err)
+	} else {
+		klog.Infof("kubernetes api is available")
+		return KubernetesAPIInstanceInfo(clientset)
+	}
+
+	return nil, fmt.Errorf("error getting instance data from ec2 metadata or kubernetes api")
+}
+
+func EC2MetadataInstanceInfo(svc EC2Metadata) (*Metadata, error) {
 	doc, err := svc.GetInstanceIdentityDocument()
 	if err != nil {
-		return nil, fmt.Errorf("could not get EC2 instance identity metadata")
+		return nil, fmt.Errorf("could not get EC2 instance identity metadata: %v", err)
 	}
 
 	if len(doc.InstanceID) == 0 {
@@ -168,6 +143,13 @@ func NewMetadataService(svc EC2Metadata, clientset kubernetes.Interface) (Metada
 		return nil, fmt.Errorf("could not get valid EC2 availability zone")
 	}
 
+	instanceInfo := Metadata{
+		InstanceID:       doc.InstanceID,
+		InstanceType:     doc.InstanceType,
+		Region:           doc.Region,
+		AvailabilityZone: doc.AvailabilityZone,
+	}
+
 	outpostArn, err := svc.GetMetadata(OutpostArnEndpoint)
 	// "outpust-arn" returns 404 for non-outpost instances. note that the request is made to a link-local address.
 	// it's guaranteed to be in the form `arn:<partition>:outposts:<region>:<account>:outpost/<outpost-id>`
@@ -176,23 +158,64 @@ func NewMetadataService(svc EC2Metadata, clientset kubernetes.Interface) (Metada
 		return nil, fmt.Errorf("something went wrong while getting EC2 outpost arn: %s", err.Error())
 	} else if err == nil {
 		klog.Infof("Running in an outpost environment with arn: %s", outpostArn)
+		outpostArn = strings.ReplaceAll(outpostArn, "outpost/", "")
+		parsedArn, err := arn.Parse(outpostArn)
+		if err != nil {
+			klog.Warningf("Failed to parse the outpost arn: %s", outpostArn)
+		} else {
+			klog.Infof("Using outpost arn: %v", parsedArn)
+			instanceInfo.OutpostArn = parsedArn
+		}
 	}
 
-	metadata := Metadata{
-		InstanceID:       doc.InstanceID,
-		InstanceType:     doc.InstanceType,
-		Region:           doc.Region,
-		AvailabilityZone: doc.AvailabilityZone,
+	return &instanceInfo, nil
+}
+
+func KubernetesAPIInstanceInfo(clientset kubernetes.Interface) (*Metadata, error) {
+	nodeName := os.Getenv("CSI_NODE_NAME")
+	if nodeName == "" {
+		return nil, fmt.Errorf("CSI_NODE_NAME env var not set")
 	}
 
-	outpostArn = strings.ReplaceAll(outpostArn, "outpost/", "")
-	parsedArn, err := arn.Parse(outpostArn)
+	// get node with k8s API
+	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		klog.Warningf("Failed to parse the outpost arn: %s", outpostArn)
-	} else {
-		klog.Infof("Using outpost arn: %v", parsedArn)
-		metadata.OutpostArn = parsedArn
+		return nil, fmt.Errorf("error getting Node %v: %v", nodeName, err)
 	}
 
-	return &metadata, nil
+	providerID := node.Spec.ProviderID
+	if providerID == "" {
+		return nil, fmt.Errorf("node providerID empty, cannot parse")
+	}
+
+	awsRegionRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9]"
+	awsAvailabilityZoneRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9][a-z]"
+	awsInstanceIDRegex := "i-[a-z0-9]+$"
+
+	re := regexp.MustCompile(awsRegionRegex)
+	region := re.FindString(providerID)
+	if region == "" {
+		return nil, fmt.Errorf("did not find aws region in node providerID string")
+	}
+
+	re = regexp.MustCompile(awsAvailabilityZoneRegex)
+	availabilityZone := re.FindString(providerID)
+	if availabilityZone == "" {
+		return nil, fmt.Errorf("did not find aws availability zone in node providerID string")
+	}
+
+	re = regexp.MustCompile(awsInstanceIDRegex)
+	instanceID := re.FindString(providerID)
+	if instanceID == "" {
+		return nil, fmt.Errorf("did not find aws instance ID in node providerID string")
+	}
+
+	instanceInfo := Metadata{
+		InstanceID:       instanceID,
+		InstanceType:     "", // we have no way to find this, so we leave it empty
+		Region:           region,
+		AvailabilityZone: availabilityZone,
+	}
+
+	return &instanceInfo, nil
 }

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -66,7 +66,7 @@ type controllerService struct {
 var (
 	// NewMetadataFunc is a variable for the cloud.NewMetadata function that can
 	// be overwritten in unit tests.
-	NewMetadataFunc = cloud.NewMetadata
+	NewMetadataFunc = cloud.NewMetadataService
 	// NewCloudFunc is a variable for the cloud.NewCloud function that can
 	// be overwritten in unit tests.
 	NewCloudFunc = cloud.NewCloud
@@ -78,7 +78,7 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 	region := os.Getenv("AWS_REGION")
 	if region == "" {
 		klog.V(5).Infof("[Debug] Retrieving region from metadata service")
-		metadata, err := NewMetadataFunc()
+		metadata, err := NewMetadataFunc(cloud.DefaultEC2MetadataClient, cloud.DefaultKubernetesAPIClient)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -109,7 +109,7 @@ func TestNewControllerService(t *testing.T) {
 
 				oldNewMetadataFunc := NewMetadataFunc
 				defer func() { NewMetadataFunc = oldNewMetadataFunc }()
-				NewMetadataFunc = func() (cloud.MetadataService, error) {
+				NewMetadataFunc = func(cloud.EC2MetadataClient, cloud.KubernetesAPIClient) (cloud.MetadataService, error) {
 					if tc.newMetadataFuncErrors {
 						return nil, testErr
 					}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -83,7 +83,7 @@ type nodeService struct {
 // it panics if failed to create the service
 func newNodeService(driverOptions *DriverOptions) nodeService {
 	klog.V(5).Infof("[Debug] Retrieving node info from metadata service")
-	metadata, err := cloud.NewMetadata()
+	metadata, err := cloud.NewMetadataService(cloud.DefaultEC2MetadataClient, cloud.DefaultKubernetesAPIClient)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -110,7 +111,7 @@ func newMetadata() (cloud.MetadataService, error) {
 		return nil, err
 	}
 
-	return cloud.NewMetadataService(ec2metadata.New(s), fake.NewSimpleClientset())
+	return cloud.NewMetadataService(func() (cloud.EC2Metadata, error) { return ec2metadata.New(s), nil }, func() (kubernetes.Interface, error) { return fake.NewSimpleClientset(), nil })
 }
 
 func newEC2Client() (*ec2.EC2, error) {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /kind cleanup

**What is this PR about? / Why do we need it?** found in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/897 that it's hard to test whether the k8s client has been initialized or not. in part because NewMetadataService accepts a kubernetes.Interface and you can't check if it's nil.

Refactored NewMetadataService to accept a func that returns a kubernetes.Interface... it's not pretty but should work.

(Also, I removed NewMetadata. Some of this code is hella confusing since we kept the naming of Metadata even though it can be constructed from k8s api now, not just ec2 instance metadata. I stopped short of renaming it, maybe to InstanceInfo or NodeInfo, because I already got  a bit carried away with what is supposed to be a simple refactor, may do it later.)

**What testing is done?** TODO: e2e test on my eks cluster

- [ ] instance metadata enabled (k8s client init should not be attempted, there should be no need to set Node Name env var)
- [ ] instance metadata disabled (k8s client init should be attempted)
