### PR TITLE
Fix unable to create CSI snapshot-EBS csi driver

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -21,7 +21,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -35,7 +35,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-snapshotter
-      tag: "v3.0.3"
+      tag: "v6.0.1"
     logLevel: 2
     resources: {}
   livenessProbe:

--- a/deploy/kubernetes/base/clusterrole-snapshotter.yaml
+++ b/deploy/kubernetes/base/clusterrole-snapshotter.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -16,7 +16,7 @@ images:
     newTag: v2.2.0-eks-1-18-13
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newTag: v3.0.3-eks-1-18-13
+    newTag: v5.0.1-eks-1-22-7
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
     newTag: v1.1.0-eks-1-18-13

--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -12,7 +12,7 @@ images:
   - name: k8s.gcr.io/sig-storage/livenessprobe
     newTag: v2.4.0
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
-    newTag: v3.0.3
+    newTag: v6.0.1
   - name: k8s.gcr.io/sig-storage/csi-resizer
     newTag: v1.1.0
   - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**
- Bug fix: #1249
- Also addresses: #1243 #1159

**What is this PR about? / Why do we need it?**
- Bumped up `csi-snapshotter` to `v6.0.1` which fixes "Failed to watch *v1beta1.VolumeSnapshotClass: failed to list *v1beta1.VolumeSnapshotClass: the server could not find the requested resource (get volumesnapshotclasses.snapshot.storage.k8s.io)" when attempting to create a snapshot, as support for `v1beta1` has been removed.
- Added `patch` to verbs list in `charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml` and `deploy/kubernetes/base/clusterrole-snapshotter.yaml`.

csi-snapshotter `v6.0.1` has not been published to public ECR: https://gallery.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter, hence using `v5.0.1` in the overlay.

**What testing is done?** 
- Validation testing.
- CI.