### PR TITLE
helm chart configurable log verbosity

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -74,7 +74,7 @@ spec:
             - --http-endpoint={{ . }}
             {{- end }}
             - --logtostderr
-            - --v=2
+            - --v={{ .Values.controller.logLevel }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -62,7 +62,7 @@ spec:
             - --volume-attach-limit={{ . }}
             {{- end }}
             - --logtostderr
-            - --v=2
+            - --v={{ .Values.node.logLevel }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -78,6 +78,7 @@ controller:
   httpEndpoint:
   # ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).
   k8sTagClusterId:
+  logLevel: 2
   nodeSelector: {}
   podAnnotations: {}
   priorityClassName:
@@ -121,7 +122,6 @@ controller:
   #    whenUnsatisfiable: ScheduleAnyway
   topologySpreadConstraints: []
 
-
 # Moving to values under node
 # The "maximum number of attachable volumes" per node
 volumeAttachLimit:
@@ -131,6 +131,7 @@ node:
     ebsPlugin: []
     nodeDriverRegistrar: []
   kubeletPath: /var/lib/kubelet
+  logLevel: 2
   priorityClassName:
   nodeSelector: {}
   podAnnotations: {}

--- a/hack/values.yaml
+++ b/hack/values.yaml
@@ -1,1 +1,6 @@
 enableVolumeSnapshot: true
+controller:
+  logLevel: 5
+node:
+  logLevel: 5
+


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** I reduced to 2 in a recent PR but that was lazy, it is useful to be configurable especially for our CI. 

copied from efs. https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/charts/aws-efs-csi-driver/values.yaml#L43

**What testing is done?**  ~~ will check PR CI results to see if logLevel: 5 actually took effect.~~ logLevel: 5 works
