### PR TITLE
[release-1.2] Fix gcr prow and github builds: cherry-pick of #1016, #1017, and #1020

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       - name: Set environment variables
         run: |
-          REGISTRY_NAME=docker.io/library/amazon
+          REGISTRY_NAME=docker.io/amazon
           BRANCH_OR_TAG=$(echo $GITHUB_REF | cut -d'/' -f3)
           if [ "$BRANCH_OR_TAG" = "master" ]; then
             GIT_TAG=$GITHUB_SHA

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 3600s
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200421-a2bf5f8
+  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930
     entrypoint: ./hack/prow.sh
     env:
       - GIT_TAG=${_GIT_TAG}

--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -41,4 +41,4 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 loudecho "Push manifest list containing amazon linux and windows based images to GCR"
 export REGISTRY=$REGISTRY_NAME
 export TAG=$GIT_TAG
-make all-push
+IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make all-push


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?** https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1062 just got merged which was a cherry-pick of https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/957.

I forgot that https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/957 on its own didn't work, it needed a few iterations of fixes: #1016, #1017, and #1020. Then after #1020 the builds passed: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/3376750521, https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1428483776043814912 

So of course, I need to cherry-pick these 3 PRs alongside 957. Whoops!

**What testing is done?** 
