### PR TITLE
Set `GOPROXY` in `cloudbuild.yaml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_DATE?=$(shell date -u -Iseconds)
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 
 GO111MODULE=on
-GOPROXY=direct
+GOPROXY?=direct
 GOPATH=$(shell go env GOPATH)
 GOOS=$(shell go env GOOS)
 GOBIN=$(shell pwd)/bin

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,5 +7,6 @@ steps:
       - PULL_BASE_REF=${_PULL_BASE_REF}
       - REGISTRY_NAME=gcr.io/${_STAGING_PROJECT}
       - HOME=/root
+      - GOPROXY=https://proxy.golang.org
 substitutions:
   _STAGING_PROJECT: "k8s-staging-provider-aws"


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**What is this PR about? / Why do we need it?**
- The `vendor` directory was removed in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1328 to address https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1326.  As a result of this change, we need to account for two scenarios:

     1) For security, a user might want to prevent outgoing connections outside their internal network. Addressed in #1330.
     2) If GOPROXY is undefined or set to "direct", then `go get` will use a direct connection to the VCS (e.g github.com). This is causing our build to [timeout](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1554118382679232512), since `go mod download` takes nearly 30 minutes to complete. Addressed by this PR.
------
**Why do we need it?**
- Dependencies are stored in immutable storage, thus avoiding the risk that any dependency might disappear in the future.
- Protection against actors who might inject malicious code since Go modules cannot be deleted or overridden once stored in the `GOPROXY`.
- Significantly faster to resolve dependencies since `GOPROXY` serves the source code over HTTP, thus not requiring the overhead when pulling from a VCS which fetches the whole repository. 
------     
**What testing is done?** 
- CI
