### PR TITLE
fix version of k8s manifest images

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -31,7 +31,7 @@ spec:
           tolerationSeconds: 300 
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.7.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode
@@ -81,7 +81,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -97,7 +97,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+          image: k8s.gcr.io/sig-storage/csi-attacher
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -110,7 +110,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -122,7 +122,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+          image: k8s.gcr.io/sig-storage/csi-resizer
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -135,7 +135,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
+          image: k8s.gcr.io/sig-storage/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -45,7 +45,7 @@ spec:
         - name: ebs-plugin
           securityContext:
             privileged: true
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.7.0
+          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
           imagePullPolicy: IfNotPresent
           args:
             - node
@@ -80,7 +80,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -97,7 +97,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.5.0
+          image: k8s.gcr.io/sig-storage/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -7,19 +7,19 @@ images:
     newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v2.1.1-eks-1-18-13
+    tagSuffix: -eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    newTag: v3.1.0-eks-1-18-13
+    tagSuffix: -eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.2.0-eks-1-18-13
+    tagSuffix: -eks-1-20-11
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newTag: v5.0.1-eks-1-22-7
+    tagSuffix: -eks-1-20-17
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newTag: v1.1.0-eks-1-18-13
+    tagSuffix: -eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.1.0-eks-1-18-13
+    tagSuffix: -eks-1-20-17

--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -4,16 +4,16 @@ bases:
   - ../../../base
 images:
   - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-    newTag: v1.6.1
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newTag: v2.1.1
+    newTag: v1.7.0
   - name: k8s.gcr.io/sig-storage/csi-attacher
+    newTag: v3.4.0
+  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newTag: v2.5.1
+  - name: k8s.gcr.io/sig-storage/csi-provisioner
     newTag: v3.1.0
-  - name: k8s.gcr.io/sig-storage/livenessprobe
-    newTag: v2.4.0
+  - name: k8s.gcr.io/sig-storage/csi-resizer
+    newTag: v1.4.0
   - name: k8s.gcr.io/sig-storage/csi-snapshotter
     newTag: v6.0.1
-  - name: k8s.gcr.io/sig-storage/csi-resizer
-    newTag: v1.1.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.1.0
+  - name: k8s.gcr.io/sig-storage/livenessprobe
+    newTag: v2.3.0

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aws-secret
-  namespace: kube-system
-stringData:
-  key_id: ""
-  access_key: ""

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,11 +13,12 @@
 The driver requires IAM permission to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./example-iam-policy.json) defines these permissions. There are several methods to grant the driver IAM permission:
 * Using IAM [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) - attach the policy to the instance profile IAM role and turn on access to [instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the instance(s) on which the driver Deployment will run
 * EKS only: Using [IAM roles for ServiceAccounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) - create an IAM role, attach the policy to it, then follow the IRSA documentation to associate the IAM role with the driver Deployment service account, which if you are installing via Helm is determined by value `controller.serviceAccount.name`, `ebs-csi-controller-sa` by default
-* Using secret object - create an IAM user, attach the policy to it, put that user's credentials in [secret manifest](../deploy/kubernetes/secret.yaml), then deploy the secret
+* Using secret object - create an IAM user, attach the policy to it, then create a generic secret called `aws-secret` in the `kube-system` namespace with the user's credentials
 ```sh
-curl https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/master/deploy/kubernetes/secret.yaml > secret.yaml
-# Edit the secret with user credentials
-kubectl apply -f secret.yaml
+kubectl create secret generic aws-secret \
+    --namespace kube-system \
+    --from-literal "key_id=${AWS_ACCESS_KEY_ID}" \
+    --from-literal "access_key=${AWS_SECRET_ACCESS_KEY}"
 ```
 
 #### Config node toleration settings


### PR DESCRIPTION
Signed-off-by: Pedro Tôrres <pedro.torres@incognia.com>

**Is this a bug fix or adding new feature?**

Fixes #1136

**What is this PR about? / Why do we need it?**

The container images defined on the K8s Manifests of this repository are not properly set and are causing some problems:

1. Not all overlays have images with ARM64 support

2. Some overlays are using the wrong registry because of a change in the base

3. Some image versions are being updated only the base and downgraded in the overlays

This is the current state of the images across overlays:

| Overlay       | Component                 | Image Registry | Image Tag              | ARM64 Support |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| base          | aws-ebs-csi-driver        | ecr-public     | v1.7.0                 | yes           |
| base          | csi-attacher              | gcr            | v3.4.0                 | yes           |
| base          | csi-node-driver-registrar | gcr            | v2.5.1                 | yes           |
| base          | csi-provisioner           | gcr            | v3.1.0                 | yes           |
| base          | csi-resizer               | gcr            | v1.4.0                 | yes           |
| base          | csi-snapshotter           | gcr            | v6.0.1                 | yes           |
| base          | livenessprobe             | gcr            | v2.5.0                 | yes           |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| grc           | aws-ebs-csi-driver        | **ecr-public** | v1.7.0                 | yes           |
| grc           | csi-attacher              | gcr            | **v3.1.0**             | yes           |
| grc           | csi-node-driver-registrar | gcr            | **v2.1.0**             | yes           |
| grc           | csi-provisioner           | gcr            | **v2.1.1**             | yes           |
| grc           | csi-resizer               | gcr            | **v1.1.0**             | yes           |
| grc           | csi-snapshotter           | gcr            | v6.0.1                 | yes           |
| grc           | livenessprobe             | gcr            | **v2.4.0**             | yes           |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| ecr           | aws-ebs-csi-driver        | **ecr-public** | v1.7.0                 | yes           |
| ecr           | csi-attacher              | ecr            | **v3.1.0**             | yes           |
| ecr           | csi-node-driver-registrar | ecr            | **v2.1.0**             | **no**        |
| ecr           | csi-provisioner           | ecr            | **v2.1.1**             | **no**        |
| ecr           | csi-resizer               | ecr            | **v1.1.0**             | yes           |
| ecr           | csi-snapshotter           | ecr            | v6.0.1                 | yes           |
| ecr           | livenessprobe             | ecr            | **v2.4.0**             | yes           |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| ecr-public    | aws-ebs-csi-driver        | ecr-public     | v1.7.0                 | yes           |
| ecr-public    | csi-attacher              | ecr-public     | **v3.1.0-eks-1-18-13** | yes           |
| ecr-public    | csi-node-driver-registrar | ecr-public     | **v2.1.0-eks-1-18-13** | yes           |
| ecr-public    | csi-provisioner           | ecr-public     | **v2.1.1-eks-1-18-13** | yes           |
| ecr-public    | csi-resizer               | ecr-public     | **v1.1.0-eks-1-18-13** | yes           |
| ecr-public    | csi-snapshotter           | ecr-public     | **v5.0.1-eks-1-22-7**  | yes           |
| ecr-public    | livenessprobe             | ecr-public     | **v2.2.0-eks-1-18-13** | yes           |

To address these problems some changes were made:

1. References the ECR Public registry on the base were replaced by the GCR registry references.

2. The image tag is no longer specified on the base to avoid someone updating the version there and not on the overlays. If necessary we can create an unstable overlay with the versions previously specified on the base.

3. Updated the images in the overlays to match the the version of the current base.

    1. I was initially thinking on updating the components to use the same version as the ones shipped with the latest patch of the oldest supported version of EKS-D (https://distro.eks.amazonaws.com/releases/1-20/17/), but not all components have these newer versions available on the EKS Private registry.

    2. Because the most recent version of livenessprobe that is available on all 3 registries is v2.3.0, a downgrade was necessary (for the ECR Public overlay it was actually an upgrade). We can revert this downgrade if someone from AWS pushes v2.6.0 or v2.7.0 to the ECR Private registry.

|        | GCR | ECR | ECR Public |
| -------| --- | --- | ---------- |
| v2.3.0 | yes | yes | yes        |
| v2.4.0 | yes | yes | no         |
| v2.5.0 | yes | yes | no         |
| v2.6.0 | yes | no  | yes        |
| v2.7.0 | yes | no  | yes        |

This is the state of the images across overlays after this patch:

| Overlay       | Component                 | Image Registry | Image Tag              | ARM64 Support |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| base          | aws-ebs-csi-driver        | **gcr**        | ****                   | yes           |
| base          | csi-attacher              | gcr            | ****                   | yes           |
| base          | csi-node-driver-registrar | gcr            | ****                   | yes           |
| base          | csi-provisioner           | gcr            | ****                   | yes           |
| base          | csi-resizer               | gcr            | ****                   | yes           |
| base          | csi-snapshotter           | gcr            | ****                   | yes           |
| base          | livenessprobe             | gcr            | ****                   | yes           |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| grc           | aws-ebs-csi-driver        | **grc**        | v1.7.0                 | yes           |
| grc           | csi-attacher              | gcr            | **v3.4.0**             | yes           |
| grc           | csi-node-driver-registrar | gcr            | **v2.5.1**             | yes           |
| grc           | csi-provisioner           | gcr            | **v3.1.0**             | yes           |
| grc           | csi-resizer               | gcr            | **v1.4.0**             | yes           |
| grc           | csi-snapshotter           | gcr            | v6.0.1                 | yes           |
| grc           | livenessprobe             | gcr            | **v2.3.0**             | yes           |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| ecr           | aws-ebs-csi-driver        | **ecr**        | v1.7.0                 | yes           |
| ecr           | csi-attacher              | ecr            | **v3.4.0**             | yes           |
| ecr           | csi-node-driver-registrar | ecr            | **v2.5.1**             | **yes**       |
| ecr           | csi-provisioner           | ecr            | **v3.1.0**             | **yes**       |
| ecr           | csi-resizer               | ecr            | **v1.4.0**             | yes           |
| ecr           | csi-snapshotter           | ecr            | v6.0.1                 | yes           |
| ecr           | livenessprobe             | ecr            | **v2.3.0**             | yes           |
| ------------- | ------------------------- | -------------- | ---------------------- | ------------- |
| ecr-public    | aws-ebs-csi-driver        | ecr-public     | v1.7.0                 | yes           |
| ecr-public    | csi-attacher              | ecr-public     | **v3.4.0-eks-1-20-15** | yes           |
| ecr-public    | csi-node-driver-registrar | ecr-public     | **v2.5.1-eks-1-20-17** | yes           |
| ecr-public    | csi-provisioner           | ecr-public     | **v3.1.0-eks-1-20-15** | yes           |
| ecr-public    | csi-resizer               | ecr-public     | **v1.4.0-eks-1-20-15** | yes           |
| ecr-public    | csi-snapshotter           | ecr-public     | **v6.0.1-eks-1-20-17** | yes           |
| ecr-public    | livenessprobe             | ecr-public     | **v2.3.0-eks-1-20-11** | yes           |

**What testing is done?** 

1. Checked that the overlays are using images from the proper registry.

2. Invoked the following command on the images used on all overlays to check whether or not we are only using images with both AMD64 and ARM64 support.

```bash
skopeo inspect --override-os linux --override-arch amd64 -n "docker://${IMAGE}"
skopeo inspect --override-os linux --override-arch arm64 -n "docker://${IMAGE}"
```