### PR TITLE
Use docker buildx 0.8.x --no-cache-filter to avoid using cached amazonlinux image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ sub-image-%:
 image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
 	docker buildx build \
+		--no-cache-filter=linux-amazon \
 		--platform=$(OS)/$(ARCH) \
 		--progress=plain \
 		--target=$(OS)-$(OSVERSION) \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** /feature

**What is this PR about? / Why do we need it?** 
When building image, always run `yum update -y` and avoid using whatever amazonlinux image/layer is in the cache because it might be outdated.

--no-cache-filter requires buildx 0.8.x which just came out in March https://github.com/docker/buildx/releases/tag/v0.8.0

there is another flag --no-cache that is available in earlier versions but I DON'T want to use that because it means that the windows layers don't get cached and those take a LONG time to build.

We need to build new images frequently to keep up with CVEs in amazonlinux image. At least until we switch to a "minimal" image that has less surface area for CVEs.

**What testing is done?** 

`make image`  works and yum update -y is always run, it's not cached.
