### PR TITLE
Update deprecated command `go get`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ bin/kubeval: | /tmp/kubeval bin
 	@rm -rf /tmp/kubeval/*
 
 bin/mockgen: | bin
-	go get github.com/golang/mock/mockgen@v1.5.0
+	go install github.com/golang/mock/mockgen@v1.5.0
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -105,7 +105,7 @@ loudecho "Installing ginkgo to ${BIN_DIR}"
 GINKGO_BIN=${BIN_DIR}/ginkgo
 if [[ ! -e ${GINKGO_BIN} ]]; then
   pushd /tmp
-  GOPATH=${TEST_DIR} GOBIN=${BIN_DIR} GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@v1.12.0
+  GOPATH=${TEST_DIR} GOBIN=${BIN_DIR} GO111MODULE=on go install github.com/onsi/ginkgo/ginkgo@v1.12.0
   popd
 fi
 


### PR DESCRIPTION
Signed-off-by: Gengtao Xu <gengtaox@amazon.com>

**Is this a bug fix or adding new feature?**
Bug fix
**What is this PR about? / Why do we need it?**
Command `go get` in Makefile and test script deprecated
**What testing is done?** 
Unit test passed