### PR TITLE
Fix gcr prow builld failing because docker missing --os-version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 3600s
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930
     entrypoint: ./hack/prow.sh
     env:
       - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** doing some wack a mole . the new build makle rule almost succeeded but failed at the manifest annotate step with `unknown flag: --os-version` https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1425539295917117440 . This new image version has a new docker version with the flag.

**What testing is done?** 
```
$ docker run -it -e DOCKER_CLI_EXPERIMENTAL=enabled --entrypoint docker gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930 manifest annotate --help
Unable to find image 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930' locally
v20210722-085d930: Pulling from k8s-testimages/gcb-docker-gcloud
Digest: sha256:7187e4554771f7faf4399ac20efcb303e4b315082046c79e3ca6eeae79f1f1fb
Status: Downloaded newer image for gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930

Usage:  docker manifest annotate [OPTIONS] MANIFEST_LIST MANIFEST

Add additional information to a local image manifest

EXPERIMENTAL:
  docker manifest annotate is an experimental feature.
  Experimental features provide early access to product functionality. These
  features may change between releases without warning, or can be removed from a
  future release. Learn more about experimental features in our documentation:
  https://docs.docker.com/go/experimental/

Options:
      --arch string           Set architecture
      --os string             Set operating system
      --os-features strings   Set operating system feature
      --os-version string     Set operating system version
      --variant string        Set architecture variant
```