### PR TITLE
Recognize instance-type node label when EC2 metadata isn't available

### DIFF
--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -210,9 +211,14 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface) (*Metadata, error
 		return nil, fmt.Errorf("did not find aws instance ID in node providerID string")
 	}
 
+	var instanceType string
+	if it, ok := node.GetLabels()[corev1.LabelInstanceTypeStable]; ok {
+		instanceType = it
+	}
+
 	instanceInfo := Metadata{
 		InstanceID:       instanceID,
-		InstanceType:     "", // we have no way to find this, so we leave it empty
+		InstanceType:     instanceType,
 		Region:           region,
 		AvailabilityZone: availabilityZone,
 	}

--- a/pkg/cloud/metadata_test.go
+++ b/pkg/cloud/metadata_test.go
@@ -114,6 +114,9 @@ func TestNewMetadataService(t *testing.T) {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"node.kubernetes.io/instance-type": stdInstanceType,
+					},
 					Name: nodeName,
 				},
 				Spec: v1.NodeSpec{
@@ -324,6 +327,9 @@ func TestNewMetadataService(t *testing.T) {
 				}
 				if m.GetInstanceID() != stdInstanceID {
 					t.Errorf("NewMetadataService() failed: got wrong instance ID %v, expected %v", m.GetInstanceID(), stdInstanceID)
+				}
+				if m.GetInstanceType() != stdInstanceType {
+					t.Errorf("GetInstanceType() failed: got wrong instance type %v, expected %v", m.GetInstanceType(), stdInstanceType)
 				}
 				if m.GetRegion() != stdRegion {
 					t.Errorf("NewMetadataService() failed: got wrong region %v, expected %v", m.GetRegion(), stdRegion)


### PR DESCRIPTION

**Is this a bug fix or adding new feature?**
/kind bug

**What is this PR about? / Why do we need it?**
This fixes volume limits on nodes that dont have the EC2 metadata endpoint available.

kOps is experiencing [volume limit test failures](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-aws-aws-ebs-csi-driver-irsa/1436862817599754240) and I believe this is because the limit is being set incorrectly.

[The nodes are t3.mediums](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-aws-ebs-csi-driver-irsa/1436862817599754240/artifacts/cluster-info/nodes.yaml) which should have a [limit of 28 volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html).

[The csi-node pod logs](https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-aws-aws-ebs-csi-driver-irsa/1436862817599754240/artifacts/cluster-info/kube-system/ebs-csi-node-t4mcd/logs.txt) report that ec2 metadata is not available so we fallback to the metadata from the k8s API which doesn't set an instance type.

The volume limit code doesn't match the nitro regex and then defaults to the non-nitro limit of 39 volumes which is higher than the t3.medium's actual limit of 28:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/edb4fbee7e5f078e9214750e579abcd576f3f3d2/pkg/driver/node.go#L681-L691

The test output confirms that it incorrectly uses a limit of 39 volumes:
`Sep 12 01:37:14.436: INFO: Node ip-172-20-34-51.ap-northeast-2.compute.internal can handle 39 volumes of driver ebs.csi.aws.com`

**What testing is done?** 
