### PR TITLE
Increased the helm chart version

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.1.1"
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.0.0
+version: 2.0.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
No,  Bumped up the the helm chart version

**What is this PR about? / Why do we need it?**
Change in helm chart version because, the PR #978 after merge had thrown message "Error: error creating GitHub release helm-chart-aws-ebs-csi-driver-2.0.0: POST https://api.github.com/repos/kubernetes-sigs/aws-ebs-csi-driver/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]". Since the changes were done in the helm chart in PR #978, apparently the helm chart version should be also be increased.

**What testing is done?** 
No testing required.
