### PR TITLE
Update to kops 1.23.0

### DIFF
--- a/hack/e2e/kops.sh
+++ b/hack/e2e/kops.sh
@@ -10,11 +10,16 @@ source "${BASE_DIR}"/util.sh
 function kops_install() {
   INSTALL_PATH=${1}
   KOPS_VERSION=${2}
-  if [[ ! -e ${INSTALL_PATH}/kops ]]; then
-    KOPS_DOWNLOAD_URL=https://github.com/kubernetes/kops/releases/download/v${KOPS_VERSION}/kops-${OS_ARCH}
-    curl -L -X GET "${KOPS_DOWNLOAD_URL}" -o "${INSTALL_PATH}"/kops
-    chmod +x "${INSTALL_PATH}"/kops
+  if [[ -e "${INSTALL_PATH}"/kops ]]; then
+    INSTALLED_KOPS_VERSION=$("${INSTALL_PATH}"/kops version)
+    if [[ "$INSTALLED_KOPS_VERSION" == *"$KOPS_VERSION"* ]]; then
+      echo "KOPS $INSTALLED_KOPS_VERSION already installed!"
+      return
+    fi
   fi
+  KOPS_DOWNLOAD_URL=https://github.com/kubernetes/kops/releases/download/v${KOPS_VERSION}/kops-${OS_ARCH}
+  curl -L -X GET "${KOPS_DOWNLOAD_URL}" -o "${INSTALL_PATH}"/kops
+  chmod +x "${INSTALL_PATH}"/kops
 }
 
 function kops_create_cluster() {

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -52,7 +52,7 @@ IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
 # eksctl: mustn't include patch version (e.g. 1.19)
 K8S_VERSION=${K8S_VERSION:-1.20.8}
 
-KOPS_VERSION=${KOPS_VERSION:-1.21.0}
+KOPS_VERSION=${KOPS_VERSION:-1.23.0}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** routine update

**What is this PR about? / Why do we need it?**

I am not updating K8S_VERSION yet (so test clusters will still be 1.20.8 which is outdated) but just want to make sure updating kops by itself works.

**What testing is done?**  CI will exercise
