### PR TITLE
Add test-e2e-external-eks make rule that tests EKS with pod instance metadata disabled. Remove hostNetwork from DaemonSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test-e2e-external:
 .PHONY: test-e2e-external-eks
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
-	K8S_VERSION="1.19" \
+	K8S_VERSION="1.20" \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b \

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,17 @@ test-e2e-external:
 	GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
 	./hack/e2e/run.sh
 
+.PHONY: test-e2e-external-eks
+test-e2e-external-eks:
+	CLUSTER_TYPE=eksctl \
+	K8S_VERSION="1.19" \
+	AWS_REGION=us-west-2 \
+	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b \
+	TEST_PATH=./tests/e2e-kubernetes/... \
+	GINKGO_FOCUS="External.Storage" \
+	GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
+	./hack/e2e/run.sh
+
 .PHONY: image-release
 image-release:
 	docker build -t $(IMAGE):$(VERSION) . --target debian-base

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ test-e2e-external:
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
 	K8S_VERSION="1.19" \
+	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b \
 	TEST_PATH=./tests/e2e-kubernetes/... \

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -37,7 +37,6 @@ spec:
         {{- with .Values.node.nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      hostNetwork: true
       serviceAccountName: {{ .Values.serviceAccount.node.name }}
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -29,7 +29,6 @@ spec:
                 - fargate
       nodeSelector:
         kubernetes.io/os: linux
-      hostNetwork: true
       serviceAccountName: ebs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:

--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -43,7 +43,9 @@ function eksctl_create_cluster() {
       --dry-run \
       "${CLUSTER_NAME}" > "${CLUSTER_FILE}"
 
-    eksctl_patch_cluster_file "$CLUSTER_FILE" "$EKSCTL_PATCH_FILE"
+    if test -f "$EKSCTL_PATCH_FILE"; then
+      eksctl_patch_cluster_file "$CLUSTER_FILE" "$EKSCTL_PATCH_FILE"
+    fi
 
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${BIN} create cluster -f "${CLUSTER_FILE}" --kubeconfig "${KUBECONFIG}"

--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -20,6 +20,7 @@ function eksctl_create_cluster() {
   K8S_VERSION=${6}
   CLUSTER_FILE=${7}
   KUBECONFIG=${8}
+  EKSCTL_PATCH_FILE=${9}
 
   generate_ssh_key "${SSH_KEY_PATH}"
 
@@ -38,10 +39,11 @@ function eksctl_create_cluster() {
       --nodes=3 \
       --instance-types="${INSTANCE_TYPE}" \
       --version="${K8S_VERSION}" \
+      --disable-pod-imds \
       --dry-run \
       "${CLUSTER_NAME}" > "${CLUSTER_FILE}"
 
-    # TODO implement patching
+    eksctl_patch_cluster_file "$CLUSTER_FILE" "$EKSCTL_PATCH_FILE"
 
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${BIN} create cluster -f "${CLUSTER_FILE}" --kubeconfig "${KUBECONFIG}"
@@ -72,4 +74,24 @@ function eksctl_delete_cluster() {
   CLUSTER_NAME=${2}
   loudecho "Deleting cluster ${CLUSTER_NAME}"
   ${BIN} delete cluster "${CLUSTER_NAME}"
+}
+
+function eksctl_patch_cluster_file() {
+  CLUSTER_FILE=${1}      # input must be yaml
+  EKSCTL_PATCH_FILE=${2} # input must be yaml
+
+  loudecho "Patching cluster $CLUSTER_NAME with $EKSCTL_PATCH_FILE"
+
+  # Temporary intermediate files for patching
+  CLUSTER_FILE_0=$CLUSTER_FILE.0
+  CLUSTER_FILE_1=$CLUSTER_FILE.1
+
+  cp "$CLUSTER_FILE" "$CLUSTER_FILE_0"
+
+  # Patch only the Cluster
+  kubectl patch -f "$CLUSTER_FILE_0" --local --type merge --patch "$(cat "$EKSCTL_PATCH_FILE")" -o yaml > "$CLUSTER_FILE_1"
+  mv "$CLUSTER_FILE_1" "$CLUSTER_FILE_0"
+
+  # Done patching, overwrite original CLUSTER_FILE
+  mv "$CLUSTER_FILE_0" "$CLUSTER_FILE" # output is yaml
 }

--- a/hack/e2e/kops.sh
+++ b/hack/e2e/kops.sh
@@ -46,7 +46,9 @@ function kops_create_cluster() {
       -o json \
       "${CLUSTER_NAME}" > "${CLUSTER_FILE}"
 
-    kops_patch_cluster_file "$CLUSTER_FILE" "$KOPS_PATCH_FILE"
+    if test -f "$KOPS_PATCH_FILE"; then
+      kops_patch_cluster_file "$CLUSTER_FILE" "$KOPS_PATCH_FILE"
+    fi
 
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${BIN} create --state "${KOPS_STATE_FILE}" -f "${CLUSTER_FILE}"

--- a/hack/e2e/kops.sh
+++ b/hack/e2e/kops.sh
@@ -86,10 +86,11 @@ function kops_delete_cluster() {
   ${BIN} delete cluster --name "${CLUSTER_NAME}" --state "${KOPS_STATE_FILE}" --yes
 }
 
-# TODO switch this to python, all this hacking with jq stinks!
+# TODO switch this to python or work exclusively with yaml, all this
+# hacking with jq stinks!
 function kops_patch_cluster_file() {
-  CLUSTER_FILE=${1}
-  KOPS_PATCH_FILE=${2}
+  CLUSTER_FILE=${1}    # input must be json
+  KOPS_PATCH_FILE=${2} # input must be yaml
 
   loudecho "Patching cluster $CLUSTER_NAME with $KOPS_PATCH_FILE"
 
@@ -116,5 +117,5 @@ function kops_patch_cluster_file() {
   mv "$CLUSTER_FILE_1" "$CLUSTER_FILE_0"
 
   # Done patching, overwrite original CLUSTER_FILE
-  mv "$CLUSTER_FILE_0" "$CLUSTER_FILE"
+  mv "$CLUSTER_FILE_0" "$CLUSTER_FILE" # output is yaml
 }

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -138,14 +138,20 @@ fi
 
 loudecho "Deploying driver"
 startSec=$(date +'%s')
-"${HELM_BIN}" upgrade --install "${DRIVER_NAME}" \
-  --namespace kube-system \
-  --set image.repository="${IMAGE_NAME}" \
-  --set image.tag="${IMAGE_TAG}" \
-  -f "${HELM_VALUES_FILE}" \
-  --wait \
-  --kubeconfig "${KUBECONFIG}" \
-  ./charts/"${DRIVER_NAME}"
+
+HELM_ARGS=(upgrade --install "${DRIVER_NAME}"
+  --namespace kube-system
+  --set image.repository="${IMAGE_NAME}"
+  --set image.tag="${IMAGE_TAG}"
+  --wait
+  --kubeconfig "${KUBECONFIG}"
+  ./charts/"${DRIVER_NAME}")
+if test -f "$HELM_VALUES_FILE"; then
+  HELM_ARGS+=(-f "${HELM_VALUES_FILE}")
+fi
+set -x
+"${HELM_BIN}" "${HELM_ARGS[@]}"
+set +x
 
 if [[ -r "${EBS_SNAPSHOT_CRD}" ]]; then
   loudecho "Deploying snapshot CRD"

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -36,7 +36,7 @@ TEST_DIR=${BASE_DIR}/csi-test-artifacts
 BIN_DIR=${TEST_DIR}/bin
 SSH_KEY_PATH=${TEST_DIR}/id_rsa
 CLUSTER_FILE=${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.json
-KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.kubeconfig"}
+KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig"}
 
 REGION=${AWS_REGION:-us-west-2}
 ZONES=${AWS_AVAILABILITY_ZONES:-us-west-2a,us-west-2b,us-west-2c}
@@ -54,6 +54,8 @@ K8S_VERSION=${K8S_VERSION:-1.20.6}
 KOPS_VERSION=${KOPS_VERSION:-1.20.0}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
+
+EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 
 HELM_VALUES_FILE=${HELM_VALUES_FILE:-./hack/values.yaml}
 
@@ -127,7 +129,8 @@ elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
     "$INSTANCE_TYPE" \
     "$K8S_VERSION" \
     "$CLUSTER_FILE" \
-    "$KUBECONFIG"
+    "$KUBECONFIG" \
+    "$EKSCTL_PATCH_FILE"
   if [[ $? -ne 0 ]]; then
     exit 1
   fi

--- a/hack/eksctl-patch.yaml
+++ b/hack/eksctl-patch.yaml
@@ -1,0 +1,9 @@
+iam:
+  vpcResourceControllerPolicy: true
+  withOIDC: true
+  serviceAccounts:
+    - metadata:
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+      wellKnownPolicies:
+        ebsCSIController: true

--- a/hack/values_eksctl.yaml
+++ b/hack/values_eksctl.yaml
@@ -3,3 +3,6 @@ controller:
   logLevel: 5
 node:
   logLevel: 5
+serviceAccount:
+  controller:
+    create: false # let eksctl create it

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog"
 )
 
+// Metadata is info about the ec2 instance on which the driver is running
 type Metadata struct {
 	InstanceID       string
 	InstanceType     string
@@ -72,84 +73,58 @@ func (m *Metadata) GetOutpostArn() arn.ARN {
 	return m.OutpostArn
 }
 
-func NewMetadata() (MetadataService, error) {
+type EC2MetadataClient func() (EC2Metadata, error)
+
+var DefaultEC2MetadataClient = func() (EC2Metadata, error) {
 	sess := session.Must(session.NewSession(&aws.Config{}))
 	svc := ec2metadata.New(sess)
-	var clientset *kubernetes.Clientset
-	if !svc.Available() {
-		// creates the in-cluster config
-		config, err := rest.InClusterConfig()
-		if err != nil {
-			return nil, err
-		}
-		// creates the clientset
-		clientset, err = kubernetes.NewForConfig(config)
-		if err != nil {
-			return nil, err
-		}
-	}
-	metadataService, err := NewMetadataService(svc, clientset)
-	if err != nil {
-		return nil, fmt.Errorf("error getting information from metadata service or node object: %w", err)
-	}
-	return metadataService, err
+	return svc, nil
 }
 
-// NewMetadataService returns a new MetadataServiceImplementation.
-func NewMetadataService(svc EC2Metadata, clientset kubernetes.Interface) (MetadataService, error) {
+type KubernetesAPIClient func() (kubernetes.Interface, error)
+
+var DefaultKubernetesAPIClient = func() (kubernetes.Interface, error) {
+	// creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+func NewMetadataService(ec2MetadataClient EC2MetadataClient, k8sAPIClient KubernetesAPIClient) (MetadataService, error) {
+	klog.Infof("retrieving instance data from ec2 metadata")
+	svc, err := ec2MetadataClient()
 	if !svc.Available() {
-		klog.Warningf("EC2 instance metadata is not available")
-		nodeName := os.Getenv("CSI_NODE_NAME")
-		if nodeName == "" {
-			return nil, fmt.Errorf("instance metadata is unavailable and CSI_NODE_NAME env var not set")
-		}
-
-		// get node with k8s API
-		node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		providerID := node.Spec.ProviderID
-		if providerID == "" {
-			return nil, fmt.Errorf("node providerID empty, cannot parse")
-		}
-
-		awsRegionRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9]"
-		awsAvailabilityZoneRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9][a-z]"
-		awsInstanceIDRegex := "i-[a-z0-9]+$"
-
-		re := regexp.MustCompile(awsRegionRegex)
-		region := re.FindString(providerID)
-		if region == "" {
-			return nil, fmt.Errorf("did not find aws region in node providerID string")
-		}
-
-		re = regexp.MustCompile(awsAvailabilityZoneRegex)
-		availabilityZone := re.FindString(providerID)
-		if availabilityZone == "" {
-			return nil, fmt.Errorf("did not find aws availability zone in node providerID string")
-		}
-
-		re = regexp.MustCompile(awsInstanceIDRegex)
-		instanceID := re.FindString(providerID)
-		if instanceID == "" {
-			return nil, fmt.Errorf("did not find aws instance ID in node providerID string")
-		}
-
-		metadata := Metadata{
-			InstanceID:       instanceID,
-			InstanceType:     "", // we have no way to find this, so we leave it empty
-			Region:           region,
-			AvailabilityZone: availabilityZone,
-		}
-
-		return &metadata, nil
+		klog.Warning("ec2 metadata is not available")
+	} else if err != nil {
+		klog.Warningf("error creating ec2 metadata client: %v", err)
+	} else {
+		klog.Infof("ec2 metadata is available")
+		return EC2MetadataInstanceInfo(svc)
 	}
 
+	klog.Infof("retrieving instance data from kubernetes api")
+	clientset, err := k8sAPIClient()
+	if err != nil {
+		klog.Warningf("error creating kubernetes api client: %v", err)
+	} else {
+		klog.Infof("kubernetes api is available")
+		return KubernetesAPIInstanceInfo(clientset)
+	}
+
+	return nil, fmt.Errorf("error getting instance data from ec2 metadata or kubernetes api")
+}
+
+func EC2MetadataInstanceInfo(svc EC2Metadata) (*Metadata, error) {
 	doc, err := svc.GetInstanceIdentityDocument()
 	if err != nil {
-		return nil, fmt.Errorf("could not get EC2 instance identity metadata")
+		return nil, fmt.Errorf("could not get EC2 instance identity metadata: %v", err)
 	}
 
 	if len(doc.InstanceID) == 0 {
@@ -168,6 +143,13 @@ func NewMetadataService(svc EC2Metadata, clientset kubernetes.Interface) (Metada
 		return nil, fmt.Errorf("could not get valid EC2 availability zone")
 	}
 
+	instanceInfo := Metadata{
+		InstanceID:       doc.InstanceID,
+		InstanceType:     doc.InstanceType,
+		Region:           doc.Region,
+		AvailabilityZone: doc.AvailabilityZone,
+	}
+
 	outpostArn, err := svc.GetMetadata(OutpostArnEndpoint)
 	// "outpust-arn" returns 404 for non-outpost instances. note that the request is made to a link-local address.
 	// it's guaranteed to be in the form `arn:<partition>:outposts:<region>:<account>:outpost/<outpost-id>`
@@ -176,23 +158,64 @@ func NewMetadataService(svc EC2Metadata, clientset kubernetes.Interface) (Metada
 		return nil, fmt.Errorf("something went wrong while getting EC2 outpost arn: %s", err.Error())
 	} else if err == nil {
 		klog.Infof("Running in an outpost environment with arn: %s", outpostArn)
+		outpostArn = strings.ReplaceAll(outpostArn, "outpost/", "")
+		parsedArn, err := arn.Parse(outpostArn)
+		if err != nil {
+			klog.Warningf("Failed to parse the outpost arn: %s", outpostArn)
+		} else {
+			klog.Infof("Using outpost arn: %v", parsedArn)
+			instanceInfo.OutpostArn = parsedArn
+		}
 	}
 
-	metadata := Metadata{
-		InstanceID:       doc.InstanceID,
-		InstanceType:     doc.InstanceType,
-		Region:           doc.Region,
-		AvailabilityZone: doc.AvailabilityZone,
+	return &instanceInfo, nil
+}
+
+func KubernetesAPIInstanceInfo(clientset kubernetes.Interface) (*Metadata, error) {
+	nodeName := os.Getenv("CSI_NODE_NAME")
+	if nodeName == "" {
+		return nil, fmt.Errorf("CSI_NODE_NAME env var not set")
 	}
 
-	outpostArn = strings.ReplaceAll(outpostArn, "outpost/", "")
-	parsedArn, err := arn.Parse(outpostArn)
+	// get node with k8s API
+	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		klog.Warningf("Failed to parse the outpost arn: %s", outpostArn)
-	} else {
-		klog.Infof("Using outpost arn: %v", parsedArn)
-		metadata.OutpostArn = parsedArn
+		return nil, fmt.Errorf("error getting Node %v: %v", nodeName, err)
 	}
 
-	return &metadata, nil
+	providerID := node.Spec.ProviderID
+	if providerID == "" {
+		return nil, fmt.Errorf("node providerID empty, cannot parse")
+	}
+
+	awsRegionRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9]"
+	awsAvailabilityZoneRegex := "([a-z]{2}(-gov)?)-(central|(north|south)?(east|west)?)-[0-9][a-z]"
+	awsInstanceIDRegex := "i-[a-z0-9]+$"
+
+	re := regexp.MustCompile(awsRegionRegex)
+	region := re.FindString(providerID)
+	if region == "" {
+		return nil, fmt.Errorf("did not find aws region in node providerID string")
+	}
+
+	re = regexp.MustCompile(awsAvailabilityZoneRegex)
+	availabilityZone := re.FindString(providerID)
+	if availabilityZone == "" {
+		return nil, fmt.Errorf("did not find aws availability zone in node providerID string")
+	}
+
+	re = regexp.MustCompile(awsInstanceIDRegex)
+	instanceID := re.FindString(providerID)
+	if instanceID == "" {
+		return nil, fmt.Errorf("did not find aws instance ID in node providerID string")
+	}
+
+	instanceInfo := Metadata{
+		InstanceID:       instanceID,
+		InstanceType:     "", // we have no way to find this, so we leave it empty
+		Region:           region,
+		AvailabilityZone: availabilityZone,
+	}
+
+	return &instanceInfo, nil
 }

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -66,7 +66,7 @@ type controllerService struct {
 var (
 	// NewMetadataFunc is a variable for the cloud.NewMetadata function that can
 	// be overwritten in unit tests.
-	NewMetadataFunc = cloud.NewMetadata
+	NewMetadataFunc = cloud.NewMetadataService
 	// NewCloudFunc is a variable for the cloud.NewCloud function that can
 	// be overwritten in unit tests.
 	NewCloudFunc = cloud.NewCloud
@@ -78,7 +78,7 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 	region := os.Getenv("AWS_REGION")
 	if region == "" {
 		klog.V(5).Infof("[Debug] Retrieving region from metadata service")
-		metadata, err := NewMetadataFunc()
+		metadata, err := NewMetadataFunc(cloud.DefaultEC2MetadataClient, cloud.DefaultKubernetesAPIClient)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -109,7 +109,7 @@ func TestNewControllerService(t *testing.T) {
 
 				oldNewMetadataFunc := NewMetadataFunc
 				defer func() { NewMetadataFunc = oldNewMetadataFunc }()
-				NewMetadataFunc = func() (cloud.MetadataService, error) {
+				NewMetadataFunc = func(cloud.EC2MetadataClient, cloud.KubernetesAPIClient) (cloud.MetadataService, error) {
 					if tc.newMetadataFuncErrors {
 						return nil, testErr
 					}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -83,7 +83,7 @@ type nodeService struct {
 // it panics if failed to create the service
 func newNodeService(driverOptions *DriverOptions) nodeService {
 	klog.V(5).Infof("[Debug] Retrieving node info from metadata service")
-	metadata, err := cloud.NewMetadata()
+	metadata, err := cloud.NewMetadataService(cloud.DefaultEC2MetadataClient, cloud.DefaultKubernetesAPIClient)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -110,7 +111,7 @@ func newMetadata() (cloud.MetadataService, error) {
 		return nil, err
 	}
 
-	return cloud.NewMetadataService(ec2metadata.New(s), fake.NewSimpleClientset())
+	return cloud.NewMetadataService(func() (cloud.EC2Metadata, error) { return ec2metadata.New(s), nil }, func() (kubernetes.Interface, error) { return fake.NewSimpleClientset(), nil })
 }
 
 func newEC2Client() (*ec2.EC2, error) {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** test

**What is this PR about? / Why do we need it?** test for the case where instance metadata is disabled for pods. EKS specifically recommends this. In this case, only pods with hostNetwork true will have access to instance metadata.

To create the environment, use eksctl --disable-pod-imds.

The expected behavior is that in lieu of instance metadata
- the controller: should get credentials from IAM for SA. This gets configured via eksctl. 
- the node: should get instance info from k8s API. This gets configured by our helm chart. The node should NOT need hostNetwork true anymore because the sole reason that was there was so it could bypass `disable-pod-imds` to touch instance metadata.

TODO for future:
a  test case where instance metadata is totally disabled on instances, not just for pods. hostNetwork is now false for both controller and node, so whether instance metadata is available on host or not should make no difference , but an extra test case won't hurt.


**What testing is done?** 
