### PR TITLE
Apply fix from helm chart to kustomize manifests

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -84,7 +84,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
           securityContext:
-            allowPrivilegeEscalation: false
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar


### PR DESCRIPTION
Fixes #1347, will need a cherry pick to `release-1.11` as well. I will open the cherry pick PR after this is merged.

Blocks 1.11.1 post-release PR.