### PR TITLE
images: fix invalid k8s-staging-test-infra/gcb-docker-gcloud tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 3600s
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: ./hack/prow.sh
     env:
       - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1125

I copy-pasted the wrong tag :sweat_smile:  Sorry about the churn