### PR TITLE
Add migration upgrade/downgrade test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ test-sanity:
 test-e2e-single-az:
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
 	TEST_PATH=./tests/e2e/... \
 	GINKGO_FOCUS="\[ebs-csi-e2e\] \[single-az\]" \
 	GINKGO_SKIP="\"sc1\"|\"st1\"" \
@@ -86,6 +87,7 @@ test-e2e-single-az:
 test-e2e-multi-az:
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
 	TEST_PATH=./tests/e2e/... \
 	GINKGO_FOCUS="\[ebs-csi-e2e\] \[multi-az\]" \
 	./hack/e2e/run.sh
@@ -94,6 +96,7 @@ test-e2e-multi-az:
 test-e2e-migration:
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
 	TEST_PATH=./tests/e2e-kubernetes/... \
 	GINKGO_FOCUS="\[ebs-csi-migration\]" \
 	EBS_CHECK_MIGRATION=true \
@@ -103,6 +106,7 @@ test-e2e-migration:
 test-e2e-external:
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
 	TEST_PATH=./tests/e2e-kubernetes/... \
 	GINKGO_FOCUS="External.Storage" \
 	GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
@@ -113,6 +117,7 @@ test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \
 	K8S_VERSION="1.20" \
 	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
 	EKSCTL_ADMIN_ROLE="Infra-prod-KopsDeleteAllLambdaServiceRoleF1578477-1ELDFIB4KCMXV" \
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b \

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -61,6 +61,7 @@ EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
 
 HELM_VALUES_FILE=${HELM_VALUES_FILE:-./hack/values.yaml}
+HELM_EXTRA_FLAGS=${HELM_EXTRA_FLAGS:-}
 
 TEST_PATH=${TEST_PATH:-"./tests/e2e/..."}
 ARTIFACTS=${ARTIFACTS:-"${TEST_DIR}/artifacts"}
@@ -155,8 +156,9 @@ HELM_ARGS=(upgrade --install "${DRIVER_NAME}"
 if test -f "$HELM_VALUES_FILE"; then
   HELM_ARGS+=(-f "${HELM_VALUES_FILE}")
 fi
+eval "EXPANDED_HELM_EXTRA_FLAGS=$HELM_EXTRA_FLAGS"
 set -x
-"${HELM_BIN}" "${HELM_ARGS[@]}"
+"${HELM_BIN}" "${HELM_ARGS[@]}" "${EXPANDED_HELM_EXTRA_FLAGS}"
 set +x
 
 if [[ -r "${EBS_SNAPSHOT_CRD}" ]]; then

--- a/hack/values.yaml
+++ b/hack/values.yaml
@@ -1,6 +1,5 @@
 enableVolumeSnapshot: true
 controller:
-  k8sTagClusterId: test
   logLevel: 5
 node:
   logLevel: 5

--- a/tests/e2e-upgrade/README.md
+++ b/tests/e2e-upgrade/README.md
@@ -1,0 +1,1 @@
+Test the AWS EBS CSI driver before/during/after the CSIMigration and CSIMigrationAWS features are enabled/disabled. For details see (https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/625-csi-migration#upgradedowngradeskew-testing)

--- a/tests/e2e-upgrade/e2e_test.go
+++ b/tests/e2e-upgrade/e2e_test.go
@@ -1,0 +1,394 @@
+package e2e_upgrade
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/homedir"
+	"k8s.io/kubernetes/test/e2e/framework"
+	frameworkconfig "k8s.io/kubernetes/test/e2e/framework/config"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var (
+	kopsBinaryPath  = flag.String("binary", "kops", "")
+	kopsStateStore  = flag.String("state", "s3://k8s-kops-csi-e2e", "")
+	kopsClusterName = flag.String("name", "", "")
+)
+
+// TestKopsMigration tests the configurations described here:
+// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/csi-migration.md#upgradedowngradeskew-testing
+func TestKopsMigration(t *testing.T) {
+	RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "TestKopsMigration")
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+
+	testing.Init()
+	frameworkconfig.CopyFlags(frameworkconfig.Flags, flag.CommandLine)
+	framework.RegisterCommonFlags(flag.CommandLine)
+	framework.RegisterClusterFlags(flag.CommandLine)
+
+	flag.Parse()
+
+	if home := homedir.HomeDir(); home != "" && framework.TestContext.KubeConfig == "" {
+		framework.TestContext.KubeConfig = filepath.Join(home, ".kube", "config")
+	}
+	framework.AfterReadingAllFlags(&framework.TestContext)
+
+	ginkgo.Describe("Kops", func() {
+		var (
+			k         *kops
+			clientset *kubernetes.Clientset
+			f         *framework.Framework
+		)
+		k = &kops{*kopsBinaryPath, *kopsStateStore, *kopsClusterName}
+		var err error
+		clientset, err = k.exportKubecfg(framework.TestContext.KubeConfig)
+		if err != nil {
+			panic(err)
+		}
+		f = framework.NewFramework("kops-migrate", framework.Options{}, clientset)
+
+		ginkgo.It("should call csi plugin for all operations after migration toggled on", func() {
+			migrationOn := false
+			toggleMigration(k, migrationOn)
+			_, inTreePVC, _ := createAndVerify(k, migrationOn, f, nil)
+			// Don't deleteAndVerify, the other test covers it. The inTreePod will
+			// get evicted & deleted as part of the following toggle
+
+			migrationOn = true
+			toggleMigration(k, migrationOn)
+			csiPod, csiPVC, csiPV := createAndVerify(k, migrationOn, f, inTreePVC)
+			deleteAndVerify(f, migrationOn, csiPod, csiPVC, csiPV)
+		})
+
+		ginkgo.It("should call in-tree plugin for all operations after migration toggled off", func() {
+			migrationOn := true
+			toggleMigration(k, migrationOn)
+			_, csiPVC, _ := createAndVerify(k, migrationOn, f, nil)
+			// Don't deleteAndVerify, the other test covers it. The csiPod will
+			// get evicted & deleted as part of the following toggle
+
+			migrationOn = false
+			toggleMigration(k, migrationOn)
+			inTreePod, inTreePVC, inTreePV := createAndVerify(k, migrationOn, f, csiPVC)
+			deleteAndVerify(f, migrationOn, inTreePod, inTreePVC, inTreePV)
+		})
+
+		/*
+			ginkgo.It("should call in-tree plugin for attach & mount and csi plugin for provision after kube-controller-manager migration toggled on and kubelet migration toggled off", func() {
+				// TODO
+			})
+		*/
+	})
+}
+
+var (
+	csiVerifier = verifier{
+		name:        "csi",
+		provisioner: "ebs.csi.aws.com",
+		plugin:      "kubernetes.io/csi/ebs.csi.aws.com",
+	}
+	inTreeVerifier = verifier{
+		name:        "in-tree",
+		provisioner: "kubernetes.io/aws-ebs",
+		plugin:      "kubernetes.io/aws-ebs",
+	}
+)
+
+func toggleMigration(k *kops, migrationOn bool) {
+	var step string
+	var err error
+	if migrationOn {
+		step = "Toggling kube-controller-manager migration ON"
+		ginkgo.By(step)
+		err = k.toggleMigration("kubeControllerManager", migrationOn)
+		framework.ExpectNoError(err, step)
+
+		step = "Toggling kubelet migration ON"
+		ginkgo.By(step)
+		err = k.toggleMigration("kubelet", migrationOn)
+		framework.ExpectNoError(err, step)
+	} else {
+		step = "Toggling kubelet migration OFF"
+		ginkgo.By(step)
+		err = k.toggleMigration("kubelet", migrationOn)
+		framework.ExpectNoError(err, step)
+
+		step = "Toggling kube-controller-manager migration OFF"
+		ginkgo.By(step)
+		err = k.toggleMigration("kubeControllerManager", migrationOn)
+		framework.ExpectNoError(err, step)
+	}
+}
+
+// createAndVerify creates a pod + pvc and verifies that csi/in-tree does
+// operations according to whether migrationOn is true/false. optionally
+// accepts a preTogglePVC to verify the same for a pvc that already existed
+// prior to migration being toggled on/off
+func createAndVerify(k *kops, migrationOn bool, f *framework.Framework, preTogglePVC *v1.PersistentVolumeClaim) (*v1.Pod, *v1.PersistentVolumeClaim, *v1.PersistentVolume) {
+	var step string
+	var err error
+	var v *verifier
+	if migrationOn {
+		v = &csiVerifier
+	} else {
+		v = &inTreeVerifier
+	}
+
+	clientset, err := k.exportKubecfg(framework.TestContext.KubeConfig)
+	f.ClientSet = clientset
+
+	if preTogglePVC != nil {
+		step = "Creating post-toggle Pod using pre-toggle PVC"
+		ginkgo.By(step)
+		extraPod, _, preTogglePV, err := createPodPVC(f, preTogglePVC)
+		framework.ExpectNoError(err, step)
+
+		step = fmt.Sprintf("Verifying pre-toggle PV %q got re-attached by %s", preTogglePV.Name, v.name)
+		ginkgo.By(step)
+		err = v.verifyAttach(f, preTogglePV)
+		framework.ExpectNoError(err, step)
+
+		step = fmt.Sprintf("Verifying pre-toggle PV %q got re-mounted by %s", preTogglePV.Name, v.name)
+		ginkgo.By(step)
+		err = v.verifyMount(f, preTogglePV, extraPod.Spec.NodeName)
+		framework.ExpectNoError(err, step)
+
+		step = fmt.Sprintf("Deleting pod %q", extraPod.Name)
+		ginkgo.By(step)
+		err = e2epod.DeletePodWithWait(f.ClientSet, extraPod)
+		framework.ExpectNoError(err, step)
+	}
+
+	step = "Creating post-toggle Pod using post-toggle PVC"
+	ginkgo.By(step)
+	pod, pvc, pv, err := createPodPVC(f, nil)
+	framework.ExpectNoError(err, step)
+
+	step = fmt.Sprintf("Verifying post-toggle PV %q got attached by %s", pv.Name, v.name)
+	ginkgo.By(step)
+	err = v.verifyAttach(f, pv)
+	framework.ExpectNoError(err, step)
+
+	step = fmt.Sprintf("Verifying post-toggle PV %q got mounted by %s", pv.Name, v.name)
+	ginkgo.By(step)
+	err = v.verifyMount(f, pv, pod.Spec.NodeName)
+	framework.ExpectNoError(err, step)
+
+	return pod, pvc, pv
+}
+
+// deleteAndVerify deletes a pod + pvc and verifies that csi/in-tree does
+// operations according to whether migrationOn is true/false
+func deleteAndVerify(f *framework.Framework, migrationOn bool, pod *v1.Pod, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
+	var step string
+	var err error
+	var v *verifier
+	if migrationOn {
+		v = &csiVerifier
+	} else {
+		v = &inTreeVerifier
+	}
+
+	step = fmt.Sprintf("Deleting Pod %q", pod.Name)
+	ginkgo.By(step)
+	err = e2epod.DeletePodWithWait(f.ClientSet, pod)
+	framework.ExpectNoError(err, step)
+
+	step = fmt.Sprintf("Deleting PVC %q", pvc.Name)
+	ginkgo.By(step)
+	err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+	framework.ExpectNoError(err, step)
+
+	step = fmt.Sprintf("Waiting for PV %q to be deleted", pv.Name)
+	ginkgo.By(step)
+	err = f.ClientSet.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(context.TODO(), pvc.Name, metav1.DeleteOptions{})
+	err = e2epv.WaitForPersistentVolumeDeleted(f.ClientSet, pvc.Spec.VolumeName, 30*time.Second, 2*time.Minute)
+	framework.ExpectNoError(err, step)
+
+	step = fmt.Sprintf("Verifying PV %q got unmounted by %s", pv.Name, v.name)
+	ginkgo.By(step)
+	err = v.verifyUnmount(f, pv, pod.Spec.NodeName)
+	framework.ExpectNoError(err, step)
+
+	step = fmt.Sprintf("Verifying PV %q got detached by %s", pv.Name, v.name)
+	ginkgo.By(step)
+	err = v.verifyDetach(f, pv)
+	framework.ExpectNoError(err, step)
+}
+
+func createPodPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim) (*v1.Pod, *v1.PersistentVolumeClaim, *v1.PersistentVolume, error) {
+	clientset := f.ClientSet
+	ns := f.Namespace.Name
+	var err error
+
+	if pvc == nil {
+		pvc = &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: f.BaseName,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+		pvc, err = clientset.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), pvc, metav1.CreateOptions{})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	pod := e2epod.MakePod(ns, nil, []*v1.PersistentVolumeClaim{pvc}, false, "")
+	pod, err = clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	err = e2epod.WaitForPodNameRunningInNamespace(clientset, pod.Name, ns)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pod, err = clientset.CoreV1().Pods(ns).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pvc, err = clientset.CoreV1().PersistentVolumeClaims(ns).Get(context.TODO(), pvc.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pv, err := clientset.CoreV1().PersistentVolumes().Get(context.TODO(), pvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return pod, pvc, pv, nil
+}
+
+type verifier struct {
+	name        string
+	provisioner string
+	plugin      string
+}
+
+/*
+func (v *verifier) verifyProvision(pv *v1.PersistentVolume) error {
+	provisionedBy, ok := pv.Annotations["pv.kubernetes.io/provisioned-by"]
+	if !ok {
+		return errors.New("provisioned-by annotation missing")
+	} else if provisionedBy != v.provisioner {
+		return fmt.Errorf("provisioned-by annotation is %q but expected %q", provisionedBy, v.provisioner)
+	}
+	return nil
+}
+
+// TODO verifyProvision/verifyDelete: check csi pod logs or kcm logs, relying on provisioned-by will break soon https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/104
+*/
+
+func (v *verifier) verifyAttach(f *framework.Framework, pv *v1.PersistentVolume) error {
+	re := regexp.MustCompile(fmt.Sprintf("AttachVolume.Attach.*%s.*%s", v.plugin, volumeID(pv)))
+	return findKubeControllerManagerLogs(f.ClientSet, re)
+}
+
+func (v *verifier) verifyDetach(f *framework.Framework, pv *v1.PersistentVolume) error {
+	re := regexp.MustCompile(fmt.Sprintf("DetachVolume.Detach.*%s.*%s", v.plugin, volumeID(pv)))
+	return findKubeControllerManagerLogs(f.ClientSet, re)
+}
+
+func (v *verifier) verifyMount(f *framework.Framework, pv *v1.PersistentVolume, nodeName string) error {
+	re := regexp.MustCompile(fmt.Sprintf("MountVolume.Mount.*%s.*%s", v.plugin, volumeID(pv)))
+	return findKubeletLogs(f, nodeName, re)
+}
+
+func (v *verifier) verifyUnmount(f *framework.Framework, pv *v1.PersistentVolume, nodeName string) error {
+	re := regexp.MustCompile(fmt.Sprintf("UnmountVolume.TearDown.*%s.*%s", v.plugin, volumeID(pv)))
+	return findKubeletLogs(f, nodeName, re)
+}
+
+func volumeID(pv *v1.PersistentVolume) string {
+	segments := strings.Split(pv.Spec.AWSElasticBlockStore.VolumeID, "/")
+	return segments[len(segments)-1]
+}
+
+func findKubeletLogs(f *framework.Framework, nodeName string, re *regexp.Regexp) error {
+	logs, err := kubeletLogs(f, nodeName)
+	if err != nil {
+		return fmt.Errorf("error getting kubelet logs: %v", err)
+	}
+	match := re.FindString(logs)
+	if match == "" {
+		return fmt.Errorf("regexp %q not found", re)
+	}
+	return nil
+}
+
+func findKubeControllerManagerLogs(clientset kubernetes.Interface, re *regexp.Regexp) error {
+	logs, err := kubeControllerManagerLogs(clientset)
+	if err != nil {
+		return fmt.Errorf("error getting kube-controller-manager logs: %v", err)
+	}
+	match := re.FindString(logs)
+	if match == "" {
+		return fmt.Errorf("regexp %q not found", re)
+	}
+	return nil
+}
+
+func kubeletLogs(f *framework.Framework, nodeName string) (string, error) {
+	hostExec := utils.NewHostExec(f)
+	node, err := f.ClientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	logs, err := hostExec.IssueCommandWithResult("journalctl -u kubelet", node)
+	if err != nil {
+		return "", err
+	}
+	return logs, nil
+}
+
+func kubeControllerManagerLogs(clientset kubernetes.Interface) (string, error) {
+	return podLogs(clientset, "kube-controller-manager")
+}
+
+func podLogs(clientset kubernetes.Interface, podNamePrefix string) (string, error) {
+	pods, err := clientset.CoreV1().Pods(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, pod := range pods.Items {
+		if strings.HasPrefix(pod.Name, podNamePrefix) {
+			body, err := clientset.CoreV1().Pods(metav1.NamespaceSystem).GetLogs(pod.Name, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
+			if err != nil {
+				return "", err
+			}
+			return string(body), nil
+		}
+	}
+	return "", fmt.Errorf("%q pod not found", podNamePrefix)
+}

--- a/tests/e2e-upgrade/kops.go
+++ b/tests/e2e-upgrade/kops.go
@@ -1,0 +1,170 @@
+package e2e_upgrade
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type kops struct {
+	kopsBinaryPath  string
+	kopsStateStore  string
+	kopsClusterName string
+}
+
+func (k *kops) commandQuiet(args ...string) *exec.Cmd {
+	args = append(args, "--state", k.kopsStateStore, "--name", k.kopsClusterName)
+	cmd := exec.Command(k.kopsBinaryPath, args...)
+	log.Print(cmd.String())
+	return cmd
+}
+
+func (k *kops) command(args ...string) *exec.Cmd {
+	cmd := k.commandQuiet(args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+func (k *kops) getCluster() (*unstructured.Unstructured, error) {
+	cmd := k.commandQuiet(
+		"get",
+		"cluster",
+		"-o",
+		"json",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("out: %v, err: %v", string(out), err)
+	}
+
+	// kops client/API takes a long time to compile so settle for kops cli and unstructured
+	cluster := new(unstructured.Unstructured)
+	_, _, err = unstructured.UnstructuredJSONScheme.Decode(out, nil, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+// similar to kubetest2 code
+// https://github.com/kubernetes/kops/tree/master/tests/e2e/kubetest2-kops/deployer
+func (k *kops) updateCluster(cluster *unstructured.Unstructured) error {
+	tmpfile, err := ioutil.TempFile("", "cluster")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = unstructured.UnstructuredJSONScheme.Encode(cluster, tmpfile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cmd := k.command(
+		"replace",
+		"-f",
+		tmpfile.Name(),
+	)
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	cmd = k.command(
+		"update",
+		"cluster",
+		"--yes",
+	)
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	cmd = k.command(
+		"rolling-update",
+		"cluster",
+		"--yes",
+	)
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *kops) exportKubecfg(kubeconfig string) (*kubernetes.Clientset, error) {
+	cmd := k.command(
+		"export",
+		"kubecfg",
+		"--admin",
+		"--kubeconfig",
+		kubeconfig,
+	)
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+func (k *kops) setFeatureGate(cluster *unstructured.Unstructured, component, featureGate string, on bool) (*unstructured.Unstructured, error) {
+	featureGates, found, err := unstructured.NestedMap(cluster.Object, "spec", component, "featureGates")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		featureGates = make(map[string]interface{})
+	}
+
+	featureGates[featureGate] = strconv.FormatBool(on)
+
+	err = unstructured.SetNestedMap(cluster.Object, featureGates, "spec", component, "featureGates")
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+func (k *kops) toggleMigration(component string, on bool) error {
+	cluster, err := k.getCluster()
+	if err != nil {
+		return err
+	}
+
+	cluster, err = k.setFeatureGate(cluster, component, "CSIMigration", on)
+	if err != nil {
+		return err
+	}
+
+	cluster, err = k.setFeatureGate(cluster, component, "CSIMigrationAWS", on)
+	if err != nil {
+		return err
+	}
+
+	err = k.updateCluster(cluster)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/920. Need to make sure toggling migration on/off works correctly.

For kops, toggling is easy by editing the cluster spec, that's what this test does
For EKS, ATM it's impossible to get a cluster with migration enabled in the first place.

**What testing is done?** 
I am testing it locally.
```
ginkgo -nodes=1 -v -- --state s3://aws-efs-csi-driver-e2e --name test-cluster-41400.k8s.local --delete-namespace=false --max-nodes-to-gather-from=0
```
having this test as part of CI is not a criteria for enabling CSIMigrationAWS on by default, but at least it has to be manually run. It's very slow (even with just 1 master + 1 node instance) so probably it should not be a PR blocking job, but  a periodic.

TODO:
- [x] if k8s-tag-cluster-id argument is set, add the "legacy" KubernetesCluster label to provisioned volumes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/932
- [x] test should use the same iam policy we document as example. if example doesnt work, fix it (spoiler ,it doesnt) https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/940 working on adding a policy with one additional statement to allow deleting of volumes with tag KubernetesCluster/kubernetes.io/cluster/x
- [x] ensure k8s-tag-cluster-id argument is set on CSI controller for migration test, this is* a documented prerequisite to enabling migration. #940
- [x] paste passing test result "should call in-tree plugin for all operations after migration toggled off"
- [x] paste passing test result "should call csi plugin for all operations after migration toggled on"
- [x] add README