### PR TITLE
add custom useragent suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VERSION=v1.0.0
 VERSION_AMAZONLINUX=$(VERSION)-amazonlinux
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 GO111MODULE=on
 GOPROXY=direct
 GOPATH=$(shell go env GOPATH)

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -153,6 +153,9 @@ var (
 	VolumeNotBeingModified = fmt.Errorf("volume is not being modified")
 )
 
+// Set during build time via -ldflags
+var driverVersion string
+
 // Disk represents a EBS volume
 type Disk struct {
 	VolumeID         string
@@ -238,6 +241,9 @@ func newEC2Cloud(region string, awsSdkDebugLog bool) (Cloud, error) {
 	if awsSdkDebugLog {
 		awsConfig.WithLogLevel(aws.LogDebugWithRequestErrors)
 	}
+
+	// Set the env var so that the session appends custom user agent string
+	os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion)
 
 	svc := ec2.New(session.Must(session.NewSession(awsConfig)))
 	svc.Handlers.AfterRetry.PushFrontNamed(request.NamedHandler{


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
new feature

**What is this PR about? / Why do we need it?**
modifies the aws sdk client's useragent string to differentiate the ebs csi driver's requests

**What testing is done?** 
turned on debug logs and confirmed that user agent had new string appended