### PR TITLE
Upgrade eksctl to v0.101.0

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -55,10 +55,6 @@ function eksctl_create_cluster() {
   fi
 
   loudecho "Cluster ${CLUSTER_NAME} kubecfg written to ${KUBECONFIG}"
-  # TODO: Workaround for https://github.com/weaveworks/eksctl/issues/5257
-  # Remove when eksctl releases a fix
-  sed -i 's/v1alpha1/v1beta1/g' ${KUBECONFIG}
-
   loudecho "Getting cluster ${CLUSTER_NAME}"
   ${BIN} get cluster "${CLUSTER_NAME}"
 

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -57,7 +57,7 @@ KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
 
-EKSCTL_VERSION=${EKSCTL_VERSION:-0.69.0}
+EKSCTL_VERSION=${EKSCTL_VERSION:-0.101.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
 EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-}
 # Creates a windows node group. The windows ami doesn't (yet) install csi-proxy


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**What is this PR about? / Why do we need it?**
- https://github.com/weaveworks/eksctl/pull/5287 included in the new release fixes eksctl utils write-config breaking CI.
- Remove sed workaround which temporarily fixed CI.
- Upgrade `eksctl` to v`0.101.0`

**What testing is done?** 
- CI 
