### PR TITLE
Fix podLabels case in Helm chart

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 1.2.1
+version: 1.2.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -17,7 +17,7 @@ spec:
         app: ebs-csi-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
-        {{- toYaml .Values.controller.podlabels | nindent 8 }}
+        {{- toYaml .Values.controller.podLabels | nindent 8 }}
         {{- end }}
       {{- if .Values.controller.podAnnotations }}
       annotations:

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -16,7 +16,7 @@ spec:
         app: ebs-csi-node
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.node.podLabels }}
-        {{- toYaml .Values.node.podlabels | nindent 8 }}
+        {{- toYaml .Values.node.podLabels | nindent 8 }}
         {{- end }}
       {{- with .Values.node.podAnnotations }}
       annotations:

--- a/charts/aws-ebs-csi-driver/templates/snapshot-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/snapshot-controller.yaml
@@ -19,7 +19,7 @@ spec:
         app: ebs-snapshot-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
         {{- if .Values.snapshotController.podLabels }}
-        {{- toYaml .Values.snapshotController.podlabels | nindent 8 }}
+        {{- toYaml .Values.snapshotController.podLabels | nindent 8 }}
         {{- end }}
       {{- if .Values.snapshotController.podAnnotations }}
       annotations: {{ toYaml .Values.snapshotController.podAnnotations | nindent 8 }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix.

**What is this PR about? / Why do we need it?**
This fixes the bug introduced in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/905 where `podLabels` did not have consistent case throughout the Helm chart.

**What testing is done?** 
`helm template` was successfully evaluated when `podLabels` was set for all three pod types.