### PR TITLE
Change the example policy to have tighter permissions.

### DIFF
--- a/docs/example-iam-policy-strict.json
+++ b/docs/example-iam-policy-strict.json
@@ -1,0 +1,126 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumesModifications"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeName": "*",
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+          "ec2:ResourceTag/kubernetes.io/cluster/<<CLUSTER_ID>>": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeSnapshotName": "*",
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+          "ec2:ResourceTag/kubernetes.io/cluster/<<CLUSTER_ID>>": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/CSIVolumeName": "*",
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true",
+          "aws:RequestTag/kubernetes.io/cluster/<<CLUSTER_ID>>": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeName": "*",
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+          "ec2:ResourceTag/kubernetes.io/cluster/<<CLUSTER_ID>>": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeName": "*",
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+          "ec2:ResourceTag/kubernetes.io/cluster/<<CLUSTER_ID>>": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeSnapshotName": "*",
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true",
+          "ec2:ResourceTag/kubernetes.io/cluster/<<CLUSTER_ID>>": "owned"
+        }
+      }
+    }
+  ]
+}

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,8 +9,9 @@
 * Important: If you intend to use the Volume Snapshot feature, the [Kubernetes Volume Snapshot CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd) must be installed **before** the EBS CSI driver. For installation instructions, see [CSI Snapshotter Usage](https://github.com/kubernetes-csi/external-snapshotter#usage).
 
 ## Installation
-### Set up driver permissions
-The driver requires IAM permissions to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./example-iam-policy.json) defines these permissions. AWS maintains a managed policy, available at ARN `arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`. 
+
+### Set up driver permission
+The driver requires IAM permissions to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./example-iam-policy.json) defines these permissions. A [stricter example policy](./example-iam-policy-strict.json) is also provided, but needs to be modified before use (specifically, replace `<<CLUSTER_ID>>` with the ID of your cluster). AWS maintains a managed policy, available at ARN `arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`.
 
 Note: Add the below statement to the example policy if you want to encrypt the EBS drives. 
 ```


### PR DESCRIPTION
Draft PR until some conversation happens. Specifically, with this PR, the example policy won't work without the end user looking at it and changing `CLUSTER_ID` to their cluster id/name.

## Description 

The example policy is too lax.

This policy presents the following issues:

* It allows the IAM Role to delete any EBS volume tagged with "CSIVolumeName" OR "ebs.csi.aws.com/cluster" OR "kubernetes.io/cluster/*"
* It allows the IAM Role to delete any EBS snapshot tagged with "CSIVolumeSnapshotName" OR "ebs.csi.aws.com/cluster"

This means the EBS CSI IAM Role can delete any volume or snapshot from any other cluster.

This commit changes this policy and replaces the OR conditions by AND conditions, as well as restricting kubernetes.io/cluster/* to kubernetes.io/cluster/EKS_CLUSTER_ID.

This means the EBS CSI IAM Role can only delete volume or snapshot it owns.