### PR TITLE
Upgrade PodDisruptionBudget api version for kubernetes 1.21+

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: ebs-csi-controller

--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is an API upgrade PR.

**What is this PR about? / Why do we need it?**
This is a PR to upgrade PDB api version for kubernetes 1.21+
The policy/v1beta1 api version will not be supported after kubernetes 1.25+. So we need to upgrade this version.
Use policy/v1 for k8s 1.21+, to avoid displaying any warning of deprecated api version.

This PR is related to below issue:
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1184

**What testing is done?** 
Tested on different kubernetes version in minikube.