### PR TITLE
Node Publish Mount Idempotent

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -620,10 +620,39 @@ func (d *nodeService) nodePublishVolumeForFileSystem(req *csi.NodePublishVolumeR
 	mountOptions = collectMountOptions(fsType, mountOptions)
 
 	klog.V(4).Infof("NodePublishVolume: mounting %s at %s with option %s as fstype %s", source, target, mountOptions, fsType)
-	if err := d.mounter.Mount(source, target, fsType, mountOptions); err != nil {
-		if removeErr := os.Remove(target); removeErr != nil {
-			return status.Errorf(codes.Internal, "Could not remove mount target %q: %v", target, err)
+	/*
+		Checking if it's a mount point. There are three cases,
+		1. true, err when the directory does not exist or corrupted.
+		2. false, nil when the path is already mounted with a device.
+		3. true, nil when the path is not mounted with any device.
+	*/
+	notMnt, err := d.mounter.IsLikelyNotMountPoint(target)
+	if err != nil && !os.IsNotExist(err){
+		//Checking if the path exists and error is related to Corrupted Mount, in that case, the system could unmount and mount.
+		_, pathErr := mountutils.PathExists(target)
+		if pathErr != nil && mountutils.IsCorruptedMnt(pathErr) {
+			klog.V(4).Infof("Target path %q is a corrupted directory",target)
+		}else{
+			return status.Errorf(codes.Internal, "Could not mount %q at %q: %v", source, target, err)
 		}
+	}
+
+	if !notMnt {
+		//Return error when any of the directory inside is not readable which means that a device could be mounted.
+		_, err = os.ReadDir(target)
+		if err != nil {
+			klog.V(4).Infof("Error occurred at reading directory %q. Trying to Unmount.",target)
+			//Reading the directory failed and trying to unmount and remount
+			if mntErr := d.mounter.Unmount(target); mntErr != nil {
+				return status.Errorf(codes.Internal, "Unable to unmount the target %q : %v", target, err)
+			}
+		} else {
+			klog.V(4).Infof("Target path %q is already mounted",target)
+			return nil
+		}
+	}
+
+	if err := d.mounter.Mount(source, target, fsType, mountOptions); err != nil {
 		return status.Errorf(codes.Internal, "Could not mount %q at %q: %v", source, target, err)
 	}
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -597,6 +597,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(stagingTargetPath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Eq([]string{"bind"})).Return(nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath},
@@ -629,6 +631,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(stagingTargetPath), gomock.Eq(targetPath), gomock.Eq(FSTypeXfs), gomock.Eq([]string{"bind", "nouuid"})).Return(nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath},
@@ -670,6 +674,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(stagingTargetPath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Eq([]string{"bind", "ro"})).Return(nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: devicePath},
@@ -703,6 +709,8 @@ func TestNodePublishVolume(t *testing.T) {
 
 				mockMounter.EXPECT().MakeDir(gomock.Eq(targetPath)).Return(nil)
 				mockMounter.EXPECT().Mount(gomock.Eq(stagingTargetPath), gomock.Eq(targetPath), gomock.Eq(defaultFsType), gomock.Eq([]string{"bind", "test-flag"})).Return(nil)
+				mockMounter.EXPECT().IsLikelyNotMountPoint(gomock.Eq(targetPath)).Return(false, nil)
+				mockMounter.EXPECT().Unmount(gomock.Eq(targetPath)).Return(nil)
 
 				req := &csi.NodePublishVolumeRequest{
 					PublishContext:    map[string]string{DevicePathKey: "/dev/fake"},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Issue Fix #955  - Node publish mount idempotent

**What is this PR about? / Why do we need it?**
The PR adds mount idempotent to the CSI driver which provides multiple requests of 'NodePublishVolume' with the same request parameters would not throw error. We need it for the idempotency in mount.

**What testing is done?** 
Unit testing.
Manual testing is done using [csc](https://github.com/rexray/gocsi/tree/master/csc) tool. Below are the screenshots which shows the NodePublishVolume call of same request made multiple times. At first, it publishes the volume at the target and later request provides the information that the target is already mounted.

<img width="1534" alt="Screen Shot 2021-08-10 at 11 55 29 AM" src="https://user-images.githubusercontent.com/37205646/128942620-767cab88-e2ae-4e5d-874c-2dacf6652888.png">
<img width="1536" alt="Screen Shot 2021-08-10 at 11 55 07 AM" src="https://user-images.githubusercontent.com/37205646/128942652-4c0151b1-ea4c-433f-90c8-a5b08e063a9a.png">


