### PR TITLE
Update example policy, use it in tests, and document it

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -72,6 +72,30 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/kubernetes.io/cluster/*": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:DeleteVolume"
       ],
       "Resource": "*",
@@ -89,7 +113,7 @@
       "Resource": "*",
       "Condition": {
         "StringLike": {
-          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+          "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
         }
       }
     },

--- a/hack/kops-patch.yaml
+++ b/hack/kops-patch.yaml
@@ -5,22 +5,118 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "ec2:AttachVolume",
             "ec2:CreateSnapshot",
-            "ec2:CreateTags",
-            "ec2:CreateVolume",
-            "ec2:DeleteSnapshot",
-            "ec2:DeleteTags",
-            "ec2:DeleteVolume",
+            "ec2:AttachVolume",
+            "ec2:DetachVolume",
+            "ec2:ModifyVolume",
+            "ec2:DescribeAvailabilityZones",
             "ec2:DescribeInstances",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",
             "ec2:DescribeVolumes",
-            "ec2:DetachVolume",
-            "ec2:ModifyVolume",
             "ec2:DescribeVolumesModifications"
           ],
           "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateTags"
+          ],
+          "Resource": [
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "ec2:CreateAction": [
+                "CreateVolume",
+                "CreateSnapshot"
+              ]
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DeleteTags"
+          ],
+          "Resource": [
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateVolume"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateVolume"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/CSIVolumeName": "*"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DeleteVolume"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "ec2:ResourceTag/CSIVolumeName": "*"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DeleteVolume"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DeleteSnapshot"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DeleteSnapshot"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+            }
+          }
         }
       ]
   kubeAPIServer:

--- a/hack/kops-patch.yaml
+++ b/hack/kops-patch.yaml
@@ -73,6 +73,30 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
+            "ec2:CreateVolume"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/kubernetes.io/cluster/*": "owned"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:DeleteVolume"
+          ],
+          "Resource": "*",
+          "Condition": {
+            "StringLike": {
+              "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
             "ec2:DeleteVolume"
           ],
           "Resource": "*",
@@ -90,7 +114,7 @@ spec:
           "Resource": "*",
           "Condition": {
             "StringLike": {
-              "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+              "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
             }
           }
         },

--- a/hack/values.yaml
+++ b/hack/values.yaml
@@ -1,5 +1,6 @@
 enableVolumeSnapshot: true
 controller:
+  k8sTagClusterId: test
   logLevel: 5
 node:
   logLevel: 5


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**  The example policy is a minimal restrictive example so it's not guaranteed to work in all scenarios... but there are is at least one* notable scenario where it breaks, so we should update* the example and documentation to account for this scenario:
- if migration is enabled, the policy restricts csi from deleting volumes that were created by KCM pre-migration
  - to fix this, i've edited the example policy such that it has permission to delete volumes with tag `"aws:RequestTag/kubernetes.io/cluster/<ID of the Kubernetes cluster>": "owned"`. also add permission to create although it's not totally necessary, maybe redundant, but to be consistent.

**What testing is done?** 
