### PR TITLE
Bump eksctl used in e2e tests to 0.69.0

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -6,7 +6,7 @@ function eksctl_install() {
   INSTALL_PATH=${1}
   EKSCTL_VERSION=${2}
   if [[ ! -e ${INSTALL_PATH}/eksctl ]]; then
-    EKSCTL_DOWNLOAD_URL="https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_$(uname -s)_amd64.tar.gz"
+    EKSCTL_DOWNLOAD_URL="https://github.com/weaveworks/eksctl/releases/download/v${EKSCTL_VERSION}/eksctl_$(uname -s)_amd64.tar.gz"
     curl --silent --location "${EKSCTL_DOWNLOAD_URL}" | tar xz -C "${INSTALL_PATH}"
     chmod +x "${INSTALL_PATH}"/eksctl
   fi
@@ -68,6 +68,7 @@ function eksctl_create_cluster() {
 
   if [[ "$WINDOWS" == true ]]; then
     ${BIN} create nodegroup \
+      --managed=false \
       --cluster="${CLUSTER_NAME}" \
       --node-ami-family=WindowsServer2019FullContainer \
       -n ng-windows \

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -57,7 +57,7 @@ KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
 
-EKSCTL_VERSION=${EKSCTL_VERSION:-0.56.0-rc.1}
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.69.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
 # Creates a windows node group. The windows ami doesn't (yet) install csi-proxy


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** bump eksctl. 1.21 support was added at some point

**What testing is done?** 
