### PR TITLE
Temporarily fix CI

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -55,6 +55,9 @@ function eksctl_create_cluster() {
   fi
 
   loudecho "Cluster ${CLUSTER_NAME} kubecfg written to ${KUBECONFIG}"
+  # TODO: Workaround for https://github.com/weaveworks/eksctl/issues/5257
+  # Remove when eksctl releases a fix
+  sed -i 's/v1alpha1/v1beta1/g' ${KUBECONFIG}
 
   loudecho "Getting cluster ${CLUSTER_NAME}"
   ${BIN} get cluster "${CLUSTER_NAME}"


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**
- Bug fix

**What is this PR about? / Why do we need it?**
- Temporarily fix CI failing due to `error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"`.
until this PR gets merged: https://github.com/weaveworks/eksctl/pull/5287

**What testing is done?** 
- CI passing