### PR TITLE
[release-1.2] Automated cherry pick of #1047: Fix windows build IsCorruptedMnt not implemented

### DIFF
--- a/pkg/driver/mount_windows.go
+++ b/pkg/driver/mount_windows.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/mounter"
+	mountutils "k8s.io/mount-utils"
 )
 
 func (m NodeMounter) FormatAndMount(source string, target string, fstype string, options []string) error {
@@ -67,6 +68,11 @@ func (m NodeMounter) GetDeviceNameFromMount(mountPath string) (string, int, erro
 		return "", 0, err
 	}
 	return deviceName, 1, nil
+}
+
+// IsCorruptedMnt return true if err is about corrupted mount point
+func (m NodeMounter) IsCorruptedMnt(err error) bool {
+	return mountutils.IsCorruptedMnt(err)
 }
 
 func (m *NodeMounter) MakeFile(path string) error {


### PR DESCRIPTION
Cherry pick of #1047 on release-1.2.

#1047: Fix windows build IsCorruptedMnt not implemented

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.