### PR TITLE
[chart] Add controller strategy

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Helm chart
 
+## v2.1.0
+
+* Custom `controller.updateStrategy` to set controller deployment strategy.
+
 ## v2.0.4
 
 * Use chart app version as default image tag

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.0.4
+version: 2.1.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:
@@ -18,7 +18,5 @@ maintainers:
     url: https://github.com/krmichel
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Use chart app version as default image tag
-    - kind: changed
-      description: Add updateStrategy to daemonsets
+    - kind: added
+      description: Custom controller.updateStrategy to set controller deployment strategy.

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  {{- with .Values.controller.updateStrategy }}
+  strategy:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: ebs-csi-controller
@@ -55,7 +59,7 @@ spec:
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if ne .Release.Name "kustomize" }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -85,6 +85,11 @@ controller:
   # region: us-east-1
   region:
   replicaCount: 2
+  updateStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 0
+  #   maxUnavailable: 1
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Is this a bug fix or adding new feature?
This PR adds the ability to configure the controller update strategy.

What is this PR about? / Why do we need it?
With the default update strategy and tightly mapped zones the surge pods cause issues.

What testing is done?
Helm template output validated.
