### PR TITLE
Automate publishing to ECR

### DIFF
--- a/.github/workflows/publish-ecr.yaml
+++ b/.github/workflows/publish-ecr.yaml
@@ -1,0 +1,76 @@
+name: Publish to ECR
+on:
+  push:
+    tags: ['*']
+jobs:
+  ecr-private:
+    name: Push to ECR Private
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-session-name: GitHubCI
+        aws-region: us-east-1
+        role-duration-seconds: 1800
+        role-skip-session-tagging: true
+
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Set environment variables
+      env:
+        REGISTRY: ${{ secrets.ECR_PRIVATE_REPOSITORY }}
+      run: |
+          echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
+          echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+    - name: Build, tag, and push manifest to Amazon ECR
+      run: make -j `nproc` all-push
+
+  ecr-public:
+    name: Push to ECR Public
+    runs-on: ubuntu-latest
+    environment: ecr-public
+    needs: ecr-private
+
+    steps:
+    - name: Set up crane
+      uses: imjasonh/setup-crane@v0.1
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-session-name: GitHubCI
+        aws-region: us-east-1
+        role-duration-seconds: 1800
+        role-skip-session-tagging: true
+
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Login to Amazon ECR Public
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        registry-type: public
+
+    - name: Copy manifest to ECR Public
+      env:
+        ECR_PRIVATE_REPOSITORY: ${{ secrets.ECR_PRIVATE_REPOSITORY }}
+        ECR_PUBLIC_REPOSITORY: ${{ secrets.ECR_PUBLIC_REPOSITORY }}
+      run: crane copy ${ECR_PRIVATE_REPOSITORY}/aws-ebs-csi-driver:${GITHUB_REF_NAME} ${ECR_PUBLIC_REPOSITORY}/aws-ebs-csi-driver:${GITHUB_REF_NAME}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION=v1.10.0
+VERSION?=v1.10.0
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)
@@ -21,7 +21,7 @@ BUILD_DATE?=$(shell date -u -Iseconds)
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 
 GO111MODULE=on
-GOPROXY?=direct
+GOPROXY?=https://proxy.golang.org
 GOPATH=$(shell go env GOPATH)
 GOOS=$(shell go env GOOS)
 GOBIN=$(shell pwd)/bin
@@ -75,7 +75,7 @@ push-manifest: create-manifest
 	docker manifest push --purge $(IMAGE):$(TAG)
 
 .PHONY: create-manifest
-create-manifest:
+create-manifest: all-image-registry
 # sed expression:
 # LHS: match 0 or more not space characters
 # RHS: replace with $(IMAGE):$(TAG)-& where & is what was matched on LHS


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**What is this PR about? / Why do we need it?**

- Added workflow to automate publishing container images to staging / public ECR. Workflow is split into two separate jobs to enable a manual approval step / verify the release before pushing to public ECR.
- `create-manifest: all-image-registry` allows for parallelization with ``make -j `nproc` all-push`` to improve build times.
- Changes `GOPROXY` default value to `https://proxy.golang.org`.

closes #1317 
closes #1315
