### PR TITLE
remove tag override from ecr overlay

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -5,7 +5,6 @@ bases:
 images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-    newTag: v1.5.0
   - name: k8s.gcr.io/sig-storage/csi-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
   - name: k8s.gcr.io/sig-storage/csi-attacher


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature.

**What is this PR about? / Why do we need it?**
Remove tag override from ECR overlay. The GCR overlay now has the same version of the CSI Driver as the other overlays, so this patch on the tag is not needed any longer.

This will also help to keep the same version of the CSI Driver synced between all overlays.

**What testing is done?** 
Run `kustomize build` and check the output is the same as before.
