### PR TITLE
Fix image tags in ecr-public kustomization

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -7,19 +7,19 @@ images:
     newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    tagSuffix: -eks-1-20-15
+    newTag: v3.1.0-eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    tagSuffix: -eks-1-20-15
+    newTag: v3.4.0-eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
     newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    tagSuffix: -eks-1-20-15
+    newTag: v2.6.0-eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    tagSuffix: -eks-1-20-17
+    newTag: v6.0.1-eks-1-20-17
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
     newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    tagSuffix: -eks-1-20-15
+    newTag: v1.4.0-eks-1-20-15
   - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
     newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    tagSuffix: -eks-1-20-17
+    newTag: v2.5.1-eks-1-20-17


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**

- Fixes #1304 

**What is this PR about? / Why do we need it?**

```
kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"

error: accumulating resources: accumulation err='accumulating resources from 
'./ecr-public': '/tmp/kustomize-014789932/deploy/kubernetes/overlays/stable/ecr-public' must resolve to a file': 
couldn't make target for path '/tmp/kustomize-014789932/deploy/kubernetes/overlays/stable/ecr-public': json: unknown field "tagSuffix"
```

**What testing is done?** 

```
kubectl apply -k "github.com/torredil/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"

serviceaccount/ebs-csi-controller-sa unchanged
serviceaccount/ebs-csi-node-sa unchanged
clusterrole.rbac.authorization.k8s.io/ebs-csi-node-role unchanged
clusterrole.rbac.authorization.k8s.io/ebs-external-attacher-role unchanged
clusterrole.rbac.authorization.k8s.io/ebs-external-provisioner-role unchanged
clusterrole.rbac.authorization.k8s.io/ebs-external-resizer-role unchanged
clusterrole.rbac.authorization.k8s.io/ebs-external-snapshotter-role unchanged
clusterrolebinding.rbac.authorization.k8s.io/ebs-csi-attacher-binding unchanged
clusterrolebinding.rbac.authorization.k8s.io/ebs-csi-node-getter-binding unchanged
clusterrolebinding.rbac.authorization.k8s.io/ebs-csi-provisioner-binding unchanged
clusterrolebinding.rbac.authorization.k8s.io/ebs-csi-resizer-binding unchanged
clusterrolebinding.rbac.authorization.k8s.io/ebs-csi-snapshotter-binding unchanged
```


