### PR TITLE
Set VERSION env variable in publish-ecr workflow

### DIFF
--- a/.github/workflows/publish-ecr.yaml
+++ b/.github/workflows/publish-ecr.yaml
@@ -36,6 +36,7 @@ jobs:
       run: |
           echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
           echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
     - name: Build, tag, and push manifest to Amazon ECR
       run: make -j `nproc` all-push


### PR DESCRIPTION
Signed-off-by: Eddie Torres <torredil@amazon.com>

**Is this a bug fix or adding new feature?**
- Bug fix

**What is this PR about? / Why do we need it?**
- The version flag, i.e `docker run $image --version` outputs the wrong driver version. Since we are no longer doing a pre-release commit to update the version in the [Makefile](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/6760e34480fa74894149d52c15cf21924bacf442/Makefile#L15), the `VERSION` env variable needs to be set and correctly passed into [LDFLAGS](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/6760e34480fa74894149d52c15cf21924bacf442/Makefile#L21) to fix the `--version` flag.

