### PR TITLE
Allow AWS access key secret name to be overridden via Helm values

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Helm chart
 
+## v2.6.0
+
+* Support overriding access key secret name via Helm values
+
 ## v2.5.0
 
 * Bump app/driver version to `v1.5.0`
-
 
 ## v2.4.1
 

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.5.0
+version: 2.6.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -92,13 +92,13 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
+                  name: {{ .Values.accessKeySecret }}
                   key: key_id
                   optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
+                  name: {{ .Values.accessKeySecret }}
                   key: access_key
                   optional: true
             {{- with .Values.controller.region }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -65,6 +65,7 @@ proxy:
   no_proxy:
 
 imagePullSecrets: []
+accessKeySecret: aws-secret
 nameOverride:
 fullnameOverride:
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

This PR adds an option to override the name of the source k8s secret for AWS access key(s) used by the controller via Helm values. This is useful in cases where the end user has multiple systems running in the same namespace which may result in conflicting and/or unclear secret names.

Note that the default value is set to `aws-secret` so this should not break existing workflows.

**What testing is done?** 

Templating/installing in a k8s cluster:

```bash
# default values results in using aws-secret as the source secret
helm upgrade --install aws-ebs-csi-driver ./charts/aws-ebs-csi-driver

# overriding accessKeySecret results in using my-secret as the source secret
helm upgrade --install aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set accessKeySecret=my-secret
```
