### PR TITLE
[chart] Allow installing snapshotter with storage.io API v1beta1

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -189,7 +189,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1" }}
+        {{- if or (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
         - name: csi-snapshotter
           image: {{ printf "%s:%s" .Values.sidecars.snapshotter.image.repository .Values.sidecars.snapshotter.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.snapshotter.image.pullPolicy }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Rather a bug fix/

**What is this PR about? / Why do we need it?**
This PR fixes the inability to deploy snapshotter in environments featuring storage.io API at v1beta1

**What testing is done?** 
Deployed to an number of EKS clusters at 1.18 and having snapshot.storage.k8s.io/v1beta1 CRD deployed; confirmed the snapshotter to work as expected.