### PR TITLE
Only run helm action when Chart.yaml modified

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - "charts/**"
+      - "charts/**/Chart.yaml"
 
 jobs:
   release:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"Bug fix"

**What is this PR about? / Why do we need it?**

The helm release action gets run every time the `charts/` directory is modified. However, if the helm version hasn't been bumped (either by accident or because the new changes intentionally shouldn't be released) then the commit has a sad red X when merged into master:

![image](https://user-images.githubusercontent.com/6501170/182694707-daac1a5e-e51b-4e77-b906-fb2f8b42b590.png)

This PR fixes that by only running the helm release action when `Chart.yaml` is modified (which very likely is a version bump).

**What testing is done?** 

Manually tested on test branch of forked repo