### PR TITLE
Use k8s mount-utils for checking volume resize

### DIFF
--- a/pkg/driver/mount_linux.go
+++ b/pkg/driver/mount_linux.go
@@ -25,8 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/klog"
-
 	mountutils "k8s.io/mount-utils"
 )
 
@@ -73,49 +71,10 @@ func (m *NodeMounter) PathExists(path string) (bool, error) {
 	return mountutils.PathExists(path)
 }
 
-//TODO: use common util from vendor kubernetes/mount-util
 func (m *NodeMounter) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
-	// TODO(xiangLi) resize fs size on formatted file system following this PR https://github.com/kubernetes/kubernetes/pull/99223
-	// Port the in-tree un-released change first, need to remove after in-tree release
-	deviceSize, err := m.getDeviceSize(devicePath)
-	if err != nil {
-		return false, err
-	}
-	var fsSize, blockSize uint64
-	format, err := m.SafeFormatAndMount.GetDiskFormat(devicePath)
-	if err != nil {
-		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
-		return false, formatErr
-	}
-
-	// If disk has no format, there is no need to resize the disk because mkfs.*
-	// by default will use whole disk anyways.
-	if format == "" {
-		return false, nil
-	}
-
-	klog.V(3).Infof("ResizeFs.needResize - checking mounted volume %s", devicePath)
-	switch format {
-	case "ext3", "ext4":
-		blockSize, fsSize, err = m.getExtSize(devicePath)
-		klog.V(5).Infof("Ext size: filesystem size=%d, block size=%d", fsSize, blockSize)
-	case "xfs":
-		blockSize, fsSize, err = m.getXFSSize(deviceMountPath)
-		klog.V(5).Infof("Xfs size: filesystem size=%d, block size=%d, err=%v", fsSize, blockSize, err)
-	default:
-		klog.Errorf("Not able to parse given filesystem info. fsType: %s, will not resize", format)
-		return false, fmt.Errorf("Could not parse fs info on given filesystem format: %s. Supported fs types are: xfs, ext3, ext4", format)
-	}
-	if err != nil {
-		return false, err
-	}
-	// Tolerate one block difference, just in case of rounding errors somewhere.
-	klog.V(5).Infof("Volume %s: device size=%d, filesystem size=%d, block size=%d", devicePath, deviceSize, fsSize, blockSize)
-	if deviceSize <= fsSize+blockSize {
-		return false, nil
-	}
-	return true, nil
+	return mountutils.NewResizeFs(m.Exec).NeedResize(devicePath, deviceMountPath)
 }
+
 func (m *NodeMounter) getDeviceSize(devicePath string) (uint64, error) {
 	output, err := m.SafeFormatAndMount.Exec.Command("blockdev", "--getsize64", devicePath).CombinedOutput()
 	outStr := strings.TrimSpace(string(output))

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -210,7 +210,6 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		msg := fmt.Sprintf("could not format %q and mount it at %q: %v", source, target, err)
 		return nil, status.Error(codes.Internal, msg)
 	}
-	//TODO: use the common function from vendor pkg kubernetes/mount-util
 
 	needResize, err := d.mounter.NeedResize(source, target)
 	if err != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Refactoring only.

**What is this PR about? / Why do we need it?**
There was some copy-pasted code from mount utils to get it early. It was needed to check if volume needs resizing.
The code is already released in kuberenes/mount-utils so the copy-pasted code should be removed.

**What testing is done?** 
This is what I did to verify the resize still works fine and did not break:

1) Prepare at least one snapshot of a claim (size 1G in the example)
```
$ oc get volumesnapshots
NAME                READYTOUSE   SOURCEPVC   SOURCESNAPSHOTCONTENT   RESTORESIZE   SNAPSHOTCLASS   SNAPSHOTCONTENT                                    CREATIONTIME   AGE
claim-1-snapshot    true         claim-1                             1Gi           csi-aws-vsc     snapcontent-20720ba2-4a60-441e-85c7-7691eab875d5   75m            75m
claim-1-snapshot2   true         claim-1                             1Gi           csi-aws-vsc     snapcontent-90b37edb-3c92-4170-b5dc-1de36fc13b30   2m24s          3m3s
```

2) Create and verify a new *larger* pvc using a snapshot as a source (can be easily done from dashboard - VolumeSnapshots - details - actions - Restore as new PVC)
```
$ oc get pvc
NAME                        STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
claim-1                     Bound     pvc-8526e671-60da-4ec3-91cd-b64a0a958f7b   1Gi        RWO            gp2-csi        78m
claim-1-snapshot2-restore   Pending                                                                        gp2-csi        76s

$ oc get pvc/claim-1-snapshot2-restore -o yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  creationTimestamp: "2022-02-10T12:04:44Z"
  finalizers:
  - kubernetes.io/pvc-protection
  name: claim-1-snapshot2-restore
  namespace: default
  resourceVersion: "62525"
  uid: 07cdce09-1e33-4652-8b17-1d2d1188a0fa
spec:
  accessModes:
  - ReadWriteOnce
  dataSource:
    apiGroup: snapshot.storage.k8s.io
    kind: VolumeSnapshot
    name: claim-1-snapshot2
  resources:
    requests:
      storage: 5Gi
  storageClassName: gp2-csi
  volumeMode: Filesystem
status:
  phase: Pending
```

3) create a pod using newly created claim with a mount and verify disk size on node
```
# lsblk | grep pvc-07cdce09-1e33-4652-8b17-1d2d1188a0fa/mount
nvme2n1     259:6    0     5G  0 disk /var/lib/kubelet/pods/563f6c06-65a1-47e1-9c45-27cd7fd368bd/volumes/kubernetes.io~csi/pvc-07cdce09-1e33-4652-8b17-1d2d1188a0fa/mount
```

4) verify the size was extended accordingly inside of a pod
```
$ oc get pvc/claim-1-snapshot2-restore -o json | jq '.status.capacity.storage'
"5Gi"

$ oc exec example3 -- /bin/sh -c 'df -h | grep mnt'
/dev/nvme2n1    4.9G   20M  4.9G   1% /mnt/test
```
