### PR TITLE
Added more volumeAttachLimit values based on instanceTypes

### DIFF
--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -22,6 +22,7 @@ type Cloud interface {
 	GetSnapshotByName(ctx context.Context, name string) (snapshot *Snapshot, err error)
 	GetSnapshotByID(ctx context.Context, snapshotID string) (snapshot *Snapshot, err error)
 	ListSnapshots(ctx context.Context, volumeID string, maxResults int64, nextToken string) (listSnapshotsResponse *ListSnapshotsResponse, err error)
+	GetVolumeAttachLimit(ctx context.Context, nodeID string) (int, error)
 }
 
 // MetadataService represents AWS metadata service.

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -186,6 +186,21 @@ func (mr *MockCloudMockRecorder) GetSnapshotByName(ctx, name interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshotByName", reflect.TypeOf((*MockCloud)(nil).GetSnapshotByName), ctx, name)
 }
 
+// GetVolumeAttachLimit mocks base method.
+func (m *MockCloud) GetVolumeAttachLimit(ctx context.Context, nodeID string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachLimit", ctx, nodeID)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVolumeAttachLimit indicates an expected call of GetVolumeAttachLimit.
+func (mr *MockCloudMockRecorder) GetVolumeAttachLimit(ctx, nodeID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachLimit", reflect.TypeOf((*MockCloud)(nil).GetVolumeAttachLimit), ctx, nodeID)
+}
+
 // IsExistInstance mocks base method.
 func (m *MockCloud) IsExistInstance(ctx context.Context, nodeID string) bool {
 	m.ctrl.T.Helper()

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1835,7 +1835,7 @@ func TestNodeGetInfo(t *testing.T) {
 			instanceType:      "m5d.large",
 			availabilityZone:  "us-west-2b",
 			volumeAttachLimit: -1,
-			expMaxVolumes:     25,
+			expMaxVolumes:     39,
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -1866,6 +1866,7 @@ func TestNodeGetInfo(t *testing.T) {
 				volumeAttachLimit: tc.volumeAttachLimit,
 			}
 
+			mockCloud := mocks.NewMockCloud(mockCtl)
 			mockMounter := mocks.NewMockMounter(mockCtl)
 
 			mockMetadata := mocks.NewMockMetadataService(mockCtl)
@@ -1875,9 +1876,12 @@ func TestNodeGetInfo(t *testing.T) {
 
 			if tc.volumeAttachLimit < 0 {
 				mockMetadata.EXPECT().GetInstanceType().Return(tc.instanceType)
+				mockMetadata.EXPECT().GetInstanceID().Return(tc.instanceID)
+				mockCloud.EXPECT().GetVolumeAttachLimit(context.TODO(), gomock.Eq("i-123456789abcdef01")).Return(39, nil)
 			}
 
 			awsDriver := &nodeService{
+				cloud:         mockCloud,
 				metadata:      mockMetadata,
 				mounter:       mockMounter,
 				inFlight:      internal.NewInFlight(),

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -291,6 +291,10 @@ func (c *fakeCloudProvider) ResizeDisk(ctx context.Context, volumeID string, new
 	return 0, cloud.ErrNotFound
 }
 
+func (c *fakeCloudProvider) GetVolumeAttachLimit(ctx context.Context, nodeID string) (int, error) {
+	return 39, nil
+}
+
 type fakeMounter struct {
 	exec.Interface
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Update in Volume Attach Limit - Fix

**What is this PR about? / Why do we need it?**
VolumeAttachLimit is updated. Different instances have different attachment limit and it is updated in this PR.
We need it because previously only two common values were used irrespective of the type of instance. Few instances allow only 19 or 11 volumeAttachLimit, but the current repo accepts limits upto 39 or 24. Hence it should be updated accordingly.

Reference: 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances

**What testing is done?** 
Unit testing is done.
Checked it using csc tool. Below are the screenshots. When the CO calls the NodeGetInfo, the volumeAttachLimit is called on the node and the volumeAttachLimit is calculated based on the other attachments(ENI and BlockDevices attached) to the node.
![Screen Shot 2021-09-29 at 2 07 05 PM](https://user-images.githubusercontent.com/37205646/135352487-87fa1c94-21ea-4bda-b306-e0ea86b78512.png)
The result 37 because the node already has a ENI attached to it and two EBS root volume. The queried instance is t2.large.
![Screen Shot 2021-09-29 at 2 06 54 PM](https://user-images.githubusercontent.com/37205646/135352502-755e4ad4-9f3e-49fc-9026-96d85dbf4231.png)


