### PR TITLE
update csi-snapshotter version to v6.0.1 in k8s manifests

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -110,7 +110,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
n/a

**What is this PR about? / Why do we need it?**
updating csi-snapshotter version to v6.0.1 in k8s manifests, to align w/ recent changes to helm chart (https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1257)

**What testing is done?** 
