### PR TITLE
Set prerelease=true for new releases before images are ready

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,4 +23,4 @@ jobs:
             ## CHANGELOG
             See [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG-0.x.md) for full list of changes
           draft: false
-          prerelease: false
+          prerelease: true

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -57,7 +57,7 @@ git push upstream v0.7.0
 
 ## Verify the release on GitHub
 
-The new tag should trigger a new Github release. Verify that it has run by going to [Releases](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases). Then, click on the new version and verify all assets have been created:
+The new tag should trigger a new Github release. It should be a pre-release true because images are not available yet and documentation, like README and CHANGELOG in master branch, does not yet reflect the new release. Verify that it has run by going to [Releases](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases). Then, click on the new version and verify all assets have been created:
 
 - Source code (zip)
 - Source code (tar.gz)
@@ -106,6 +106,10 @@ Send a PR to merge both the release and post-release commits to the main branch.
 ## Verify the helm chart release
 
 Visit the [Releases](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases) pages to verify we have a new helm chart release.
+
+## Update the GitHub release to be pre-release false
+
+Now that images are available and documentation is updated, uncheck "This is a pre-release".
 
 ## Update AWS EKS documentation
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

This is a hack to "hide" the release until images are ready. Right now, we cut a github release the moment a a tag is pushed. However, there is a period after that during which images need to be scanned and possibly rebuilt. Therefore we should treat the release as "pre-release" until we actually have a working image that passes tests/scans etc., at the end of the release process.

**What testing is done?** 
