### PR TITLE
c6i.metal and g5g.metal are nitro instances

### DIFF
--- a/pkg/cloud/volume_limits.go
+++ b/pkg/cloud/volume_limits.go
@@ -14,13 +14,6 @@ const (
 	nitroMaxAttachments                  = 28
 )
 
-// / It is possible to have an instance family where the virtualized instances are Nitro
-// / and metal instances are not
-var nonNitroInstances = map[string]struct{}{
-	"c6i.metal": {},
-	"g5g.metal": {},
-}
-
 // / List of nitro instance types can be found here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
 var nonNitroInstanceFamilies = map[string]struct{}{
 	"t2":     {},
@@ -41,10 +34,6 @@ var nonNitroInstanceFamilies = map[string]struct{}{
 }
 
 func IsNitroInstanceType(it string) bool {
-	if _, ok := nonNitroInstances[it]; ok {
-		return false
-	}
-
 	strs := strings.Split(it, ".")
 
 	if len(strs) != 2 {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1991,7 +1991,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      1,
-			expMaxVolumes:     31,
+			expMaxVolumes:     27, // 28 (max) - 1 (eni)
 			outpostArn:        emptyOutpostArn,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Wayne Mesard <wsm@amazon.com>

**Is this a bug fix or adding new feature?**

Bug

**What is this PR about? / Why do we need it?**

An earlier version of the [Available instance types list](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances) was unclear on whether `c6i.metal` and `g5g.metal`. They are. And the docs now say so unambiguously. This PR updates the code to match the doc (and reality).

**What testing is done?** 

`make && make test`