### PR TITLE
deploy: Fix csi-resizer tag and bump to v1.1.0

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -122,7 +122,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.0.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -20,7 +20,7 @@ images:
     newTag: v3.0.3-eks-1-18-3
   - name: k8s.gcr.io/sig-storage/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newTag: v1.0.1-eks-1-18-3
+    newTag: v1.1.0-eks-1-18-3
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -14,6 +14,6 @@ images:
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
     newTag: v3.0.3
   - name: k8s.gcr.io/sig-storage/csi-resizer
-    newTag: v1.0.0
+    newTag: v1.1.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newTag: v2.1.0


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Follow up on #1080. I tried to keep versions consistent between GCR and ECR, but did not notice 1.0.1 was not built against Kubernetes 1.18.3.

This uses `v1.1.0-eks-1-18-3`, so all ECR images are built against Kubernetes 1.18.3, and updates the GCR image as to v1.1.0 as well for consistency.

Changelog: https://github.com/kubernetes-csi/external-resizer/blob/release-1.1/CHANGELOG-1.1.md

**What testing is done?**

```
docker pull public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.1.0-eks-1-18-3
docker pull k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
```

Running the ECR image in multiple environments (actually `v1.1.0-eks-1-19-8` to be exact).
