### PR TITLE
hash volume name to get client token

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -18,6 +18,8 @@ package cloud
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -320,9 +322,12 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 		}
 	}
 
+	// We hash the volume name to generate a unique token that is less than or equal to 64 characters
+	clientToken := sha256.Sum256([]byte(volumeName))
+
 	requestInput := &ec2.CreateVolumeInput{
 		AvailabilityZone:  aws.String(zone),
-		ClientToken:       aws.String(volumeName),
+		ClientToken:       aws.String(hex.EncodeToString(clientToken[:])),
 		Size:              aws.Int64(capacityGiB),
 		VolumeType:        aws.String(createType),
 		TagSpecifications: []*ec2.TagSpecification{&tagSpec},


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
fixes #1038 

**What is this PR about? / Why do we need it?**
hash the volume name using sha-256 in case the name is longer than 64 characters.

**What testing is done?** 
manually tested that a volume could be created with new token