### PR TITLE
[release-1.5] add ecr-private kustomize overlay and Update ECR sidecars to 1-18-13

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Helm chart
 
+## v2.6.2
+
+* Update csi-resizer version to v1.1.0
+
+## v2.6.1
+
+* Add securityContext support for controller Deployment
 
 ## v2.5.0
 
 * Bump app/driver version to `v1.5.0`
+
+## v2.4.1
+
+* Replace deprecated arg `--extra-volume-tags` by `--extra-tags`
 
 ## v2.4.0
 

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.5.0
+version: 2.6.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -8,6 +8,11 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# -- Custom labels to add into metadata
+customLabels:
+  {}
+  # k8s-app: aws-ebs-csi-driver
+
 sidecars:
   provisioner:
     env: []
@@ -37,14 +42,14 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/livenessprobe
-      tag: "v2.2.0"
+      tag: "v2.4.0"
     resources: {}
   resizer:
     env: []
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-resizer
-      tag: "v1.0.0"
+      tag: "v1.1.0"
     logLevel: 2
     resources: {}
   nodeDriverRegistrar:
@@ -113,8 +118,8 @@ controller:
   #   cpu: 100m
   #   memory: 128Mi
   serviceAccount:
-    create: true  # A service account will be created for you if set to true. Set to false if you want to use your own.
-    name: ebs-csi-controller-sa  # Name of the service-account to be used/created.
+    create: true # A service account will be created for you if set to true. Set to false if you want to use your own.
+    name: ebs-csi-controller-sa # Name of the service-account to be used/created.
     annotations: {}
   tolerations: []
   # TSCs without the label selector stanza
@@ -129,6 +134,9 @@ controller:
   #    topologyKey: kubernetes.io/hostname
   #    whenUnsatisfiable: ScheduleAnyway
   topologySpreadConstraints: []
+  securityContext: {}
+  #  AWS EKS /var/run/secrets/eks.amazonaws.com/serviceaccount/token FS group is nogroup (65534) - required for Kubernetes 1.18.x and below
+  #  fsGroup: 65534
 
 node:
   env: []

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -28,10 +28,10 @@ spec:
           operator: Exists
         - operator: Exists
           effect: NoExecute
-          tolerationSeconds: 300
+          tolerationSeconds: 300 
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.0
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -45,7 +45,7 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.3.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver:v1.5.0
           imagePullPolicy: IfNotPresent
           args:
             - node

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,26 +1,25 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../../../base
+  - ../ecr
 images:
-  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
     newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
-    newTag: v1.4.0
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newTag: v2.1.1-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-attacher
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
     newTag: v3.1.0-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/livenessprobe
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newTag: v2.2.0-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
     newTag: v3.0.3-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-resizer
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
     newTag: v1.1.0-eks-1-18-3
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -7,19 +7,19 @@ images:
     newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v2.1.1-eks-1-18-3
+    newTag: v2.1.1-eks-1-18-13
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    newTag: v3.1.0-eks-1-18-3
+    newTag: v3.1.0-eks-1-18-13
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.2.0-eks-1-18-3
+    newTag: v2.2.0-eks-1-18-13
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newTag: v3.0.3-eks-1-18-3
+    newTag: v3.0.3-eks-1-18-13
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newTag: v1.1.0-eks-1-18-3
+    newTag: v1.1.0-eks-1-18-13
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.1.0-eks-1-18-3
+    newTag: v2.1.0-eks-1-18-13

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
+    newTag: v1.4.0
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newTag: v2.1.1-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-attacher
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+    newTag: v3.1.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newTag: v2.2.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
+    newTag: v3.0.3-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
+    newTag: v1.1.0-eks-1-18-3
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newTag: v2.1.0-eks-1-18-3

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,26 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../../../base
+  - ../gcr
 images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-    newTag: v1.5.0
   - name: k8s.gcr.io/sig-storage/csi-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newTag: v2.1.1
   - name: k8s.gcr.io/sig-storage/csi-attacher
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
-    newTag: v3.1.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newTag: v2.2.0
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
-    newTag: v3.0.3
   - name: k8s.gcr.io/sig-storage/csi-resizer
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
-    newTag: v1.1.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -7,20 +7,20 @@ images:
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
     newTag: v1.5.0
   - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v2.1.1-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
+    newTag: v2.1.1
   - name: k8s.gcr.io/sig-storage/csi-attacher
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    newTag: v3.1.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
+    newTag: v3.1.0
   - name: k8s.gcr.io/sig-storage/livenessprobe
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.2.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
+    newTag: v2.2.0
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newTag: v3.0.3-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
+    newTag: v3.0.3
   - name: k8s.gcr.io/sig-storage/csi-resizer
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newTag: v1.1.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
+    newTag: v1.1.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.1.0-eks-1-18-3
+    newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
+    newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../../base
+images:
+  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newTag: v1.4.0
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
+    newTag: v2.1.1
+  - name: k8s.gcr.io/sig-storage/csi-attacher
+    newTag: v3.1.0
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newTag: v2.2.0
+  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+    newTag: v3.0.3
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newTag: v1.1.0
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newTag: v2.1.0

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,19 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-  - ../../base
-images:
-  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-    newTag: v1.5.0
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newTag: v2.1.1
-  - name: k8s.gcr.io/sig-storage/csi-attacher
-    newTag: v3.1.0
-  - name: k8s.gcr.io/sig-storage/livenessprobe
-    newTag: v2.2.0
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
-    newTag: v3.0.3
-  - name: k8s.gcr.io/sig-storage/csi-resizer
-    newTag: v1.1.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.1.0
+resources:
+  - ./ecr-public


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
**What is this PR about? / Why do we need it?** cherry-pick https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1124 (and https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1133) on 1.5 branch because that's where stable kustomize overlay lives i.e. where kustomize installation instructions point to


**What testing is done?** 
