### PR TITLE
Explicitly pass VERSION as a build-arg

### DIFF
--- a/.github/workflows/publish-ecr.yaml
+++ b/.github/workflows/publish-ecr.yaml
@@ -36,6 +36,7 @@ jobs:
       run: |
           echo "REGISTRY=${REGISTRY}" >> $GITHUB_ENV
           echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
     - name: Build, tag, and push manifest to Amazon ECR
       run: make -j `nproc` all-push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,5 +22,5 @@ jobs:
 
             ## CHANGELOG
             See [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md) for full list of changes
-          draft: false
+          draft: true
           prerelease: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN go mod download
 COPY . .
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION
 RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2 AS linux-amazon

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 		--output=type=$(OUTPUT_TYPE) \
 		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
 		--build-arg=GOPROXY=$(GOPROXY) \
+		--build-arg=VERSION=$(VERSION) \
 		.
 	touch $@
 


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- `VERSION` is being [set](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/7883559757?check_suite_focus=true#step:7:4)  but not correctly passed into [LDFLAGS](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/7883559757?check_suite_focus=true#step:8:228) because it must be passed explicitly as a build-arg.
- Set release draft to true.

**What testing is done?** 
- Test run on forked repo: https://github.com/torredil/aws-ebs-csi-driver/runs/7886619522?check_suite_focus=true#step:8:234
