### PR TITLE
Fix IOPS parameter bug when no volume type is defined

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -299,6 +299,8 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 		throughput = int64(diskOptions.Throughput)
 	case "":
 		createType = DefaultVolumeType
+		iops = int64(diskOptions.IOPS)
+		throughput = int64(diskOptions.Throughput)
 	default:
 		return nil, fmt.Errorf("invalid AWS VolumeType %q", diskOptions.VolumeType)
 	}

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -67,6 +67,24 @@ func TestCreateDisk(t *testing.T) {
 			expErr: nil,
 		},
 		{
+			name:       "success: normal with iops",
+			volumeName: "vol-test-name",
+			diskOptions: &DiskOptions{
+				CapacityBytes: util.GiBToBytes(1),
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
+				IOPS:          6000,
+			},
+			expDisk: &Disk{
+				VolumeID:         "vol-test",
+				CapacityGiB:      1,
+				AvailabilityZone: defaultZone,
+			},
+			expCreateVolumeInput: &ec2.CreateVolumeInput{
+				Iops: aws.Int64(6000),
+			},
+			expErr: nil,
+		},
+		{
 			name:       "success: normal with gp2 options",
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**

- Bug Fix: #1235 

**What is this PR about? / Why do we need it?**

- The IOPS parameter, defined in the StorageClass.parameters, is not picked up by the driver when the volume type is not defined (i.e. defaults to gp3). 

### Steps to Reproduce

- Create a StorageClass without a volume type but with IOPS

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: test
parameters:
  iops: "6000"
provisioner: ebs.csi.aws.com
```

- Provision a volume with this StorageClass.

```
k apply -f claim.yaml
```

- You'll see that the IOPS values is not honored in the volume created. 

```
 % aws ec2 describe-volumes --volume-id vol-085b747b34dd7f330 --query 'Volumes[0].[Iops, VolumeType]'
[
    3000,
    "gp3"
]
```

