### PR TITLE
Fix canonical nvme device resolution in more cases

### DIFF
--- a/pkg/driver/node_linux_test.go
+++ b/pkg/driver/node_linux_test.go
@@ -36,7 +36,9 @@ func TestFindDevicePath(t *testing.T) {
 	nvmeDevicePath := "/dev/nvme1n1"
 	volumeID := "vol-test"
 	nvmeName := "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_voltest"
+	deviceFileInfo := fs.FileInfo(&fakeFileInfo{devicePath, os.ModeDevice})
 	symlinkFileInfo := fs.FileInfo(&fakeFileInfo{nvmeName, os.ModeSymlink})
+	nvmeDevicePathSymlinkFileInfo := fs.FileInfo(&fakeFileInfo{nvmeDevicePath, os.ModeSymlink})
 	type testCase struct {
 		name             string
 		devicePath       string
@@ -55,9 +57,8 @@ func TestFindDevicePath(t *testing.T) {
 			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
 				gomock.InOrder(
 					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(true, nil),
-
-					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(symlinkFileInfo, nil),
-					mockDeviceIdentifier.EXPECT().EvalSymlinks(gomock.Eq(symlinkFileInfo.Name())).Return(nvmeDevicePath, nil),
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(devicePath)).Return(nvmeDevicePathSymlinkFileInfo, nil),
+					mockDeviceIdentifier.EXPECT().EvalSymlinks(gomock.Eq(devicePath)).Return(nvmeDevicePath, nil),
 				)
 			},
 			expectDevicePath: nvmeDevicePath,
@@ -70,8 +71,7 @@ func TestFindDevicePath(t *testing.T) {
 			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
 				gomock.InOrder(
 					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(true, nil),
-
-					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(nil, os.ErrNotExist),
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(devicePath)).Return(deviceFileInfo, nil),
 				)
 			},
 			expectDevicePath: devicePath,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix further improving on https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1082

**What is this PR about? / Why do we need it?**
- It allows the `/dev/xvdXX` symlinks to continue to function, but properly identifies them as nvme devices based on the `/dev/nvme` prefix
- No matter what kind of symlinking is setup, it will always find the canonical block device because all symlinks are always resolved now. This means that if some crazy non-nitro system had `/dev/xvdb` symlinked to `/dev/sdb`, even that would work correctly.
- nvme devices resolved via the `/dev/xvdXX` symlinks will now correctly handle appending the partition string
- The `/dev/disk/by-id` fallback continues to work correctly
- It fixes logging for `node_linux.go`: this file was using klog v2 while the rest of the repo was using v1 so its logging was going nowhere

**What testing is done?** 
- Tested on:
  - a kubelet with just the `/dev/xvdXX` udev rules for nvme devices
  - a kubelet with just the `/dev/disk/by-id` udev rules for nvme devices
  - a kubelet with both sets of udev rules present
- On each of those, I confirmed that:
  - pods with PVCs can be created and deleted successfully
  - when kubelet in 1.21 is restarted, the CSI driver correctly recognizes that the volumes are already mounted and the operation is idempotent