### PR TITLE
Reorder isMounted for readability

### DIFF
--- a/examples/kubernetes/windows/README.md
+++ b/examples/kubernetes/windows/README.md
@@ -7,7 +7,7 @@ This example shows how to create a EBS volume and consume it from a Windows cont
 
 1. A 1.18+ Windows node. Windows support has only been tested on 1.18 EKS Windows nodes. https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
 2. [csi-proxy](https://github.com/kubernetes-csi/csi-proxy) v1.0.0+ installed on the Windows node.
-3. Driver v1.3.2 from GCR k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.2. It can be built and pushed to another image registry with the command `TAG=$MY_TAG REGISTRY=$MY_REGISTRY make all-push` where `MY_TAG` refers to the image tag to push and `MY_REGISTRY` to the destination image registry like "XXXXXXXXXXXX.dkr.ecr.us-west-2.amazonaws.com"
+3. Driver v1.3.2 from GCR: `k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.2`. It can be built and pushed to another image registry with the command `TAG=$MY_TAG REGISTRY=$MY_REGISTRY make all-push` where `MY_TAG` refers to the image tag to push and `MY_REGISTRY` to the destination image registry like "XXXXXXXXXXXX.dkr.ecr.us-west-2.amazonaws.com"
 4. The driver installed with the Node plugin on the Windows node and the Controller plugin on a Linux node: `helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --set node.enableWindows=true --set image.repository=$MY_REGISTRY/aws-ebs-csi-driver --set image.tag=$MY_TAG`
 
 ## Usage


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** my addition https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1081 made this function a bit confusing https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1083#discussion_r726607784 so want to do some quick refactoring before I forget what intention of my change was.

- make return value explicit for each case
  - if returning error, just return false. The caller should check the error and ignore the boolean.
  - if target DNE, just return false. IsLikelyNotMountPoint must have returned "true, ErrNotExists", so returning "false, nil" is the same as returning "!notMnt, nil" like this function was doing before
- add debug log message for case when target path doesn't exist (on Windows it would be annoying at lower verbosity cuz it would get printed all the time
- make isMounted come right after preparePublishPath in both the block and non-block case.

**What testing is done?** 
