### PR TITLE
Add KubernetesCluster tag to provisioned volumes when cluster-id set

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -86,6 +86,11 @@ const (
 	// in-tree volume plugin. Used only when --cluster-id is set.
 	NameTag = "Name"
 
+	// KubernetesClusterTag is tag applied to provisioned EBS volume for backward compatibility with
+	// in-tree volume plugin. Used only when --cluster-id is set.
+	// See https://github.com/kubernetes/cloud-provider-aws/blob/release-1.20/pkg/providers/v1/tags.go#L38-L41.
+	KubernetesClusterTag = "KubernetesCluster"
+
 	// PVCNameTag is tag applied to provisioned EBS volume for backward compatibility
 	// with in-tree volume plugin. Value of the tag is PVC name. It is applied only when
 	// the external provisioner sidecar is started with --extra-create-metadata=true and

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -220,6 +220,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		resourceLifecycleTag := ResourceLifecycleTagPrefix + d.driverOptions.kubernetesClusterID
 		volumeTags[resourceLifecycleTag] = ResourceLifecycleOwned
 		volumeTags[NameTag] = d.driverOptions.kubernetesClusterID + "-dynamic-" + volName
+		volumeTags[KubernetesClusterTag] = d.driverOptions.kubernetesClusterID
 	}
 	for k, v := range d.driverOptions.extraTags {
 		volumeTags[k] = v

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -1356,12 +1356,14 @@ func TestCreateVolume(t *testing.T) {
 			name: "success with cluster-id",
 			testFunc: func(t *testing.T) {
 				const (
-					volumeName            = "random-vol-name"
-					clusterID             = "test-cluster-id"
-					expectedOwnerTag      = "kubernetes.io/cluster/test-cluster-id"
-					expectedOwnerTagValue = "owned"
-					expectedNameTag       = "Name"
-					expectedNameTagValue  = "test-cluster-id-dynamic-random-vol-name"
+					volumeName                        = "random-vol-name"
+					clusterID                         = "test-cluster-id"
+					expectedOwnerTag                  = "kubernetes.io/cluster/test-cluster-id"
+					expectedOwnerTagValue             = "owned"
+					expectedNameTag                   = "Name"
+					expectedNameTagValue              = "test-cluster-id-dynamic-random-vol-name"
+					expectedKubernetesClusterTag      = "KubernetesCluster"
+					expectedKubernetesClusterTagValue = "test-cluster-id"
 				)
 				req := &csi.CreateVolumeRequest{
 					Name:               volumeName,
@@ -1381,10 +1383,11 @@ func TestCreateVolume(t *testing.T) {
 				diskOptions := &cloud.DiskOptions{
 					CapacityBytes: stdVolSize,
 					Tags: map[string]string{
-						cloud.VolumeNameTagKey:   volumeName,
-						cloud.AwsEbsDriverTagKey: "true",
-						expectedOwnerTag:         expectedOwnerTagValue,
-						expectedNameTag:          expectedNameTagValue,
+						cloud.VolumeNameTagKey:       volumeName,
+						cloud.AwsEbsDriverTagKey:     "true",
+						expectedOwnerTag:             expectedOwnerTagValue,
+						expectedNameTag:              expectedNameTagValue,
+						expectedKubernetesClusterTag: expectedKubernetesClusterTagValue,
 					},
 				}
 
@@ -1418,7 +1421,6 @@ func TestCreateVolume(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				const (
 					volumeName              = "random-vol-name"
-					clusterID               = "test-cluster-id"
 					expectedPVCNameTag      = "kubernetes.io/created-for/pvc/name"
 					expectedPVCNamespaceTag = "kubernetes.io/created-for/pvc/namespace"
 					expectedPVNameTag       = "kubernetes.io/created-for/pv/name"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** users (namely kops) may have policies ocnfigured for their KCM such that KCM can only attach/detach/create/delete volumes with this tag. If user enables  migration, CSI provisions volume, and then user later disables migration, the tag must bep resent so that KCM can attach/detach/create/delete  it. Details:https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/927#issuecomment-858034205

**What testing is done?** 
TODO: I'll do a manual test to sanity check the tag actually shows up. we don't have an automatic tagging e2e test , could be useful (i.e. a test that sets extraTags, clusterID, and checks tags are present in AWS API)
- [x] manual test

