### PR TITLE
Adding tagging support through StorageClass.parameters

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,6 +51,7 @@ func main() {
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),
 		driver.WithKubernetesClusterID(options.ControllerOptions.KubernetesClusterID),
 		driver.WithAwsSdkDebugLog(options.ControllerOptions.AwsSdkDebugLog),
+		driver.WithWarnOnInvalidTag(options.ControllerOptions.WarnOnInvalidTag),
 	)
 	if err != nil {
 		klog.Fatalln(err)

--- a/cmd/options/controller_options.go
+++ b/cmd/options/controller_options.go
@@ -35,6 +35,8 @@ type ControllerOptions struct {
 	KubernetesClusterID string
 	// flag to enable sdk debug log
 	AwsSdkDebugLog bool
+	// flag to warn on invalid tag, instead of returning an error
+	WarnOnInvalidTag bool
 }
 
 func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
@@ -42,4 +44,5 @@ func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
 	fs.Var(cliflag.NewMapStringString(&s.ExtraVolumeTags), "extra-volume-tags", "DEPRECATED: Please use --extra-tags instead. Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.StringVar(&s.KubernetesClusterID, "k8s-tag-cluster-id", "", "ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).")
 	fs.BoolVar(&s.AwsSdkDebugLog, "aws-sdk-debug-log", false, "To enable the aws sdk debug log level (default to false).")
+	fs.BoolVar(&s.WarnOnInvalidTag, "warn-on-invalid-tag", false, "To warn on invalid tags, instead of returning an error")
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,9 @@ To help manage volumes in the aws account, CSI driver will automatically add tag
 | kubernetes.io/cluster/X| owned                     | kubernetes.io/cluster/aws-cluster-id-1 = owned                      | add to all volumes and snapshots if k8s-tag-cluster-id argument is set to X.|
 | extra-key              | extra-value               | extra-key = extra-value                                             | add to all volumes and snapshots if extraTags argument is set|
 
+
+The CSI driver also supports passing tags through `StorageClass.parameters`. For more information, please refer to the [tagging doc](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/TAGGING.md).
+
 ## Driver Options
 There are couple driver options that can be passed as arguments when starting driver container.
 

--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -1,0 +1,103 @@
+# Tagging
+
+The AWS EBS CSI Driver supports tagging through `StorageClass.parameters`. 
+
+If a key has the prefix `tagSpecification`, the CSI driver will treat the value as a key-value pair to be applied to the dynamically provisioned volume as tags.
+
+
+**Example 1**
+```
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+parameters:
+  tagSpecification_1: "key1=value1"
+  tagSpecification_2: "key2=hello world"
+  tagSpecification_3: "key3="
+```
+
+Provisioning a volume using this StorageClass will apply two tags:
+
+```
+key1=value1
+key2=hello world
+key3=<empty string>
+```
+
+________
+
+To allow for PV-level granularity, the CSI driver support runtime string interpolation on the tag values. You can specify placeholders for PVC namespace, PVC name and PV name, which will then be dynamically computed at runtime.
+
+**NOTE: This requires the `--extra-create-metadata` flag to be enabled on the `external-provisioner` sidecar.**
+
+**Example 2**
+```
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+parameters:
+  tagSpecification_1: "pvcnamespace={{ .PVCNamespace }}"
+  tagSpecification_2: "pvcname={{ .PVCName }}"
+  tagSpecification_3: "pvname={{ .PVName }}"
+```
+Provisioning a volume using this StorageClass, with a PVC named 'ebs-claim' in namespace 'default', will apply the following tags:
+
+```
+pvcnamespace=default
+pvcname=ebs-claim
+pvname=<the computed pv name>
+```
+
+
+_________
+
+The driver uses Go's `text/template` package for string interpolation. As such, cluster admins are free to use the constructs provided by the package (except for certain function, see `Failure Modes` below). To aid cluster admins to be more expressive, certain functions have been provided.
+
+They include:
+
+-   **field** delim index str: Split `str` by `delim` and extract the  word at position `index`.
+-   **substring** start end str: Get a substring of `str` given the `start` and `end` indices
+-   **toUpper** str: Convert `str` to uppercase
+-   **toLower** str: Convert `str` to lowercase
+-   **contains** str1 str2: Returns a boolean if `str2` contains `str1`
+
+
+**Example 3**
+```
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+parameters:
+  tagSpecification_1: 'backup={{ .PVCNamespace | contains "prod" }}'
+  tagSpecification_2: 'billingID={{ .PVCNamespace | field "-" 2 | toUpper }}'
+```
+
+Assuming the PVC namespace is `ns-prod-abcdef`, the attached tags will be
+
+```
+backup=true
+billingID=ABCDEF
+```
+
+____
+
+## Failure Modes
+
+There can be multipe failure modes:
+
+* The template cannot be parsed.
+* The key/interpolated value do not meet the [AWS Tag Requirements](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+* The key is not allowed (such as keys used internally by the CSI driver e.g., 'CSIVolumeName').
+* The template uses one of the disabled function calls. The driver disables the following `text/template` functions: `js`, `call`, `html`, `urlquery`. 
+
+In this case, the CSI driver will not provision a volume, but instead return an error.
+
+The driver also defines another flag, `--warn-on-invalid-tag` that will (if set), instead of returning an error, log a warning and skip the offending tag.
+
+

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/container-storage-interface/spec v1.3.0
 	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.4.3
+	github.com/google/go-cmp v0.5.5
 	github.com/kubernetes-csi/csi-proxy/client v1.0.1
 	github.com/kubernetes-csi/csi-test v2.0.0+incompatible
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0
@@ -36,7 +37,6 @@ require (
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -98,6 +98,8 @@ const (
 const (
 	// MaxNumTagsPerResource represents the maximum number of tags per AWS resource.
 	MaxNumTagsPerResource = 50
+	// MinTagKeyLength represents the minimum key length for a tag.
+	MinTagKeyLength = 1
 	// MaxTagKeyLength represents the maximum key length for a tag.
 	MaxTagKeyLength = 128
 	// MaxTagValueLength represents the maximum value length for a tag.

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -68,6 +68,10 @@ const (
 	// PVNameKey contains name of the final PV that will be used for the dynamically
 	// provisioned volume
 	PVNameKey = "csi.storage.k8s.io/pv/name"
+
+	// TagKeyPrefix contains the prefix of a volume parameter that designates it as
+	// a tag to be attached to the resource
+	TagKeyPrefix = "tagSpecification"
 )
 
 // constants for volume tags and their values

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -66,6 +66,7 @@ type DriverOptions struct {
 	volumeAttachLimit   int64
 	kubernetesClusterID string
 	awsSdkDebugLog      bool
+	warnOnInvalidTag    bool
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
@@ -189,5 +190,11 @@ func WithKubernetesClusterID(clusterID string) func(*DriverOptions) {
 func WithAwsSdkDebugLog(enableSdkDebugLog bool) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.awsSdkDebugLog = enableSdkDebugLog
+	}
+}
+
+func WithWarnOnInvalidTag(warnOnInvalidTag bool) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.warnOnInvalidTag = warnOnInvalidTag
 	}
 }

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -108,7 +108,7 @@ func TestValidateExtraVolumeTags(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateExtraTags(tc.tags)
+			err := validateExtraTags(tc.tags, false)
 			if !reflect.DeepEqual(err, tc.expErr) {
 				t.Fatalf("error not equal\ngot:\n%s\nexpected:\n%s", err, tc.expErr)
 			}

--- a/pkg/util/template/funcs.go
+++ b/pkg/util/template/funcs.go
@@ -1,0 +1,72 @@
+package template
+
+import (
+	"fmt"
+	"html/template"
+	"strings"
+)
+
+// Disable functions
+func html(args ...interface{}) (string, error) {
+	return "", fmt.Errorf("cannot call 'html' function")
+}
+
+func js(args ...interface{}) (string, error) {
+	return "", fmt.Errorf("cannot call 'js' function")
+}
+
+func call(args ...interface{}) (string, error) {
+	return "", fmt.Errorf("cannot call 'call' function")
+}
+
+func urlquery(args ...interface{}) (string, error) {
+	return "", fmt.Errorf("cannot call 'urlquery' function")
+}
+
+func contains(arg1, arg2 string) bool {
+	return strings.Contains(arg2, arg1)
+}
+
+func substring(start, end int, arg string) string {
+	if start < 0 {
+		return arg[:end]
+	}
+
+	if end < 0 || end > len(arg) {
+		return arg[start:]
+	}
+
+	return arg[start:end]
+}
+
+func field(delim string, idx int, arg string) (string, error) {
+	w := strings.Split(arg, delim)
+	if idx >= len(w) {
+		return "", fmt.Errorf("extractWord: cannot index into split string; index = %d, length = %d", idx, len(w))
+	}
+	return w[idx], nil
+}
+
+func index(arg1, arg2 string) int {
+	return strings.Index(arg2, arg1)
+}
+
+func lastIndex(arg1, arg2 string) int {
+	return strings.LastIndex(arg2, arg1)
+}
+
+func newFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"html":      html,
+		"js":        js,
+		"call":      call,
+		"urlquery":  urlquery,
+		"contains":  contains,
+		"toUpper":   strings.ToUpper,
+		"toLower":   strings.ToLower,
+		"substring": substring,
+		"field":     field,
+		"index":     index,
+		"lastIndex": lastIndex,
+	}
+}

--- a/pkg/util/template/template.go
+++ b/pkg/util/template/template.go
@@ -1,0 +1,55 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+	"text/template"
+
+	"k8s.io/klog/v2"
+)
+
+type Props struct {
+	PVCName      string
+	PVCNamespace string
+	PVName       string
+}
+
+func Evaluate(tm []string, props *Props, warnOnly bool) (map[string]string, error) {
+	md := make(map[string]string)
+	for _, s := range tm {
+		st := strings.SplitN(s, "=", 2)
+		if len(st) != 2 {
+			return nil, fmt.Errorf("the key-value pair doesn't contain a value (string: %s)", s)
+		}
+
+		key, value := st[0], st[1]
+
+		t := template.New("tmpl").Funcs(template.FuncMap(newFuncMap()))
+		val, err := execTemplate(value, props, t)
+		if err != nil {
+			if warnOnly {
+				klog.Warningf("Unable to interpolate the value for tag (%s, %s): %v", key, value, err)
+			} else {
+				return nil, err
+			}
+		} else {
+			md[key] = val
+		}
+	}
+	return md, nil
+}
+
+func execTemplate(value string, props *Props, t *template.Template) (string, error) {
+	tmpl, err := t.Parse(value)
+	if err != nil {
+		return "", err
+	}
+
+	b := new(strings.Builder)
+	err = tmpl.Execute(b, props)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/pkg/util/template/template_test.go
+++ b/pkg/util/template/template_test.go
@@ -1,0 +1,214 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEvaluate(t *testing.T) {
+	testCases := []struct {
+		name         string
+		input        []string
+		pvcName      string
+		pvName       string
+		pvcNamespace string
+		warnOnly     bool
+		expectErr    bool
+		expectedTags map[string]string
+	}{
+		{
+			name:         "empty input",
+			expectedTags: make(map[string]string),
+		},
+		{
+			name: "no interpolation",
+			input: []string{
+				"key1=value1",
+				"key2=hello world",
+			},
+			expectedTags: map[string]string{
+				"key1": "value1",
+				"key2": "hello world",
+			},
+		},
+		{
+			name: "no tag values gives empty string",
+			input: []string{
+				"key1=",
+			},
+			expectedTags: map[string]string{
+				"key1": "",
+			},
+		},
+		{
+			name: "no = returns an error",
+			input: []string{
+				"key1",
+			},
+			expectErr: true,
+		},
+		{
+			name: "simple substitution",
+			input: []string{
+				"key1={{ .PVCName }}",
+				"key2={{ .PVCNamespace }}",
+				"key3={{ .PVName }}",
+			},
+			pvcName:      "ebs-claim",
+			pvcNamespace: "default",
+			pvName:       "ebs-claim-012345",
+			expectedTags: map[string]string{
+				"key1": "ebs-claim",
+				"key2": "default",
+				"key3": "ebs-claim-012345",
+			},
+		},
+		{
+			name: "template parsing error",
+			input: []string{
+				"key1={{ .PVCName }",
+			},
+			expectErr: true,
+		},
+		{
+			name: "template parsing error warn only",
+			input: []string{
+				"key1={{ .PVCName }",
+				"key2={{ .PVCNamespace }}",
+			},
+			pvcName:      "ebs-claim",
+			pvcNamespace: "default",
+			warnOnly:     true,
+			expectedTags: map[string]string{
+				"key2": "default",
+			},
+		},
+		{
+			name: "test function - html - returns error",
+			input: []string{
+				`backup={{ .PVCNamespace | html }}`,
+			},
+			pvcNamespace: "ns-prod",
+			expectErr:    true,
+		},
+		{
+			name: "test func - js - returns error",
+			input: []string{
+				`backup={{ .PVCNamespace | js }}`,
+			},
+			pvcNamespace: "ns-prod",
+			expectErr:    true,
+		},
+		{
+			name: "test func - call - returns error",
+			input: []string{
+				`backup={{ .PVCNamespace | call }}`,
+			},
+			pvcNamespace: "ns-prod",
+			expectErr:    true,
+		},
+		{
+			name: "test func - urlquery - returns error",
+			input: []string{
+				`backup={{ .PVCNamespace | urlquery }}`,
+			},
+			pvcNamespace: "ns-prod",
+			expectErr:    true,
+		},
+		{
+			name: "test function - contains",
+			input: []string{
+				`backup={{ .PVCNamespace | contains "prod" }}`,
+			},
+			pvcNamespace: "ns-prod",
+			expectedTags: map[string]string{
+				"backup": "true",
+			},
+		},
+		{
+			name: "test function - toUpper",
+			input: []string{
+				`backup={{ .PVCNamespace | toUpper }}`,
+			},
+			pvcNamespace: "ns-prod",
+			expectedTags: map[string]string{
+				"backup": "NS-PROD",
+			},
+		},
+		{
+			name: "test function - toLower",
+			input: []string{
+				`backup={{ .PVCNamespace | toLower }}`,
+			},
+			pvcNamespace: "ns-PROD",
+			expectedTags: map[string]string{
+				"backup": "ns-prod",
+			},
+		},
+		{
+			name: "test function - field",
+			input: []string{
+				`backup={{ .PVCNamespace | field "-" 1 }}`,
+			},
+			pvcNamespace: "ns-prod-default",
+			expectedTags: map[string]string{
+				"backup": "prod",
+			},
+		},
+		{
+			name: "test function - substring",
+			input: []string{
+				`key1={{ .PVCNamespace | substring 0 4 }}`,
+			},
+			pvcNamespace: "prod-12345",
+			expectedTags: map[string]string{
+				"key1": "prod",
+			},
+		},
+		{
+			name: "no extra-create-metadata flag",
+			input: []string{
+				`key1={{ .PVCNamespace }}`,
+				`key2={{ .PVCName }}`,
+			},
+			expectedTags: map[string]string{
+				"key1": "",
+				"key2": "",
+			},
+		},
+		{
+			name: "field returns error",
+			input: []string{
+				`key1={{ .PVCNamespace | field "-" 1 }}`,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			props := &Props{
+				PVCName:      tc.pvcName,
+				PVCNamespace: tc.pvcNamespace,
+				PVName:       tc.pvName,
+			}
+
+			tags, err := Evaluate(tc.input, props, tc.warnOnly)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error; got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("err is not nil; err = %v", err)
+				}
+				if diff := cmp.Diff(tc.expectedTags, tags); diff != "" {
+					t.Fatalf("tags are different; diff = %v", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION

**Is this a bug fix or adding new feature?**
/kind feature

**What is this PR about? / Why do we need it?**
This commit adds tagging support (w/ string interpolation) through StorageClass.parameters.

For more information about the design, refer to https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1190 and the markdown file in `docs/`. 

Also, see #180.

**What testing is done?** 
Unit tests
e2e test
Manual testing by creating volumes specified with tags through StorageClass.parameters. 