### PR TITLE
Use minimal base image for linux builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
-FROM amazonlinux:2 AS linux-amazon
-RUN yum update -y && \
-    yum install ca-certificates e2fsprogs xfsprogs util-linux -y && \
-    yum clean all
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2 AS linux-amazon
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ sub-image-%:
 image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION):
 	docker buildx build \
-		--no-cache-filter=linux-amazon \
 		--platform=$(OS)/$(ARCH) \
 		--progress=plain \
 		--target=$(OS)-$(OSVERSION) \


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**What is this PR about? / Why do we need it?**

- Most incoming CVEs are not related to the CSI driver binary, but the base AL2 image layer. By using a minimal base image (for linux builds) we can greatly reduce ebs-csi-driver container image attack surface area and size.
- Addresses: #272

**What testing is done?** 

- The CSI driver requires the following dependencies in the base image layer: 
```
util-linux
e2fsprogs
xfsprogs
mount
```

- The driver uses the following binaries:
```
blkid
blockdev
dumpe2fs
resize2fs
fsck
fsck.ext4
fsck.ext3
mkfs
mkfs.ext4
mkfs.ext3
mkfs.xfs
xfs_io
xfs_growfs
umount
mount
```

- Using docker entrypoint to test binaries in container image:
```
$ docker run --entrypoint blkid public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2
// There is no output, as expected.

$ docker run --entrypoint blockdev public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

Usage:
 blockdev -V
 blockdev --report [devices]
 blockdev [-v|-q] commands devices
...

$ docker run --entrypoint dumpe2fs public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

dumpe2fs 1.42.9 (28-Dec-2013)
Usage: dumpe2fs [-bfhixV] [-o superblock=<num>] [-o blocksize=<num>] device

$ docker run --entrypoint resize2fs public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

resize2fs 1.42.9 (28-Dec-2013)
Usage: resize2fs [-d debug_flags] [-f] [-F] [-M] [-P] [-p] device [new_size]

$ docker run --entrypoint fsck public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

fsck from util-linux 2.30.2

$ docker run --entrypoint fsck.ext4 public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

Usage: fsck.ext4 [-panyrcdfvtDFV] [-b superblock] [-B blocksize]
		[-I inode_buffer_blocks] [-P process_inode_size]
		[-l|-L bad_blocks_file] [-C fd] [-j external_journal]
		[-E extended-options] device
...

$ docker run --entrypoint fsck.ext3 public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

Usage: fsck.ext3 [-panyrcdfvtDFV] [-b superblock] [-B blocksize]
		[-I inode_buffer_blocks] [-P process_inode_size]
		[-l|-L bad_blocks_file] [-C fd] [-j external_journal]
		[-E extended-options] device
...

$ docker run --entrypoint mkfs public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

Usage:
 mkfs [options] [-t <type>] [fs-options] <device> [<size>]

$ docker run --entrypoint mkfs.ext4 public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2
Usage: mkfs.ext4 [-c|-l filename] [-b block-size] [-C cluster-size]
...

$ docker run --entrypoint mkfs.ext3 public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2
Usage: mkfs.ext3 [-c|-l filename] [-b block-size] [-C cluster-size
...

$ docker run --entrypoint mkfs.xfs public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

no device name given in argument list
Usage: mkfs.xfs
...

$ docker run --entrypoint xfs_io public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

xfs_io> %

$ docker run --entrypoint xfs_growfs public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

Usage: xfs_growfs [options] mountpoint
...

$ docker run --entrypoint umount public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

Usage:
 umount [-hV]
 umount -a [options]
 umount [options] <source> | <directory>
...

$  docker run --entrypoint mount public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

overlay on / type overlay (rw,relatime,lowerdir=/local/docker/overlay2/l/UZSVPV7M3UXLKOOLZFP2JDEZ5Z:/local/docker/overlay2/l/BFJHJQVTOLENYSKV7PTEL5FAU2:/local/docker/overlay2/l/AIP4WHCMJFSDFZLXAUNJ4XQWWG:/local/docker/overlay2/l/TQ66HDDH5DD23TLTLOMIMMXAYS,upperdir=/local/docker/overlay2/d97b29e25c19951d0b3acbc72b06ae3c8eb07bdc15de96d3e84476495664540b/diff,workdir=/local/docker/overlay2/d97b29e25c19951d0b3acbc72b06ae3c8eb07bdc15de96d3e84476495664540b/work)
...
```

- Manifest:
```
$ crane manifest public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

{
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "schemaVersion": 2,
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:01e84b4a8a8d7c52443e202d5758b8cd4aefb23d358cffae7a0f8bb2f4722347",
         "size": 916,
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "digest": "sha256:83188a6846278419dff4644a7a690184876231036f6b79e4f24103b3177d004d",
         "size": 916,
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```
```
$ syft packages public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2

 ✔ Pulled image
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [25 packages]
NAME                    VERSION                   TYPE
basesystem              10.0-7.amzn2.0.1          rpm
ca-certificates         2021.2.50-72.amzn2.0.3    rpm
e2fsprogs               1.42.9-19.amzn2           rpm
e2fsprogs-libs          1.42.9-19.amzn2           rpm
filesystem              3.2-25.amzn2.0.4          rpm
glibc                   2.26-58.amzn2             rpm
glibc-common            2.26-58.amzn2             rpm
glibc-minimal-langpack  2.26-58.amzn2             rpm
gpg-pubkey              c87f5b1a-593863f8         rpm
libblkid                2.30.2-2.amzn2.0.7        rpm
libcom_err              1.42.9-19.amzn2           rpm
libgcc                  7.3.1-14.amzn2            rpm
libmount                2.30.2-2.amzn2.0.7        rpm
libselinux              2.5-12.amzn2.0.2          rpm
libsepol                2.5-8.1.amzn2.0.2         rpm
libstdc++               7.3.1-14.amzn2            rpm
libuuid                 2.30.2-2.amzn2.0.7        rpm
ncurses-libs            6.0-8.20170212.amzn2.1.3  rpm
pcre                    8.32-17.amzn2.0.2         rpm
readline                6.2-10.amzn2.0.2          rpm
setup                   2.8.71-10.amzn2.0.1       rpm
system-release          1:2-14.amzn2              rpm
tzdata                  2021e-1.amzn2             rpm
util-linux              2.30.2-2.amzn2.0.7        rpm
xfsprogs                4.5.0-18.amzn2.0.1        rpm
```
- CI ✅
- amd64 architecture validation testing ✅
- arm64 architecture validation testing ✅

https://github.com/aws/eks-distro-build-tooling/pull/398