### PR TITLE
Pass GOPROXY to image builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@
 FROM --platform=$BUILDPLATFORM golang:1.17 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY go.* .
+ARG GOPROXY
 RUN go mod download
 COPY . .
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 		--target=$(OS)-$(OSVERSION) \
 		--output=type=$(OUTPUT_TYPE) \
 		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
+		--build-arg=GOPROXY=$(GOPROXY) \
 		.
 	touch $@
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** 

**What is this PR about? / Why do we need it?** for networks where proxy.golang.org is blocked, go mod download fails.

**What testing is done?**  ~~testing now, now go mod download seems to be working but it is taking a while.~~
edit: it worked. took 15+ minutes but I assume it will be cached :pray: '
```
10 [builder 4/6] RUN go mod download
#10 DONE 1052.4s
```