### PR TITLE
Updated deprecated exec command in READMEs

### DIFF
--- a/examples/kubernetes/block-volume/README.md
+++ b/examples/kubernetes/block-volume/README.md
@@ -25,7 +25,7 @@ app    1/1     Running   0          16m
 Verify the device node is mounted inside the container:
 
 ```sh
-$ kubectl exec -ti app -- ls -al /dev/xvda
+$ kubectl exec -it app -- ls -al /dev/xvda
 brw-rw----    1 root     disk      202, 23296 Mar 12 04:23 /dev/xvda
 ```
 

--- a/examples/kubernetes/dynamic-provisioning/README.md
+++ b/examples/kubernetes/dynamic-provisioning/README.md
@@ -21,7 +21,7 @@ kubectl describe pv
 
 3. Validate the pod successfully wrote data to the volume:
 ```
-kubectl exec -it app cat /data/out.txt
+kubectl exec -it app -- cat /data/out.txt
 ```
 
 4. Cleanup resources:

--- a/examples/kubernetes/resizing/README.md
+++ b/examples/kubernetes/resizing/README.md
@@ -34,7 +34,7 @@ You should see that both should have the new value relfected in the capacity fie
 
 6. Verify that the application is continuously running without any interruption:
 ```sh
-kubectl exec -it app cat /data/out.txt
+kubectl exec -it app -- cat /data/out.txt
 ```
 
 7. Cleanup resources:

--- a/examples/kubernetes/snapshot/README.md
+++ b/examples/kubernetes/snapshot/README.md
@@ -34,7 +34,7 @@ kubectl describe pv
 
 4. Validate the pod successfully wrote data to the volume, taking note of the timestamp of the first entry:
 ```
-kubectl exec -it app cat /data/out.txt
+kubectl exec -it app -- cat /data/out.txt
 ```
 
 5. Create a `VolumeSnapshot` referencing the `PersistentVolumeClaim` name:
@@ -59,7 +59,7 @@ kubectl apply -f specs/snapshot-restore/
 
 9. Validate the new pod has the restored data by comparing the timestamp of the first entry to that of in step 4:
 ```
-kubectl exec -it app cat /data/out.txt
+kubectl exec -it app -- cat /data/out.txt
 ```
 
 10. Cleanup resources:

--- a/examples/kubernetes/static-provisioning/README.md
+++ b/examples/kubernetes/static-provisioning/README.md
@@ -42,7 +42,7 @@ kubectl describe po app
 
 4. Validate the pod successfully wrote data to the volume:
 ```sh
-kubectl exec -it app cat /data/out.txt
+kubectl exec -it app -- cat /data/out.txt
 ```
 
 5. Cleanup resources:

--- a/examples/kubernetes/storageclass/README.md
+++ b/examples/kubernetes/storageclass/README.md
@@ -16,7 +16,7 @@ kubectl describe pv
 
 4. Validate the pod successfully wrote data to the volume:
 ```sh
-kubectl exec -it app cat /data/out.txt
+kubectl exec -it app -- cat /data/out.txt
 ```
 
 5. Cleanup resources:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a slight fix in the `examples/kubernetes` READMEs

**What is this PR about? / Why do we need it?**
In some of the documentation, you are told to execute a command the format of which is deprecated. This gives you the following warning:
`kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.`

With my changes, it no longer uses the deprecated way of executing commands in pod.

**What testing is done?** 

As you can see by the following snippet, it no longer shows the **deprecated** warning when using the double dashes in the exec command.
```
$ kubectl run --image=nginx my-app
pod/my-app created
$ kubectl exec -it my-app echo "test"
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
test
$ kubectl exec -it my-app -- echo "test"
test
```

Signed-off-by: Mathis Van Eetvelde <mathis.vaneetvelde@protonmail.com>
