### PR TITLE
Update base images: yum update al2, bump debian tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,13 @@ COPY . .
 RUN make
 
 FROM amazonlinux:2 AS amazonlinux
+RUN yum update -y
 RUN yum install ca-certificates e2fsprogs xfsprogs util-linux -y
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 
-FROM k8s.gcr.io/build-image/debian-base:v2.1.3 AS debian-base
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.8.0 AS debian-base
 RUN clean-install ca-certificates e2fsprogs mount udev util-linux xfsprogs
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?** trigger another build. for al2, this time make sure update packages. for debian, make sure we are using a newer base image that roughly matches whatever k/k is using (although nowadays most k/k images are distroless) https://github.com/kubernetes/release/tree/master/images/build/debian-base

BTW I am probably going to soon be removing debian base and going back to just maintaining amazonlinux base. We wanted to push debian because users are probably already using debian base images in their cluster anyway (kube-proxy) and they don't want to risk CVEs from both debian images and amazonlinux images in their cluster. But it's harder on maintainers to keep up pushing builds for both which is itself a risk.

**What testing is done?** 
