### PR TITLE
Skip volume expansion if block node

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -433,9 +433,16 @@ func (d *controllerService) ControllerExpandVolume(ctx context.Context, req *csi
 		return nil, status.Errorf(codes.Internal, "Could not resize volume %q: %v", volumeID, err)
 	}
 
+	nodeExpansionRequired := true
+	// if this is a raw block device, no expansion should be necessary on the node
+	cap := req.GetVolumeCapability()
+	if cap != nil && cap.GetBlock() != nil {
+		nodeExpansionRequired = false
+	}
+
 	return &csi.ControllerExpandVolumeResponse{
 		CapacityBytes:         util.GiBToBytes(actualSizeGiB),
-		NodeExpansionRequired: true,
+		NodeExpansionRequired: nodeExpansionRequired,
 	}, nil
 }
 


### PR DESCRIPTION
No expansion on the node should be necessary if device is of type raw block

