### PR TITLE
Set up custom tolerations before adding default ones set by the chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -42,6 +42,10 @@ spec:
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
+        {{/* The order is important here - custom tolerations need to be put first as some can override eachother */}}
+        {{- with .Values.node.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
@@ -50,9 +54,6 @@ spec:
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300
-        {{- end }}
-        {{- with .Values.node.tolerations }}
-        {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
         - name: ebs-plugin

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -42,6 +42,10 @@ spec:
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
+        {{/* The order is important here - custom tolerations need to be put first as some can override eachother */}}
+        {{- with .Values.node.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
@@ -50,9 +54,6 @@ spec:
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300
-        {{- end }}
-        {{- with .Values.node.tolerations }}
-        {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
         - name: ebs-plugin


### PR DESCRIPTION
**Is this a bug fix or adding a new feature?**

Bugfix

**What is this PR about? / Why do we need it?**

It looks like K8s 1.20 uses the first global match for tolerations, making it impossible to specify custom toleration with the same operator. As such I switched the custom tolerations to come first.

Example:

This allows node daemonset to tolerate `myrole` taint:
```
    - key: role
      operator: Equal
      value: myrole
      effect: NoExecute
    - operator: Exists
      effect: NoExecute
      tolerationSeconds: 60
```

This gets evicted every 60 seconds:
```
    - operator: Exists
      effect: NoExecute
      tolerationSeconds: 60
    - key: role
      operator: Equal
      value: myrole
      effect: NoExecute
```

This is needed since `tolerateAllTaints` may not be applicable in all environments, e.g. we want to tolerate our DB taints, but not tolerate a Fargate taint.

**What testing is done?** 

Tested in our production cluster.