### PR TITLE
[helm-chart] csi-snapshotter in ebs-csi-controller now checks for enableVolumeSnapshot before including it in containers

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -189,6 +189,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+{{- if or .Values.enableVolumeSnapshot (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
         - name: csi-snapshotter
           image: {{ printf "%s:%s" .Values.sidecars.snapshotterImage.repository .Values.sidecars.snapshotterImage.tag }}
           args:
@@ -210,6 +211,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+{{- end }}
         - name: csi-resizer
           image: {{ printf "%s:%s" .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
           imagePullPolicy: Always


### PR DESCRIPTION


**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/942

**What testing is done?** 
locally, yes