### PR TITLE
Avoid git tag conflicts when vendoring hack/e2e in other repos (efs/fsx)

### DIFF
--- a/hack/e2e/README.md
+++ b/hack/e2e/README.md
@@ -32,7 +32,7 @@ Reference: https://stackoverflow.com/questions/23937436/add-subdirectory-of-remo
 How to consume this directory by read-treeing the ebs repo:
 
 ```
-git remote add ebs git@github.com:kubernetes-sigs/aws-ebs-csi-driver.git
+git remote add ebs git@github.com:kubernetes-sigs/aws-ebs-csi-driver.git --no-tags
 git fetch ebs
 git read-tree --prefix=hack/e2e/ -u ebs/master:hack/e2e
 ```
@@ -52,5 +52,6 @@ To consume newer changes from the ebs repo:
 git fetch ebs
 git diff HEAD:hack/e2e ebs/master:hack/e2e > /tmp/hack_e2e.diff
 git apply --reject --directory hack/e2e /tmp/hack_e2e.diff
-git commit
+git add hack/e2e
+git commit -m "Update hack/e2e"
 ```


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

I use git  to basically vendor or copy/paste hack/e2e for reuse in efs/fsx repos. When adding ebs remote to efs/fsx, use `--no-tags`, otherwise `git fetch` also fetches tags that might conflict, e.g. it fetches 1.6.0 which points to some EBS commit when I want 1.6.0 to point to an EFS commit when I am in the efs repo, obviously

**What testing is done?** 
