### PR TITLE
Download fixed version of eksctl to avoid bugs

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 
 function eksctl_install() {
   INSTALL_PATH=${1}
+  EKSCTL_VERSION=${2}
   if [[ ! -e ${INSTALL_PATH}/eksctl ]]; then
-    EKSCTL_DOWNLOAD_URL="https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
+    EKSCTL_DOWNLOAD_URL="https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_$(uname -s)_amd64.tar.gz"
     curl --silent --location "${EKSCTL_DOWNLOAD_URL}" | tar xz -C "${INSTALL_PATH}"
     chmod +x "${INSTALL_PATH}"/eksctl
   fi

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -57,6 +57,7 @@ KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
 
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.56.0-rc.1}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
 
@@ -84,8 +85,8 @@ if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   kops_install "${BIN_DIR}" "${KOPS_VERSION}"
   KOPS_BIN=${BIN_DIR}/kops
 elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
-  loudecho "Installing eksctl latest to ${BIN_DIR}"
-  eksctl_install "${BIN_DIR}"
+  loudecho "Installing eksctl ${EKSCTL_VERSION} to ${BIN_DIR}"
+  eksctl_install "${BIN_DIR}" "${EKSCTL_VERSION}"
   EKSCTL_BIN=${BIN_DIR}/eksctl
 else
   loudecho "${CLUSTER_TYPE} must be kops or eksctl!"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** eks job is failing, the latest release 0.55.0 has a bug "Error: --instance-types is only valid with managed nodegroups (--managed)" https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-aws-ebs-csi-driver-external-test-eks that is fixed in 0.56.0-rc.1. Could also revert to 0.54.0 but it doesn't really matter IMO, may as well try the newest.

**What testing is done?**  watch CI job
