### PR TITLE
Replace deprecated arg "--extra-volume-tags" by "--extra-tags"

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Helm chart
 
+## v2.4.1
+
+* Replace deprecated arg `--extra-volume-tags` by `--extra-tags`
+
 ## v2.4.0
 
 * Bump app/driver version to `v1.4.0`

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.4.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.4.0
+version: 2.4.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -56,7 +56,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-Convert the `--extra-volume-tags` command line arg from a map.
+Convert the `--extra-tags` command line arg from a map.
 */}}
 {{- define "aws-ebs-csi-driver.extra-volume-tags" -}}
 {{- $result := dict "pairs" (list) -}}
@@ -64,7 +64,7 @@ Convert the `--extra-volume-tags` command line arg from a map.
 {{- $noop := printf "%s=%v" $key $value | append $result.pairs | set $result "pairs" -}}
 {{- end -}}
 {{- if gt (len $result.pairs) 0 -}}
-{{- printf "%s=%s" "- --extra-volume-tags" (join "," $result.pairs) -}}
+{{- printf "%s=%s" "- --extra-tags" (join "," $result.pairs) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bugfix

**What is this PR about? / Why do we need it?**
Get rid of `DEPRECATION WARNING: --extra-volume-tags is deprecated, please use --extra-tags instead`

**What testing is done?** 
The chart has been deployed to own EKS cluster