### PR TITLE
Default controller.extra-create-metadata true so that volumes get created with pvc/pv tags

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.1.0"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 1.2.2
+version: 1.2.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -68,7 +68,7 @@ controller:
     snapshotter: []
     resizer: []
   # If set, add pv/pvc metadata to plugin create requests as parameters.
-  extraCreateMetadata: false
+  extraCreateMetadata: true
   # Will be removed in later version in favor of env.ebsPlugin
   extraVars: {}
   # Extra volume tags to attach to each dynamically provisioned volume.


### PR DESCRIPTION

**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/937 updated the toplevel extra-create-metadata but not the controller.extra-create-metadata . the top level is the one we want to deprecate. In any case they should match to avoid confusion.
 
**What testing is done?** 
