### PR TITLE
deploy: Add resizer and snapshotter images to kustomization

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -15,6 +15,12 @@ images:
   - name: k8s.gcr.io/sig-storage/livenessprobe
     newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.2.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
+    newTag: v3.0.3-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
+    newTag: v1.0.1-eks-1-18-3
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -11,5 +11,9 @@ images:
     newTag: v3.1.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
     newTag: v2.2.0
+  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+    newTag: v3.0.3
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newTag: v1.0.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newTag: v2.1.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

* Set `csi-snapshotter` and `csi-resizer` images in `kustomization.yaml` like the others
* Add their Public ECR counterparts in ECR overlay

**What testing is done?**

Deployed images from Public ECR on EKS
