### PR TITLE
Improve securityContext implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,9 @@ generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-provisioner.yaml > ../../deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-resizer.yaml > ../../deploy/kubernetes/base/clusterrolebinding-resizer.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-snapshotter.yaml > ../../deploy/kubernetes/base/clusterrolebinding-snapshotter.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/controller.yaml --api-versions 'snapshot.storage.k8s.io/v1' > ../../deploy/kubernetes/base/controller.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/controller.yaml --set "image.repository=k8s.gcr.io/provider-aws/aws-ebs-csi-driver" --api-versions 'snapshot.storage.k8s.io/v1' | sed -e "/namespace: /d" | sed -e "s/:v.*$$//g" > ../../deploy/kubernetes/base/controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/csidriver.yaml > ../../deploy/kubernetes/base/csidriver.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/node.yaml  > ../../deploy/kubernetes/base/node.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/poddisruptionbudget-controller.yaml > ../../deploy/kubernetes/base/poddisruptionbudget-controller.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-controller.yaml > ../../deploy/kubernetes/base/serviceaccount-csi-controller.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/node.yaml --set "image.repository=k8s.gcr.io/provider-aws/aws-ebs-csi-driver" | sed -e "/namespace: /d" | sed -e "s/:v.*$$//g" > ../../deploy/kubernetes/base/node.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/poddisruptionbudget-controller.yaml --api-versions 'policy/v1/PodDisruptionBudget' | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/poddisruptionbudget-controller.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-controller.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm chart
 
+## 2.10.0
+* Implement securityContext for containers
+* Add securityContext for node pod
+* Utilize more secure defaults for securityContext
+
 ## v2.9.0
 * Bump app/driver to version `v1.10.0`
 * Feature: Reference `configMaps` across multiple resources using `envFrom` ([#1312](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1312), [@jebbens](https://github.com/jebbens))

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.10.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.9.0
+version: 2.10.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -61,7 +61,7 @@ spec:
       {{- with .Values.controller.securityContext }}
       securityContext:  
         {{- toYaml . | nindent 8 }}
-      {{- end }} 
+      {{- end }}
       containers:
         - name: ebs-plugin
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
@@ -153,6 +153,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.controller.containerSecurityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-provisioner
           image: {{ printf "%s:%s" .Values.sidecars.provisioner.image.repository .Values.sidecars.provisioner.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.provisioner.image.pullPolicy }}
@@ -185,6 +189,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.provisioner.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: csi-attacher
           image: {{ printf "%s:%s" .Values.sidecars.attacher.image.repository .Values.sidecars.attacher.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.attacher.image.pullPolicy }}
@@ -212,6 +220,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.attacher.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if or (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
         - name: csi-snapshotter
           image: {{ printf "%s:%s" .Values.sidecars.snapshotter.image.repository .Values.sidecars.snapshotter.image.tag }}
@@ -237,6 +249,10 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- with default .Values.controller.resources .Values.sidecars.snapshotter.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sidecars.snapshotter.securityContext }}
+          securityContext:  
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
@@ -267,6 +283,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.resizer.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.livenessProbe.image.pullPolicy }}
@@ -281,6 +301,10 @@ spec:
               mountPath: /csi
           {{- with default .Values.controller.resources .Values.sidecars.livenessProbe.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sidecars.livenessProbe.securityContext }}
+          securityContext:  
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -49,10 +49,12 @@ spec:
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- with .Values.node.securityContext }}
+      securityContext:  
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ebs-plugin
-          securityContext:
-            privileged: true
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -104,6 +106,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.node.containerSecurityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: node-driver-registrar
           image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.nodeDriverRegistrar.image.pullPolicy }}
@@ -135,6 +141,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.nodeDriverRegistrar.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
           image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.livenessProbe.image.pullPolicy }}
@@ -149,6 +159,10 @@ spec:
               mountPath: /csi
           {{- with default .Values.node.resources .Values.sidecars.livenessProbe.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sidecars.livenessProbe.securityContext }}
+          securityContext:  
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- if .Values.imagePullSecrets }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -22,6 +22,9 @@ sidecars:
       tag: "v3.1.0"
     logLevel: 2
     resources: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   attacher:
     env: []
     image:
@@ -30,6 +33,9 @@ sidecars:
       tag: "v3.4.0"
     logLevel: 2
     resources: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   snapshotter:
     env: []
     image:
@@ -38,12 +44,18 @@ sidecars:
       tag: "v6.0.1"
     logLevel: 2
     resources: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   livenessProbe:
     image:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/livenessprobe
       tag: "v2.6.0"
     resources: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   resizer:
     env: []
     image:
@@ -52,6 +64,9 @@ sidecars:
       tag: "v1.4.0"
     logLevel: 2
     resources: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
   nodeDriverRegistrar:
     env: []
     image:
@@ -60,6 +75,9 @@ sidecars:
       tag: "v2.5.1"
     logLevel: 2
     resources: {}
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
 
 proxy:
   http_proxy:
@@ -136,9 +154,16 @@ controller:
   #    topologyKey: kubernetes.io/hostname
   #    whenUnsatisfiable: ScheduleAnyway
   topologySpreadConstraints: []
-  securityContext: {}
-  #  AWS EKS /var/run/secrets/eks.amazonaws.com/serviceaccount/token FS group is nogroup (65534) - required for Kubernetes 1.18.x and below
-  #  fsGroup: 65534
+  # securityContext on the controller pod
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  # securityContext on the controller container (see sidecars for securityContext on sidecar containers)
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
 
 node:
   env: []
@@ -172,6 +197,17 @@ node:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: "10%"
+  # securityContext on the node pod
+  securityContext:
+    # The node pod must be run as root to bind to the registration/driver sockets
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: 0
+  # securityContext on the node container (see sidecars for securityContext on sidecar containers)
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    privileged: true
 
 storageClasses: []
 # Add StorageClass resources like:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -28,7 +28,12 @@ spec:
           operator: Exists
         - operator: Exists
           effect: NoExecute
-          tolerationSeconds: 300 
+          tolerationSeconds: 300
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
         - name: ebs-plugin
           image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
@@ -63,6 +68,7 @@ spec:
                   name: aws-meta
                   key: endpoint
                   optional: true
+          envFrom:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -86,6 +92,9 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner
           imagePullPolicy: IfNotPresent
@@ -99,9 +108,13 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          envFrom:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-attacher
           image: k8s.gcr.io/sig-storage/csi-attacher
           imagePullPolicy: IfNotPresent
@@ -112,9 +125,13 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          envFrom:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-snapshotter
           image: k8s.gcr.io/sig-storage/csi-snapshotter
           imagePullPolicy: IfNotPresent
@@ -124,9 +141,13 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          envFrom:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: csi-resizer
           image: k8s.gcr.io/sig-storage/csi-resizer
           imagePullPolicy: IfNotPresent
@@ -137,17 +158,25 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          envFrom:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: liveness-probe
           image: k8s.gcr.io/sig-storage/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
+          envFrom:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -41,10 +41,13 @@ spec:
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
       containers:
         - name: ebs-plugin
-          securityContext:
-            privileged: true
           image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
           imagePullPolicy: IfNotPresent
           args:
@@ -59,6 +62,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          envFrom:
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
@@ -79,6 +83,10 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: true
+            readOnlyRootFilesystem: true
         - name: node-driver-registrar
           image: k8s.gcr.io/sig-storage/csi-node-driver-registrar
           imagePullPolicy: IfNotPresent
@@ -91,19 +99,27 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+          envFrom:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: liveness-probe
           image: k8s.gcr.io/sig-storage/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
+          envFrom:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/deploy/kubernetes/base/poddisruptionbudget-controller.yaml
+++ b/deploy/kubernetes/base/poddisruptionbudget-controller.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: ebs-csi-controller

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -6,6 +6,6 @@ metadata:
   name: ebs-csi-controller-sa
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
-  #Enable if EKS IAM for SA is used
+  #Enable if EKS IAM roles for service accounts (IRSA) is used. See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
   #annotations:
-  #  eks.amazonaws.com/role-arn: arn:aws:iam::586565787010:role/ebs-csi-role
+  #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature
Fixes #1332
Fixes #1101

**What is this PR about? / Why do we need it?**

Implements `securityContext` for the node pod and all containers (including sidecar containers). Also switches to a more secure `securityContext` default of running as a non-root user and with a read-only root filesystem.

Currently, the node pod must run as a root user because `/var/lib/kubelet/plugins/ebs.csi.aws.com/` and `/var/lib/kubelet/plugins_registry/` are kubelet-managed and usually only writable by root (additionally, the node driver needs `privileged` for the bidirectional mount anyways, so root would not give extra security to that container anyways).

Also makes some minor improvements to `make generate-kustomize` so it doesn't generate useless diffs that have to be manually removed.

**What testing is done?** 

Manually tested.