### PR TITLE
Fix static provisioning example

### DIFF
--- a/examples/kubernetes/static-provisioning/README.md
+++ b/examples/kubernetes/static-provisioning/README.md
@@ -48,8 +48,8 @@ This example shows you how to create and consume a `PersistentVolume` from an ex
     ```sh
     $ kubectl get pvc ebs-claim
 
-    NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-    ebs-claim   Bound    pvc-119a0c81-f45a-4bec-a116-c36cc428cc57   5Gi        RWO            gp2            53s
+    NAME        STATUS   VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    ebs-claim   Bound    test-pv   5Gi        RWO                           53s
     ```
 
 4. Validate the pod successfully wrote data to the statically provisioned volume:

--- a/examples/kubernetes/static-provisioning/manifests/claim.yaml
+++ b/examples/kubernetes/static-provisioning/manifests/claim.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: ebs-claim
 spec:
+  storageClassName: "" # Empty string must be explicitly set otherwise default StorageClass will be set
+  volumeName: test-pv
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
- Fix **static volume provisioning** example

**What is this PR about? / Why do we need it?**
- Set `volumeNmae` explicitly to avoid falling back to dynamic provisioning.
- Ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reserving-a-persistentvolume

**What testing is done?** 
- Tested by deploying to an EKS cluster