### PR TITLE
Bump up sidecar versions

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -19,7 +19,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: "v2.2.2"
+      tag: "v3.1.0"
     logLevel: 2
     resources: {}
   attacher:
@@ -27,7 +27,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-attacher
-      tag: "v3.1.0"
+      tag: "v3.4.0"
     logLevel: 2
     resources: {}
   snapshotter:
@@ -42,14 +42,14 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/livenessprobe
-      tag: "v2.4.0"
+      tag: "v2.5.0"
     resources: {}
   resizer:
     env: []
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-resizer
-      tag: "v1.1.0"
+      tag: "v1.4.0"
     logLevel: 2
     resources: {}
   nodeDriverRegistrar:
@@ -57,7 +57,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-      tag: "v2.3.0"
+      tag: "v2.5.1"
     logLevel: 2
     resources: {}
 

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -81,7 +81,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -110,7 +110,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v3.0.3
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -122,7 +122,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -80,7 +80,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -97,7 +97,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.4.0
+          image: k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
bump up the following sidecars:
external-attacher v3.1.0 -> v3.4.0
external-resizer v1.1.0 -> v1.4.0
external-provisioner v2.2.2 -> v3.1.0
node-driver-registrar v2.3.0 -> v2.5.1
livenessprobe v2.4.0 -> v2.5.0

re-generate kustomize profile

**What testing is done?** 
Unit test and functionality test