### PR TITLE
Fix github build failing because of wrong docker hub registry name 

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set environment variables
         run: |
-          REGISTRY_NAME=docker.io/library/amazon
+          REGISTRY_NAME=docker.io/amazon
           BRANCH_OR_TAG=$(echo $GITHUB_REF | cut -d'/' -f3)
           if [ "$BRANCH_OR_TAG" = "master" ]; then
             GIT_TAG=$GITHUB_SHA


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?**
build is failing. There is no "library" in the registry name https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/3256645072

**What testing is done?** locally can pull from docker.io/amazon but not docker.io/library/amazon, the former is the correct one.
