### PR TITLE
Update windows example to refer to v1.4.0

### DIFF
--- a/examples/kubernetes/windows/README.md
+++ b/examples/kubernetes/windows/README.md
@@ -7,7 +7,7 @@ This example shows how to create a EBS volume and consume it from a Windows cont
 
 1. A 1.18+ Windows node. Windows support has only been tested on 1.18 EKS Windows nodes. https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html
 2. [csi-proxy](https://github.com/kubernetes-csi/csi-proxy) v1.0.0+ installed on the Windows node.
-3. Driver v1.3.2 from GCR: `k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.2`. It can be built and pushed to another image registry with the command `TAG=$MY_TAG REGISTRY=$MY_REGISTRY make all-push` where `MY_TAG` refers to the image tag to push and `MY_REGISTRY` to the destination image registry like "XXXXXXXXXXXX.dkr.ecr.us-west-2.amazonaws.com"
+3. Driver v1.4.0 from GCR: `k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.4.0`. It can be built and pushed to another image registry with the command `TAG=$MY_TAG REGISTRY=$MY_REGISTRY make all-push` where `MY_TAG` refers to the image tag to push and `MY_REGISTRY` to the destination image registry like "XXXXXXXXXXXX.dkr.ecr.us-west-2.amazonaws.com"
 4. The driver installed with the Node plugin on the Windows node and the Controller plugin on a Linux node: `helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --set node.enableWindows=true --set image.repository=$MY_REGISTRY/aws-ebs-csi-driver --set image.tag=$MY_TAG`
 
 ## Usage


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /bug

**What is this PR about? / Why do we need it?** originally planned to release 1.3.2 with the fix https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1081 but it's only in 1.4.0 as of now

**What testing is done?** 
examples works for me with 1.4.0. there might be other bugs preventing it from working for others (still debugging their reports) but for now 1.4.0 is the minimum.