### PR TITLE
Bump up Helm chart to v2.6.10

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Helm chart
 
+## v2.6.10
+
+* Add quotes around the `extra-tags` argument in order to prevent special characters such as `":"` from breaking the manifest YAML after template rendering.
+
 ## v2.6.9
 
 * Update csi-snapshotter to version `v6.0.1`

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.6.2
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.6.9
+version: 2.6.10
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**What is this PR about? / Why do we need it?**
- Bump up the Helm chart to `v2.6.10` to include fix: #1198 
