### PR TITLE
Disable uuid checks on XFS

### DIFF
--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -613,7 +613,7 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 		},
 		{
-			name: "success fstype",
+			name: "success fstype xfs",
 			testFunc: func(t *testing.T) {
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -628,7 +628,7 @@ func TestNodePublishVolume(t *testing.T) {
 				}
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
-				mockMounter.EXPECT().Mount(gomock.Eq(stagingTargetPath), gomock.Eq(targetPath), gomock.Eq(FSTypeXfs), gomock.Eq([]string{"bind"})).Return(nil)
+				mockMounter.EXPECT().Mount(gomock.Eq(stagingTargetPath), gomock.Eq(targetPath), gomock.Eq(FSTypeXfs), gomock.Eq([]string{"bind", "nouuid"})).Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bugfix

**What is this PR about? / Why do we need it?**
By default, XFS does not allow mounting two devices that have the same UUID of the XFS filesystem. As result, it's not possible to mount a volume + its restored snapshot.

Therefore disable UUID check in XFS using a mount option.

**What testing is done?** 
Tested with https://github.com/kubernetes/kubernetes/pull/102538