### PR TITLE
Add kustomize verification for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,12 @@ verify-vendor:
 	@ echo; echo "### $@:"
 	@ ./hack/verify-vendor.sh
 
+.PHONY: verify-kustomize
+verify: verify-kustomize
+verify-kustomize:
+	@ echo; echo "### $@:"
+	@ ./hack/verify-kustomize
+
 .PHONY: generate-kustomize
 generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrole-attacher.yaml > ../../deploy/kubernetes/base/clusterrole-attacher.yaml

--- a/hack/verify-kustomize
+++ b/hack/verify-kustomize
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+echo "Verifying kustomize"
+diff=$(git status --porcelain=v1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  echo
+  echo "Please commit all changes before verifying"
+  exit 1
+fi
+make generate-kustomize
+echo
+diff=$(git status --porcelain=v1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  echo
+  echo "Please run make generate-kustomize to fix the issue(s)"
+  exit 1
+fi
+echo "No issue found"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New "feature"

**What is this PR about? / Why do we need it?**

Adds verification to CI that kustomize templates were regenerated when the helm chart is changed. Prevents mistakes that cause issues such as #1347.

**What testing is done?** 

Manually tested. CI will fail until #1348 is merged because it is designed to test for the problem that PR fixes (and thus, fails against current master).
