### PR TITLE
Update gcb-docker-gcloud to latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 timeout: 3600s
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94
     entrypoint: ./hack/prow.sh
     env:
       - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind bug

**What is this PR about? / Why do we need it?**
cloudbuild is failing because the gdb-docker-gcloud image uses buildx v0.7.0, which doesn't support the `--no-cache-filter` argument (v0.8.0). Updating the image to the latest version which uses buildx v0.8.0.

**What testing is done?** 
