### PR TITLE
Revert "Fix kustomize RBAC bindings to have namespace kube-system"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,19 +163,19 @@ generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrole-resizer.yaml > ../../deploy/kubernetes/base/clusterrole-resizer.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrole-snapshot-controller.yaml > ../../deploy/kubernetes/base/clusterrole-snapshot-controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrole-snapshotter.yaml > ../../deploy/kubernetes/base/clusterrole-snapshotter.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-attacher.yaml -n kube-system > ../../deploy/kubernetes/base/clusterrolebinding-attacher.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-csi-node.yaml -n kube-system > ../../deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-provisioner.yaml -n kube-system > ../../deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-resizer.yaml -n kube-system > ../../deploy/kubernetes/base/clusterrolebinding-resizer.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-snapshot-controller.yaml -n kube-system > ../../deploy/kubernetes/base/clusterrolebinding-snapshot-controller.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-snapshotter.yaml -n kube-system > ../../deploy/kubernetes/base/clusterrolebinding-snapshotter.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-attacher.yaml > ../../deploy/kubernetes/base/clusterrolebinding-attacher.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-csi-node.yaml > ../../deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-provisioner.yaml > ../../deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-resizer.yaml > ../../deploy/kubernetes/base/clusterrolebinding-resizer.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-snapshot-controller.yaml > ../../deploy/kubernetes/base/clusterrolebinding-snapshot-controller.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-snapshotter.yaml > ../../deploy/kubernetes/base/clusterrolebinding-snapshotter.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/controller.yaml  > ../../deploy/kubernetes/base/controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/csidriver.yaml > ../../deploy/kubernetes/base/csidriver.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/node.yaml  > ../../deploy/kubernetes/base/node.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/poddisruptionbudget-controller.yaml > ../../deploy/kubernetes/base/poddisruptionbudget-controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/poddisruptionbudget-snapshot-controller.yaml -f ../../deploy/kubernetes/values/snapshotter.yaml > ../../deploy/kubernetes/base/poddisruptionbudget-snapshot-controller.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/role-snapshot-controller-leaderelection.yaml -n kube-system > ../../deploy/kubernetes/base/role-snapshot-controller-leaderelection.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/rolebinding-snapshot-controller-leaderelection.yaml -n kube-system > ../../deploy/kubernetes/base/rolebinding-snapshot-controller-leaderelection.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/role-snapshot-controller-leaderelection.yaml > ../../deploy/kubernetes/base/role-snapshot-controller-leaderelection.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/rolebinding-snapshot-controller-leaderelection.yaml > ../../deploy/kubernetes/base/rolebinding-snapshot-controller-leaderelection.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-controller.yaml > ../../deploy/kubernetes/base/serviceaccount-csi-controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-snapshot-controller.yaml > ../../deploy/kubernetes/base/serviceaccount-snapshot-controller.yaml

--- a/deploy/kubernetes/base/clusterrolebinding-attacher.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-attacher.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: ebs-external-attacher-role

--- a/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-csi-node.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-node-sa
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: ebs-csi-node-role

--- a/deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: ebs-external-provisioner-role

--- a/deploy/kubernetes/base/clusterrolebinding-resizer.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-resizer.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: ebs-external-resizer-role

--- a/deploy/kubernetes/base/clusterrolebinding-snapshot-controller.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-snapshot-controller.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-snapshot-controller
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: ebs-snapshot-controller-role

--- a/deploy/kubernetes/base/clusterrolebinding-snapshotter.yaml
+++ b/deploy/kubernetes/base/clusterrolebinding-snapshotter.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-controller-sa
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: ClusterRole
   name: ebs-external-snapshotter-role

--- a/deploy/kubernetes/base/rolebinding-snapshot-controller-leaderelection.yaml
+++ b/deploy/kubernetes/base/rolebinding-snapshot-controller-leaderelection.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-snapshot-controller
-    namespace: kube-system
+    namespace: default
 roleRef:
   kind: Role
   name: ebs-snapshot-controller-leaderelection


### PR DESCRIPTION
This reverts commit `3716e5ef3175bdbb6745018f9646957b5a635eac`

**Is this a bug fix or adding new feature?**
Fixes #946 946

**What is this PR about? / Why do we need it?**
Issue described in ticket

**What testing is done?** 
