### PR TITLE
Fix gcr prow build failing because of IMAGE variable collision

### DIFF
--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -41,4 +41,4 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 loudecho "Push manifest list containing amazon linux and windows based images to GCR"
 export REGISTRY=$REGISTRY_NAME
 export TAG=$GIT_TAG
-make all-push
+IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make all-push


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
build is failing. It seems like the build container already sets IMAGE to gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8 so the new Makefile rule tries pushing to this invalid tag: "invalid tag "gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8:v20210805-helm-chart-aws-ebs-csi-driver-2.0.4-3-gf30d7f8e-linux-amd64-amazon": invalid reference format". The fix should be to override IMAGE for the `make` call. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1423392293334814720

**What testing is done?** 
Can't verify locally, will check if build succeeds in master branch after this merges.