### PR TITLE
Default extra-create-metadata true so that volumes get created with pvc/pv tags

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -46,7 +46,7 @@ enableVolumeSnapshot: false
 
 # Moving to values under controller
 affinity: {}
-extraCreateMetadata: false
+extraCreateMetadata: true
 extraVolumeTags: {}
 k8sTagClusterId:
 nodeSelector: {}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -31,7 +31,7 @@ spec:
           tolerationSeconds: 300
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.0.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.1.0
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode
@@ -86,6 +86,7 @@ spec:
             - --csi-address=$(ADDRESS)
             - --v=5
             - --feature-gates=Topology=true
+            - --extra-create-metadata
             - --leader-election=true
             - --default-fstype=ext4
           env:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -41,7 +41,7 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.0.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.1.0
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION


**Is this a bug fix or adding new feature?** this flag has been in external-provisioner for a long time now, we should default it true so that volumes get created with pvc/pv tags kubernetes.io/created-for  https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/9f4ce44bd3c1d454177bd97b12170b6f95bfafde/pkg/driver/constants.go#L89

**What is this PR about? / Why do we need it?** people want tags https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/180

**What testing is done?** 
