### PR TITLE
Allow default fstype to be overriden via values.yaml

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Helm chart
 
+## v2.3.0
+
+* Support overriding controller `--default-fstype` flag via values
+
 ## v2.2.1
 
 * Bump app/driver version to `v1.3.0`

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.2.1
+version: 2.3.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -149,7 +149,7 @@ spec:
             - --extra-create-metadata
             {{- end}}
             - --leader-election=true
-            - --default-fstype=ext4
+            - --default-fstype={{ .Values.controller.defaultFsType }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -68,6 +68,9 @@ controller:
   # If arbitrary args like "--aws-sdk-debug-log=true" need to be passed, use this value
   additionalArgs: []
   affinity: {}
+  # The default filesystem type of the volume to provision when fstype is unspecified in the StorageClass.
+  # If the default is not set and fstype is unset in the StorageClass, then no fstype will be set
+  defaultFsType: ext4
   env: []
   # If set, add pv/pvc metadata to plugin create requests as parameters.
   extraCreateMetadata: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature.

**What is this PR about? / Why do we need it?**

Default `fstype` is hardcoded as ext4, users may wish to override it to use other filesystems instead of specifying them explicitly in the StorageClass resource.

**What testing is done?** 

Helm templating + test deploy on k8s cluster.

Change is backwards compatible, as the default is still `ext4`
