### PR TITLE
[chart] Node update strategy & auto driver image tag

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Helm chart
 
-# v2.0.0
+## v2.0.4
+
+* Use chart app version as default image tag
+* Add updateStrategy to daemonsets
+
+## v2.0.3
+
+* Bump app/driver version to `v1.2.0`
+
+## v2.0.2
+
+* Bump app/driver version to `v1.1.3`
+
+## v2.0.1
+
+* Only create Windows daemonset if enableWindows is true
+* Update Windows daemonset to align better to the Linux one
+
+## v2.0.0
+
 * Remove support for Helm 2
 * Remove deprecated values
 * No longer install snapshot controller or its CRDs
@@ -8,7 +27,8 @@
 
 [Upgrade instructions](/docs/README.md#upgrading-from-version-1x-to-2x-of-the-helm-chart)
 
-# v1.2.4
+## v1.2.4
+
 * Bump app/driver version to `v1.1.1`
 * Install VolumeSnapshotClass, VolumeSnapshotContent, VolumeSnapshot CRDs if enableVolumeSnapshot is true
 * Only run csi-snapshotter sidecar if enableVolumeSnapshot is true or if CRDs are already installed

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "1.2.0"
+appVersion: 1.2.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.0.3
+version: 2.0.4
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:
@@ -16,3 +16,9 @@ maintainers:
     email: chengpan@amazon.com
   - name: krmichel
     url: https://github.com/krmichel
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Use chart app version as default image tag
+    - kind: changed
+      description: Add updateStrategy to daemonsets

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if ne .Release.Name "kustomize" }}

--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       app: ebs-csi-node
       {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{ toYaml .Values.node.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:
@@ -54,7 +56,7 @@ spec:
         {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       app: ebs-csi-node
       {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    {{- toYaml .Values.node.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:
@@ -56,7 +58,7 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -4,7 +4,8 @@
 
 image:
   repository: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-  tag: "v1.2.0"
+  # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
+  tag: ""
   pullPolicy: IfNotPresent
 
 sidecars:
@@ -133,6 +134,10 @@ node:
   enableWindows: false
   # The "maximum number of attachable volumes" per node
   volumeAttachLimit:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
 
 storageClasses: []
 # Add StorageClass resources like:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -12,6 +12,10 @@ spec:
     matchLabels:
       app: ebs-csi-node
       app.kubernetes.io/name: aws-ebs-csi-driver
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -22,11 +26,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: eks.amazonaws.com/compute-type
-                operator: NotIn
-                values:
-                - fargate
+              - matchExpressions:
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: ebs-csi-node-sa


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This PR adds the ability to configure the node update strategy and uses the chart app version for the image tag.

Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/985.

**What is this PR about? / Why do we need it?**
With the default update strategy the more nodes added to the cluster the longer it takes to upgrade, this PR makes this customisable and sets the default to the 10% unavailable strategy used by the aws-vpc-cni and the EKS kube-proxy daemonsets.

**What testing is done?** 
Helm template output validated.