### PR TITLE
Use TARGETOS/TARGETARCH in Dockerfile but OS/ARCH in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# See
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+# for info on BUILDPLATFORM, TARGETOS, TARGETARCH, etc.
 FROM --platform=$BUILDPLATFORM golang:1.17 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY . .
-ARG OS
-ARG ARCH
-RUN make $OS/$ARCH
+ARG TARGETOS
+ARG TARGETARCH
+RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
 FROM amazonlinux:2 AS linux-amazon
 RUN yum update -y && \

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,11 @@ ALL_OS?=linux windows
 ALL_ARCH_linux?=amd64 arm64
 ALL_OSVERSION_linux?=amazon
 ALL_OS_ARCH_OSVERSION_linux=$(foreach arch, $(ALL_ARCH_linux), $(foreach osversion, ${ALL_OSVERSION_linux}, linux-$(arch)-${osversion}))
+
 ALL_ARCH_windows?=amd64
 ALL_OSVERSION_windows?=1809 2004 20H2
 ALL_OS_ARCH_OSVERSION_windows=$(foreach arch, $(ALL_ARCH_windows), $(foreach osversion, ${ALL_OSVERSION_windows}, windows-$(arch)-${osversion}))
+
 ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})
 
 # split words on hyphen, access by 1-index
@@ -84,7 +86,7 @@ annotate-manifest: .annotate-manifest-$(OS)-$(ARCH)-$(OSVERSION)
 .annotate-manifest-$(OS)-$(ARCH)-$(OSVERSION):
 	set -x; docker manifest annotate --os $(OS) --arch $(ARCH) --os-version $(OSVERSION) $(IMAGE):$(TAG) $(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 
-# only linux for OUTPUT_TYPE=docker because windows image cannot be exported
+# Only linux for OUTPUT_TYPE=docker because windows image cannot be exported
 # "Currently, multi-platform images cannot be exported with the docker export type. The most common usecase for multi-platform images is to directly push to a registry (see registry)."
 # https://docs.docker.com/engine/reference/commandline/buildx_build/#output
 all-image-docker: $(addprefix sub-image-docker-,$(ALL_OS_ARCH_OSVERSION_linux))
@@ -97,8 +99,6 @@ image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
 	docker buildx build \
 		--platform=$(OS)/$(ARCH) \
-		--build-arg OS=$(OS) \
-		--build-arg ARCH=$(ARCH) \
 		--progress=plain \
 		--target=$(OS)-$(OSVERSION) \
 		--output=type=$(OUTPUT_TYPE) \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?** The Makefile->Dockerfile->Makefile recursion is pretty confusing. I think it would be clearer if:
1. the Makefile continues to use OS and ARCH.
2. then when the Makefile invokes Dockerfile, it passes --platform which magically sets the args TARGETOS and TARGETARCH: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope. This means build-arg OS and build-arg ARCH are redundant, so I'm removing them.
3. then when the Dockerfile invokes Makefile, it sets OS to TARGETOS and ARCH to TARGETARCH

**What testing is done?** 
`make image` still works as intended.
```
#11 [builder 4/4] RUN OS=linux ARCH=amd64 make linux/amd64
#11 0.182 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags "-X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.driverVersion=v1.5.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud.driverVersion=v1.5.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=9ac4ce71cb3feb3f6268456f5ccdb8d487dff4d2 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=2021-12-09T00:12:00+00:00 -s -w" -o bin/aws-ebs-csi-driver ./cmd/
```
testing another platform:
`OS=linux ARCH=arm64 make image` works as intended
```
#11 [builder 4/4] RUN OS=linux ARCH=arm64 make linux/arm64
#11 0.185 CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=vendor -ldflags "-X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.driverVersion=v1.5.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud.driverVersion=v1.5.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=092cc89ba5d73fd0dc84b0d536714035769a2b49 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=2021-12-09T00:12:22+00:00 -s -w" -o bin/aws-ebs-csi-driver ./cmd/

$ docker run -it --rm --entrypoint sh gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:092cc89ba5d73fd0dc84b0d536714035769a2b49-linux-arm64-amazon
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested
sh-4.2# file /bin/aws-ebs-csi-driver 
/bin/aws-ebs-csi-driver: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
```

`OS=windows ARCH=amd64 OSVERSION=1809 make image` works as intended
```
#10 [builder 4/4] RUN OS=windows ARCH=amd64 make windows/amd64
#10 0.163 CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -mod=vendor -ldflags "-X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.driverVersion=v1.5.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud.driverVersion=v1.5.0 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.gitCommit=092cc89ba5d73fd0dc84b0d536714035769a2b49 -X github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver.buildDate=2021-12-09T00:14:38+00:00 -s -w" -o bin/aws-ebs-csi-driver.exe ./cmd/
```