### PR TITLE
Automated cherry pick of #1240: Temporarily fix CI

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -55,6 +55,9 @@ function eksctl_create_cluster() {
   fi
 
   loudecho "Cluster ${CLUSTER_NAME} kubecfg written to ${KUBECONFIG}"
+  # TODO: Workaround for https://github.com/weaveworks/eksctl/issues/5257
+  # Remove when eksctl releases a fix
+  sed -i 's/v1alpha1/v1beta1/g' ${KUBECONFIG}
 
   loudecho "Getting cluster ${CLUSTER_NAME}"
   ${BIN} get cluster "${CLUSTER_NAME}"


### PR DESCRIPTION
Cherry pick of #1240 on release-1.6.

#1240: Temporarily fix CI

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```