### PR TITLE
add ecr-private kustomize overlay

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,26 +1,25 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../../../base
+  - ../ecr
 images:
-  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
     newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
-    newTag: v1.4.0
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newTag: v2.1.1-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-attacher
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
     newTag: v3.1.0-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/livenessprobe
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.2.0-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
     newTag: v3.0.3-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-resizer
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
     newTag: v1.1.0-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
+    newTag: v1.4.0
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.1.1-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-attacher
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+    newTag: v3.1.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newTag: v2.2.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
+    newTag: v3.0.3-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
+    newTag: v1.1.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -7,20 +7,20 @@ images:
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
     newTag: v1.4.0
   - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v2.1.1-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
+    newTag: v2.1.1
   - name: k8s.gcr.io/sig-storage/csi-attacher
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    newTag: v3.1.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
+    newTag: v3.1.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.2.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
+    newTag: v2.2.0
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newTag: v3.0.3-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
+    newTag: v3.0.3
   - name: k8s.gcr.io/sig-storage/csi-resizer
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newTag: v1.1.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
+    newTag: v1.1.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.1.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+    newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,26 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../../../base
+  - ../gcr
 images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-    newTag: v1.4.0
   - name: k8s.gcr.io/sig-storage/csi-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v2.1.1
   - name: k8s.gcr.io/sig-storage/csi-attacher
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
-    newTag: v3.1.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.2.0
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
-    newTag: v3.0.3
   - name: k8s.gcr.io/sig-storage/csi-resizer
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
-    newTag: v1.1.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newTag: v1.4.0
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
+    newTag: v2.1.1
+  - name: k8s.gcr.io/sig-storage/csi-attacher
+    newTag: v3.1.0
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newTag: v2.2.0
+  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+    newTag: v3.0.3
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newTag: v1.1.0
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,19 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
-images:
-  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-    newTag: v1.4.0
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newTag: v2.1.1
-  - name: k8s.gcr.io/sig-storage/csi-attacher
-    newTag: v3.1.0
-  - name: k8s.gcr.io/sig-storage/livenessprobe
-    newTag: v2.2.0
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
-    newTag: v3.0.3
-  - name: k8s.gcr.io/sig-storage/csi-resizer
-    newTag: v1.1.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.1.0
+resources:
+  - ./ecr-public


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature.

**What is this PR about? / Why do we need it?**
Address @wongma7's comment on PR #1098: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1098#discussion_r733131616.

This will allow ECR Private to be used when pulling images. Advantages of this method include being able to use the ECR Endpoint and to target a specific AWS Region where the image will be pulled from.

I decided to use `ecr` as the overlay for ECR Private and `ecr-public` as the overlay for ECR Public for it to match the identifiers of both services used on their domains and when writing IAM policies for them.

**What testing is done?** 
Check that all images referenced on Kustomization are publicly available.

It's important to note that `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/external-resizer` doesn't seem to be accessible to everyone. I opened a support ticket on AWS so this issue can be fixed (Case ID 9276886011).