### PR TITLE
Builds should not set/get GOPROXY in the environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please go through [CSI Spec](https://github.com/container-storage-interface/spec
 * Docker 17.05+ for releasing
 
 ### Dependency
-Dependencies are managed through go module. To build the project, first turn on go mod using `export GO111MODULE=on`, then build the project using: `make`
+Dependencies are managed through go module. To build the project simply type: `make`
 
 ### Testing
 * To execute all unit tests, run: `make test`

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ BUILD_DATE?=$(shell date -u -Iseconds)
 LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 
 GO111MODULE=on
-GOPROXY?=https://proxy.golang.org
 GOPATH=$(shell go env GOPATH)
 GOOS=$(shell go env GOOS)
 GOBIN=$(shell pwd)/bin

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,5 @@ steps:
       - PULL_BASE_REF=${_PULL_BASE_REF}
       - REGISTRY_NAME=gcr.io/${_STAGING_PROJECT}
       - HOME=/root
-      - GOPROXY=https://proxy.golang.org
 substitutions:
   _STAGING_PROJECT: "k8s-staging-provider-aws"


### PR DESCRIPTION
Go settings are managed by `go env`. This is the way.

Also, simplify the build instructions. `GO111MODULE` does not need to
be set in the build environment.

Signed-off-by: Wayne Mesard <wsm@amazon.com>

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
