### PR TITLE
Support optional ec2 endpoint configuration

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -97,6 +97,12 @@ spec:
                   name: aws-secret
                   key: access_key
                   optional: true
+            - name: AWS_EC2_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: aws-meta
+                  key: endpoint
+                  optional: true
             {{- with .Values.controller.region }}
             - name: AWS_REGION
               value: {{ . }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -57,6 +57,12 @@ spec:
                   name: aws-secret
                   key: access_key
                   optional: true
+            - name: AWS_EC2_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: aws-meta
+                  key: endpoint
+                  optional: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/


### PR DESCRIPTION
This PR improves on an existing feature introduced in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/e4569c373c609115ce2cf756e4e1646095f7a979. With this change, a user can configure the EC2 endpoint using a config map. For example, to change the EC2 endpoint a user can apply the following:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: aws-meta
  namespace: kube-system
data:
  endpoint: "https://specific.aws.endpoint"
```

Tested locally with setting a custom endpoint and seeing cloud actions being sent to endpoint domain.

Please let me know if there is a different preferred method to set this endpoint as well as if you want me to document this approach anywhere.