### PR TITLE
Fix windows build IsCorruptedMnt not implemented

### DIFF
--- a/pkg/driver/mount_windows.go
+++ b/pkg/driver/mount_windows.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/mounter"
+	mountutils "k8s.io/mount-utils"
 )
 
 func (m NodeMounter) FormatAndMount(source string, target string, fstype string, options []string) error {
@@ -67,6 +68,11 @@ func (m NodeMounter) GetDeviceNameFromMount(mountPath string) (string, int, erro
 		return "", 0, err
 	}
 	return deviceName, 1, nil
+}
+
+// IsCorruptedMnt return true if err is about corrupted mount point
+func (m NodeMounter) IsCorruptedMnt(err error) bool {
+	return mountutils.IsCorruptedMnt(err)
 }
 
 func (m *NodeMounter) MakeFile(path string) error {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** as seen in our master branch CI https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/3508198636  the windows build fails.

this was not cauhgt by PR CI because no PR CI exercises the windows build, I've assigned myself a task to fix this: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1046

~After this merges, what I plan to do is retag 1.1.4 and 1.2.1 to trigger another image rebuild. It is not pretty but, since no images for 1.1.4 or 1.2.1 got pushed to docker hub/gcr there is no harm.~

edit: 1.1.4 and 1.2.1 failed for a different reason than master branch, they timed out unexpectedly after 1hr: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1433833154082246656
the 1.1.3 build succeeded after 45 mins: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1418730174391783424

**What testing is done?** 
$ make windows/amd64
CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=vendor -ldflags "-X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.driverVersion=v1.2.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud.driverVersion=v1.2.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=3b6a45aace77298ad774fba267096aa7d0d3a3c8 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=2021-09-08T20:27:35+00:00 -s -w" -o bin/aws-ebs-csi-driver.exe ./cmd/
