### PR TITLE
Allow controller to use metadata service to fetch default AZ when not specified

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,6 +51,7 @@ func main() {
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),
 		driver.WithKubernetesClusterID(options.ControllerOptions.KubernetesClusterID),
 		driver.WithAwsSdkDebugLog(options.ControllerOptions.AwsSdkDebugLog),
+		driver.WithAvailabilityZoneFromMetadata(options.ControllerOptions.AvailabilityZoneFromMetadata),
 	)
 	if err != nil {
 		klog.Fatalln(err)

--- a/cmd/options/controller_options.go
+++ b/cmd/options/controller_options.go
@@ -35,6 +35,8 @@ type ControllerOptions struct {
 	KubernetesClusterID string
 	// flag to enable sdk debug log
 	AwsSdkDebugLog bool
+	// flag to enable metadata service for default topology
+	AvailabilityZoneFromMetadata bool
 }
 
 func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
@@ -42,4 +44,5 @@ func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.Var(cliflag.NewMapStringString(&s.ExtraVolumeTags), "extra-volume-tags", "DEPRECATED: Please use --extra-tags instead. Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.StringVar(&s.KubernetesClusterID, "k8s-tag-cluster-id", "", "ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).")
 	fs.BoolVar(&s.AwsSdkDebugLog, "aws-sdk-debug-log", false, "To enable the aws sdk debug log level (default to false).")
+	fs.BoolVar(&s.AvailabilityZoneFromMetadata, "az-from-metadata", false, "If true, use the metadata service to fetch controller AZ. Otherwise, default to a random one in the region.")
 }

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -1157,7 +1158,8 @@ func (c *cloud) getLatestVolumeModification(ctx context.Context, volumeID string
 }
 
 // randomAvailabilityZone returns a random zone from the given region
-// the randomness relies on the response of DescribeAvailabilityZones
+// the randomness is explicit because DescribeAvailabilityZones may
+// return an ordered list
 func (c *cloud) randomAvailabilityZone(ctx context.Context) (string, error) {
 	request := &ec2.DescribeAvailabilityZonesInput{}
 	response, err := c.ec2.DescribeAvailabilityZonesWithContext(ctx, request)
@@ -1170,7 +1172,9 @@ func (c *cloud) randomAvailabilityZone(ctx context.Context) (string, error) {
 		zones = append(zones, *zone.ZoneName)
 	}
 
-	return zones[0], nil
+	randomIndex := rand.Intn(len(zones))
+
+	return zones[randomIndex], nil
 }
 
 func volumeModificationDone(state string) bool {

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -316,7 +316,7 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 	if zone == "" {
 		var err error
 		zone, err = c.randomAvailabilityZone(ctx)
-		klog.V(5).Infof("[Debug] AZ is not provided. Using node AZ [%s]", zone)
+		klog.V(5).Infof("[Debug] AZ is not provided. Using random AZ [%s]", zone)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get availability zone %s", err)
 		}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -19,9 +19,11 @@ package driver
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -75,6 +77,7 @@ var (
 // newControllerService creates a new controller service
 // it panics if failed to create the service
 func newControllerService(driverOptions *DriverOptions) controllerService {
+	rand.Seed(time.Now().UTC().UnixNano())
 	region := os.Getenv("AWS_REGION")
 	if region == "" {
 		klog.V(5).Infof("[Debug] Retrieving region from metadata service")

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -49,10 +49,13 @@ func TestNewControllerService(t *testing.T) {
 		testErr    = errors.New("test error")
 		testRegion = "test-region"
 
-		getNewCloudFunc = func(expectedRegion string, awsSdkDebugLog bool) func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
-			return func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
+		getNewCloudFunc = func(expectedRegion string, expectedDefaultAvailabilityZone string, awsSdkDebugLog bool) func(region string, defaultAvailabilityZone string, awsSdkDebugLog bool) (cloud.Cloud, error) {
+			return func(region string, defaultAvailabilityZone string, awsSdkDebugLog bool) (cloud.Cloud, error) {
 				if region != expectedRegion {
 					t.Fatalf("expected region %q but got %q", expectedRegion, region)
+				}
+				if defaultAvailabilityZone != expectedDefaultAvailabilityZone {
+					t.Fatalf("expected defaultAvailabilityZone %q but got %q", expectedDefaultAvailabilityZone, defaultAvailabilityZone)
 				}
 				return cloudObj, nil
 			}
@@ -62,30 +65,30 @@ func TestNewControllerService(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		region                string
-		newCloudFunc          func(string, bool) (cloud.Cloud, error)
+		newCloudFunc          func(string, string, bool) (cloud.Cloud, error)
 		newMetadataFuncErrors bool
 		expectPanic           bool
 	}{
 		{
 			name:         "AWS_REGION variable set, newCloud does not error",
 			region:       "foo",
-			newCloudFunc: getNewCloudFunc("foo", false),
+			newCloudFunc: getNewCloudFunc("foo", "", false),
 		},
 		{
 			name:   "AWS_REGION variable set, newCloud errors",
 			region: "foo",
-			newCloudFunc: func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
+			newCloudFunc: func(region string, defaultAvailabilityZone string, awsSdkDebugLog bool) (cloud.Cloud, error) {
 				return nil, testErr
 			},
 			expectPanic: true,
 		},
 		{
 			name:         "AWS_REGION variable not set, newMetadata does not error",
-			newCloudFunc: getNewCloudFunc(testRegion, false),
+			newCloudFunc: getNewCloudFunc(testRegion, "", false),
 		},
 		{
 			name:                  "AWS_REGION variable not set, newMetadata errors",
-			newCloudFunc:          getNewCloudFunc(testRegion, false),
+			newCloudFunc:          getNewCloudFunc(testRegion, "", false),
 			newMetadataFuncErrors: true,
 			expectPanic:           true,
 		},

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -60,12 +60,13 @@ type Driver struct {
 }
 
 type DriverOptions struct {
-	endpoint            string
-	extraTags           map[string]string
-	mode                Mode
-	volumeAttachLimit   int64
-	kubernetesClusterID string
-	awsSdkDebugLog      bool
+	endpoint                     string
+	extraTags                    map[string]string
+	mode                         Mode
+	volumeAttachLimit            int64
+	kubernetesClusterID          string
+	awsSdkDebugLog               bool
+	availabilityZoneFromMetadata bool
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -189,5 +190,11 @@ func WithKubernetesClusterID(clusterID string) func(*DriverOptions) {
 func WithAwsSdkDebugLog(enableSdkDebugLog bool) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.awsSdkDebugLog = enableSdkDebugLog
+	}
+}
+
+func WithAvailabilityZoneFromMetadata(enableAZFromMetdata bool) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.availabilityZoneFromMetadata = enableAZFromMetdata
 	}
 }

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -366,7 +366,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
-		cloud, err := awscloud.NewCloud(region, false)
+		cloud, err := awscloud.NewCloud(region, "", false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -86,7 +86,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region, false)
+		cloud, err = awscloud.NewCloud(region, "", false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature (specify default AZ behaviour) along with some bugfixes and clarified log messages

**What is this PR about? / Why do we need it?**

If `zone` is unspecified in `VolumeOptions`, the default behaviour chooses a random availability zone. In practice, it is always the first availability zone listed (almost always(?) `<region>a`). This PR allows the controller operator to specify a flag which allows the default availability zone to be retrieved from the metadata service (as the region is).

**What testing is done?** 

Unit testing and some end-to-end testing in a staging environment on AWS.