### PR TITLE
images: use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 3600s
 steps:
-  - name: gcr.io/k8s-testimages/gcb-docker-gcloud:v20210722-085d930
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af
     entrypoint: ./hack/prow.sh
     env:
       - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523