### PR TITLE
Replace Windows 2004(EOL) with ltsc2019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,10 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS windows-1809
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]
 
-FROM mcr.microsoft.com/windows/servercore:2004 AS windows-2004
+FROM mcr.microsoft.com/windows/servercore:20H2 AS windows-20H2
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]
 
-FROM mcr.microsoft.com/windows/servercore:20H2 AS windows-20H2
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 AS windows-ltsc2019
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ALL_OSVERSION_linux?=amazon
 ALL_OS_ARCH_OSVERSION_linux=$(foreach arch, $(ALL_ARCH_linux), $(foreach osversion, ${ALL_OSVERSION_linux}, linux-$(arch)-${osversion}))
 
 ALL_ARCH_windows?=amd64
-ALL_OSVERSION_windows?=1809 2004 20H2
+ALL_OSVERSION_windows?=1809 20H2 ltsc2019
 ALL_OS_ARCH_OSVERSION_windows=$(foreach arch, $(ALL_ARCH_windows), $(foreach osversion, ${ALL_OSVERSION_windows}, windows-$(arch)-${osversion}))
 
 ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**What is this PR about? / Why do we need it?**

- Stop building for Windows 2004 which has reached EOL for all editions.
- Build ltsc2019.

**What testing is done?**

- Deployed CSI driver with helm chart using new ltsc2019 image.
