### PR TITLE
[release-1.1] Increase prow timeout to 1h15m

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 3600s
+timeout: 4500s
 steps:
   - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
     entrypoint: ./hack/prow.sh


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?** This is a bandaid fix to get 1.1.4 out. Our build time has been steadily increasing and now it consistently breaches the 1h timeout. https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images. It was already very slow before compared to github actions (30-45 mins vs 15mins) so it will need to be fixed, tracking it here: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1048

for comparison master branch is still pretty slow at 40 mins but it building for windows in addition to x86 and arm! So one option to solve https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1048 is to backport the Makefile/Dockerfile/build changes to release-1.1 branch.

**What testing is done?** 
