### PR TITLE
Bump up Helm chart to v2.7.0

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm chart
 
+## v2.7.0
+* Support optional ec2 endpoint configuration.
+* Fix node driver registrar socket path.
+* Fix hardcoded kubelet path.
+
 ## v2.6.11
 * Bump app/driver to version `v1.7.0`
 * Set handle-volume-inuse-error to `false`

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.7.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.6.11
+version: 2.7.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**
- Bump up Helm chart to v2.7.0

**What is this PR about? / Why do we need it?**

Helm chart  v2.7.0
* Support optional ec2 endpoint configuration.
* Fix node driver registrar socket path.
* Fix hardcoded kubelet path.
