### PR TITLE
Update cluster role configuration for external snapshotter

### DIFF
--- a/deploy/kubernetes/base/clusterrole-snapshotter.yaml
+++ b/deploy/kubernetes/base/clusterrole-snapshotter.yaml
@@ -10,9 +10,13 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "events" ]
     verbs: [ "list", "watch", "create", "update", "patch" ]
-  - apiGroups: [ "" ]
-    resources: [ "secrets" ]
-    verbs: [ "get", "list" ]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  #  - apiGroups: [""]
+  #    resources: ["secrets"]
+  #    verbs: ["get", "list"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotclasses" ]
     verbs: [ "get", "list", "watch" ]


### PR DESCRIPTION
Remove un-necessary access to secrets by the external-snapshotter-role

External-snapshoter does not require access to secrets for its functionality, keep the access to all secret values may cause other security issues.