### PR TITLE
Add how to consume new hack/e2e scripts in other repos (efs/fsx)

### DIFF
--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -41,7 +41,16 @@ To commit changes and submit them as a PR back to the ebs repo:
 
 ```
 git diff ebs/master:hack/e2e HEAD:hack/e2e > /tmp/hack_e2e.diff
-cd $GOPATH/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+pushd $GOPATH/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
+git apply --reject --directory hack/e2e /tmp/hack_e2e.diff
+git commit
+```
+
+To consume newer changes from the ebs repo:
+
+```
+git fetch ebs
+git diff HEAD:hack/e2e ebs/master:hack/e2e > /tmp/hack_e2e.diff
 git apply --reject --directory hack/e2e /tmp/hack_e2e.diff
 git commit
 ```


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
since I am trying to reuse these scripts in efs and fsx repo (in poor imitation of csi-release-tools) i want to document how to work with them.

These commands generated patch that applied cleanly you can see in first commit here:
https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/510

**What testing is done?** 
