### PR TITLE
Add support for securityContext in controller

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Helm chart
 
+## v2.5.1
+
+* Add securityContext support for controller Deployment
+
 ## v2.5.0
 
 * Bump app/driver version to `v1.5.0`
-
 
 ## v2.4.1
 

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Helm chart
 
-## v2.5.1
+## v2.6.0
 
 * Add securityContext support for controller Deployment
 

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.6.0
 
 * Add securityContext support for controller Deployment
+* Bump app/driver version to `v1.6.0`
 
 ## v2.5.0
 

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.5.0
+appVersion: 1.6.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
 version: 2.6.0

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.5.1
+version: 2.6.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -57,6 +57,10 @@ spec:
       topologySpreadConstraints:
         {{- $constraints | toYaml | nindent 8 }}
       {{- end }}
+      securityContext:
+        {{- with .Values.controller.securityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }} 
       containers:
         - name: ebs-plugin
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -57,10 +57,10 @@ spec:
       topologySpreadConstraints:
         {{- $constraints | toYaml | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- with .Values.controller.securityContext }}
+      {{- with .Values.controller.securityContext }}
+      securityContext:  
         {{- toYaml . | nindent 8 }}
-        {{- end }} 
+      {{- end }} 
       containers:
         - name: ebs-plugin
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -133,6 +133,9 @@ controller:
   #    topologyKey: kubernetes.io/hostname
   #    whenUnsatisfiable: ScheduleAnyway
   topologySpreadConstraints: []
+  securityContext: {}
+  #  AWS EKS /var/run/secrets/eks.amazonaws.com/serviceaccount/token FS group is nogroup (65534) - required for Kubernetes 1.18.x and below
+  #  fsGroup: 65534
 
 node:
   env: []


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix for EKS kubernetes versions below `1.19`.

**What is this PR about? / Why do we need it?**
Your [compatibility matrix ](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/v1.2.1#kubernetes-version-compatibility-matrix)says that appVersion 1.2.1 of the Helm Chart supports Kubernetes versions 1.17 and above. In EKS this [does not seem to be the case](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#run-the-application-as-a-non-root-user).

We are running appVersion 1.2.1 of the `aws-ebs-csi-driver` on EKS Kubernetes `v1.18` and encountered the following error when the controller attempted to mount an EBS volume:
```
error listing AWS instances: "WebIdentityErr: failed fetching WebIdentity token: \ncaused by: WebIdentityErr: unable to read file at /var/run/secrets/eks.amazonaws.com/serviceaccount/token\ncaused by: open /var/run/secrets/eks.amazonaws.com/serviceaccount/token: permission denied"
```
This seems expected based on the AWS EKS doc I linked above, so we manually added the following to our controller Deployment live manifest and relaunched the controller pods:
```
controller:
  securityContext:
    fsGroup: 65534
```
Which immediately resulted in the EBS volume being successfully mounted:
```
  Normal  Provisioning           2m38s                  ebs.csi.aws.com_ebs-csi-controller-7b97794f89-kmhvx_c175a4ba-04a7-4508-a727-fb727d13bd58  External provisioner is provisioning volume for claim "workflow-engine/data-staging-green-zeebe-0"
  Normal  ProvisioningSucceeded  2m33s                  ebs.csi.aws.com_ebs-csi-controller-7b97794f89-kmhvx_c175a4ba-04a7-4508-a727-fb727d13bd58  Successfully provisioned volume pvc-37b7bc12-95af-4420-8f7d-a0bb2f026adc
```

**What testing is done?** 
I ran through your `make verify`, `make test` and `make test-integration` but they all failed with `ERROR: vendor check failed`, which is not a directory I touched for this PR.
