### PR TITLE
Fix windows mounting bug-1090

### DIFF
--- a/pkg/mounter/safe_mounter_windows.go
+++ b/pkg/mounter/safe_mounter_windows.go
@@ -260,6 +260,16 @@ func (mounter *CSIProxyMounter) FormatAndMount(source string, target string, fst
 		return err
 	}
 
+	// Ensure the disk is online before mounting.
+	setDiskStateRequest := &disk.SetDiskStateRequest{
+		DiskNumber: uint32(diskNumber),
+		IsOnline:   true,
+	}
+	_, err = mounter.DiskClient.SetDiskState(context.Background(), setDiskStateRequest)
+	if err != nil {
+		return err
+	}
+
 	// List the volumes on the given disk.
 	volumeIDsRequest := &volume.ListVolumesOnDiskRequest{
 		DiskNumber: uint32(diskNumber),


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**

- Customers can encounter this bug when attempting to mount a disk with offline status on a Windows node, resulting in pods being perpetually stuck in the ContainerCreating stage. #1090 

**What is this PR about? / Why do we need it?**

- This bug is fixed by ensuring the disk is online before being mounted using the CSI-Proxy API.

**What testing is done?** 

1. Build and upload container images to a registry.
2. Change the image in the helm chart.
3. Test mounting functionality using the new helm chart.
