### PR TITLE
Set inital release to draft status

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,5 +22,5 @@ jobs:
 
             ## CHANGELOG
             See [CHANGELOG](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md) for full list of changes
-          draft: false
+          draft: true
           prerelease: false


### PR DESCRIPTION
Signed-off-by: Gengtao Xu <gengtaox@amazon.com>

**Is this a bug fix or adding new feature?**

Big fix

**What is this PR about? / Why do we need it?**

Once release tag it post a new version in release section while the images are not ready. To avoid confusion we set the initial release as draft release and mark it as official release once the all processes are done.

**What testing is done?** 
