### PR TITLE
Support custom pod labels in Helm chart

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 1.1.0
+version: 1.1.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 1.1.1
+version: 1.2.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         app: ebs-csi-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
+        {{- if .Values.controller.podLabels }}
+        {{- toYaml .Values.controller.podlabels | nindent 8 }}
+        {{- end }}
       {{- if .Values.controller.podAnnotations }}
       annotations:
         {{- toYaml .Values.controller.podAnnotations | nindent 8 }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: ebs-csi-node
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
+        {{- if .Values.node.podLabels }}
+        {{- toYaml .Values.node.podlabels | nindent 8 }}
+        {{- end }}
       {{- with .Values.node.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/aws-ebs-csi-driver/templates/snapshot-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/snapshot-controller.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: ebs-snapshot-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
+        {{- if .Values.snapshotController.podLabels }}
+        {{- toYaml .Values.snapshotController.podlabels | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.snapshot.name }}
       nodeSelector:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -30,6 +30,7 @@ sidecars:
 snapshotController:
   repository: k8s.gcr.io/sig-storage/snapshot-controller
   tag: "v3.0.3"
+  podLabels: {}
 
 proxy:
   http_proxy:
@@ -80,6 +81,7 @@ controller:
   k8sTagClusterId:
   nodeSelector: {}
   podAnnotations: {}
+  podLabels: {}
   priorityClassName:
   # AWS region to use. If not specified then the region will be looked up via the AWS EC2 metadata
   # service.
@@ -134,6 +136,7 @@ node:
   priorityClassName:
   nodeSelector: {}
   podAnnotations: {}
+  podLabels: {}
   tolerateAllTaints: false
   tolerations: []
   resources: {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adds the feature requested in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/904

**What is this PR about? / Why do we need it?**
Many organizations use custom labels for a variety of purposes such as grouping metrics and setting affinity rules for other pods. This feature is also present in most of the stable eks-charts.