### PR TITLE
add verbs to volumesnapshotcontents in clusterrole-snapshotter

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -21,7 +21,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "*" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
test env :
EKS 1.22
aws-ebs-csi-driver using helm chart v2.6.7 (latest)
external-snapshotter v5.0.1 (latest)

after installed driver and snapshotter, use example code for snapshot.

```
k describe vsc
...
Events:
  Type     Reason                  Age              From                             Message
  ----     ------                  ----             ----                             -------
  Warning  SnapshotCreationFailed  3s (x3 over 4s)  csi-snapshotter ebs.csi.aws.com  Failed to create snapshot: failed to add VolumeSnapshotBeingCreated annotation on the content snapcontent-0c729f16-4c9e-485c-bd45-4db0f5caec39: "snapshot controller failed to update snapcontent-0c729f16-4c9e-485c-bd45-4db0f5caec39 on API server: volumesnapshotcontents.snapshot.storage.k8s.io \"snapcontent-0c729f16-4c9e-485c-bd45-4db0f5caec39\" is forbidden: User \"system:serviceaccount:kube-system:ebs-csi-controller-sa\" cannot patch resource \"volumesnapshotcontents\" in API group \"snapshot.storage.k8s.io\" at the cluster scope"
```

**What testing is done?** 
after changed to `["*"]`, there's no error and I can see snapshot in AWS console.