### PR TITLE
Feature/allow add debug args

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -78,6 +78,9 @@ spec:
             {{- end }}
             - --logtostderr
             - --v={{ .Values.controller.logLevel }}
+            {{- range .Values.controller.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -60,7 +60,7 @@ topologySpreadConstraints: []
 
 controller:
   # If arbitrary args like "--aws-sdk-debug-log=true" need to be passed, use this value
-  # additionalArgs: []
+  additionalArgs: []
   affinity: {}
   # True if enable volume scheduling for dynamic volume provisioning
   env:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -59,7 +59,7 @@ tolerations: []
 topologySpreadConstraints: []
 
 controller:
-  # If arbitray args like "--aws-sdk-debug-log=true" need to be passed, use this value
+  # If arbitrary args like "--aws-sdk-debug-log=true" need to be passed, use this value
   # additionalArgs: []
   affinity: {}
   # True if enable volume scheduling for dynamic volume provisioning

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -59,6 +59,8 @@ tolerations: []
 topologySpreadConstraints: []
 
 controller:
+  # If arbitray args like "--aws-sdk-debug-log=true" need to be passed, use this value
+  # additionalArgs: []
   affinity: {}
   # True if enable volume scheduling for dynamic volume provisioning
   env:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding a new feature.

**What is this PR about? / Why do we need it?**
I was trying to debug a deployment of the EBS CSI and needed the `--aws-sdk-debug-log` flag set to true. I could not do it from the chart, so I had to keep editing the deployment in-place, and my CI process kept redeploying the helm chart. Being able to set this value from the chart, and other aribitrary commandline flags would make it easier for power users to debug.

**What testing is done?** 
I've templated the chart a few times with different values, and deployed it to a cluster without issue.