### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,3 +1,6 @@
+# v1.3.1
+* Push multi-arch/os image manifest to ECR.
+
 # v1.3.0
 ## Notable changes
 * Make NodePublish Mount Idempotent ([#1019](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1019), [@nirmalaagash](https://github.com/nirmalaagash))

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION=v1.3.0
+VERSION=v1.3.1
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 | AWS EBS CSI Driver \ CSI Version       | v0.3.0| v1.0.0 | v1.1.0 |
 |----------------------------------------|-------|--------|--------|
 | master branch                          | no    | no     | yes    |
-| v1.3.0                                 | no    | no     | yes    |
+| v1.3.x                                 | no    | no     | yes    |
 | v1.2.x                                 | no    | no     | yes    |
 | v1.1.x                                 | no    | no     | yes    |
 | v1.0.0                                 | no    | no     | yes    |
@@ -80,7 +80,7 @@ Following sections are Kubernetes specific. If you are Kubernetes user, use foll
 | AWS EBS CSI Driver \ Kubernetes Version| v1.12 | v1.13 | v1.14 | v1.15 | v1.16 | v1.17 | v1.18+|
 |----------------------------------------|-------|-------|-------|-------|-------|-------|-------|
 | master branch                          | no    | no+   | no    | no    | no    | yes   | yes   |
-| v1.3.0                                 | no    | no+   | no    | no    | no    | yes   | yes   |
+| v1.3.x                                 | no    | no+   | no    | no    | no    | yes   | yes   |
 | v1.2.x                                 | no    | no+   | no    | no    | no    | yes   | yes   |
 | v1.1.x                                 | no    | no+   | no    | no    | no    | yes   | yes   |
 | v1.0.0                                 | no    | no+   | no    | no    | no    | yes   | yes   |
@@ -100,6 +100,7 @@ Following sections are Kubernetes specific. If you are Kubernetes user, use foll
 ## Container Images:
 |AWS EBS CSI Driver Version | GCR Image                                        | ECR Image                                                                   |
 |---------------------------|--------------------------------------------------|-----------------------------------------------------------------------------|
+|v1.3.1                     |k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.1 | 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver:v1.3.1  |
 |v1.3.0                     |k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.0 | 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver:v1.3.0  |
 |v1.2.1                     |k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.1 | 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver:v1.2.1  |
 |v1.2.0                     |k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.2.0 | 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver:v1.2.0  |


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** This release is to mark the start of the image in ECR being multi-arch/os just like the image in GCR/Docker Hub. EKS documentation points to the image in ECR and EKS supports linux/arm instances + windows/amd instances so the image in ECR ought to run on such instances. Anyway, it has been a source of confusion how different registries host different variations of the driver image so this release should make it so all registries are equal and facilitate the deprecation of GCR/Dcoker Hub as announced in v1.1.3.

**What testing is done?** 
