### PR TITLE
Automated cherry pick of #1348: Apply fix from helm chart to kustomize manifests

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -84,7 +84,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
           securityContext:
-            allowPrivilegeEscalation: false
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar


### PR DESCRIPTION
Cherry pick of #1348 on release-1.11.

#1348: Apply fix from helm chart to kustomize manifests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```