### PR TITLE
Add warning message when region is unavailable on the controller

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -81,6 +81,7 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 		klog.V(5).Infof("[Debug] Retrieving region from metadata service")
 		metadata, err := NewMetadataFunc(cloud.DefaultEC2MetadataClient, cloud.DefaultKubernetesAPIClient, region)
 		if err != nil {
+			klog.Errorf("Could not determine region from any metadata service. The region can be manually supplied via the AWS_REGION environment variable.")
 			panic(err)
 		}
 		region = metadata.GetRegion()


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Adds clearer warning message so customers with cases such as #1357 understand they should manually supply the region.

**What testing is done?** 

N/A