### PR TITLE
Support IOPS parameter for IO1/IO2 volumes

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -7,13 +7,21 @@ The AWS EBS CSI Driver supports [tagging](tagging.md) through `StorageClass.para
 |-----------------------------|----------------------------------------|----------|---------------------|
 | "csi.storage.k8s.io/fstype" | xfs, ext2, ext3, ext4                  | ext4     | File system type that will be formatted during volume creation. This parameter is case sensitive! |
 | "type"                      | io1, io2, gp2, gp3, sc1, st1,standard  | gp3*     | EBS volume type.     |
-| "iopsPerGB"                 |                                        |          | I/O operations per second per GiB. Required when io1 or io2 volume type is specified. If this value multiplied by the size of a requested volume produces a value above the maximum IOPs allowed for the volume type, as documented [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html), AWS will cap the IOPS to maximum supported value. If the value is lower than minimal supported IOPS value per volume, either error is returned (the default behavior) or the value is increased to fit into the supported range when `allowautoiopspergbincrease` is `"true"`.|
+| "iopsPerGB"                 |                                        |          | I/O operations per second per GiB. Can be specified for IO1, IO2, and GP3 volumes. |
 | "allowAutoIOPSPerGBIncrease"| true, false                            | false    | When `"true"`, the CSI driver increases IOPS for a volume when `iopsPerGB * <volume size>` is too low to fit into IOPS range supported by AWS. This allows dynamic provisioning to always succeed, even when user specifies too small PVC capacity or `iopsPerGB` value. On the other hand, it may introduce additional costs, as such volumes have higher IOPS than requested in `iopsPerGB`.|
-| "iops"                      |                                        | 3000     | I/O operations per second. Only effective when gp3 volume type is specified. If empty, it will set to 3000 as documented [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html). |
+| "iops"                      |                                        |          | I/O operations per second. Can be specified for IO1, IO2, and GP3 volumes. |
 | "throughput"                |                                        | 125      | Throughput in MiB/s. Only effective when gp3 volume type is specified. If empty, it will set to 125MiB/s as documented [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html). |
 | "encrypted"                 |                                        |          | Whether the volume should be encrypted or not. Valid values are "true" or "false". |
 | "kmsKeyId"                  |                                        |          | The full ARN of the key to use when encrypting the volume. If not specified, AWS will use the default KMS key for the region the volume is in. This will be an auto-generated key called `/aws/ebs` if not changed. |
 
-**Notes**:
+**Appendix**
 * `gp3` is currently not supported on outposts. Outpost customers need to use a different type for their volumes.
 * Unless explicitly noted, all parameters are case insensitive (e.g. "kmsKeyId", "kmskeyid" and any other combination of upper/lowercase characters can be used).
+* If the requested IOPs (either directly from `iops` or from `iopsPerGB` multiplied by the volume's capacity) produces a value above the maximum IOPs allowed for the [volume type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html), the IOPS will be capped at the maximum value allowed. If the value is lower than the minimal supported IOPS value per volume, either an error is returned (the default behavior), or the value is increased to fit into the supported range when `allowautoiopspergbincrease` is `"true"`.
+* You may specify either the "iops" or "iopsPerGb" parameters, not both. Specifying both parameters will result in an invalid StorageClass.
+
+| Volume Type                 | Min total IOPS                         | Max total IOPS   | Max IOPS per GB   |
+|-----------------------------|----------------------------------------|------------------|-------------------|
+| IO1                         | 100                                    | 64000            | 50                |
+| IO2                         | 100                                    | 64000            | 500               |
+| GP3                         | 3000                                   | 16000            | 500               |

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -160,8 +160,9 @@ func IOPSForVolumeType(volumeType string) string {
 	switch volumeType {
 	case "gp3":
 		// Maximum IOPS for gp3 is 16000. However, maximum IOPS/GB for gp3 is 500.
-		// Since the tests will run using minimum volume capacity (1GB), set to 500.
-		return "500"
+		// Since the tests will run using minimum volume capacity (1GB), set to 3000
+		// because minimum IOPS for gp3 is 3000.
+		return "3000"
 	default:
 		return ""
 	}


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- Support IOPS parameter for IO1/IO2 volumes.
- Support IOPSPerGB for GP3 volumes.
- Address #1364.

**What testing is done?** 

- `make test`
- CI


```
StorageClass
---------------------------
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
parameters:
  csi.storage.k8s.io/fstype: ext4
  IOPS: "100"
  type: io2
---------------------------

**Old behavior**

$ kubectl describe pvc

Warning  ProvisioningFailed    2s (x3 over 5s)  ebs.csi.aws.com_ebs-csi-controller-756d5594dd-vgzsj_728a3701-f044-4021-bfaf-316189032728  failed to provision volume with StorageClass "ebs-sc": rpc error: code = Internal desc = Could not create volume "pvc-6ebcdc8f-0ab7-4e9a-9ee4-477c7cbb7d87": invalid combination of volume size 4 GB and iopsPerGB 0: the resulting IOPS 0 is too low for AWS, it must be at least 100

**New behavior**

$ kubectl describe pvc

Normal   ProvisioningSucceeded  3s                 ebs.csi.aws.com_ebs-csi-controller-58f67d8bfb-fm2m7_9ca56fcb-bcc9-4ba8-a2e3-872db5595932  Successfully provisioned volume pvc-36e7c4ac-00cd-4340-9517-f3b5bcac6da8
```
-  Failure mode: specifying `IOPS` and `IOPSPerGB` StorageClass parameters.
```
StorageClass
---------------------------
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
parameters:
  csi.storage.k8s.io/fstype: ext4
  IOPS: "100"
  IOPSPerGB: "100"
  type: io2
---------------------------

$ kubectl describe pvc

Warning  ProvisioningFailed    2s (x2 over 3s)  ebs.csi.aws.com_ebs-csi-controller-58f67d8bfb-fm2m7_9ca56fcb-bcc9-4ba8-a2e3-872db5595932  failed to provision volume with StorageClass "ebs-sc": rpc error: code = Internal desc = Could not create volume "pvc-2c35f4c6-cc22-48c1-8d40-3a42645b7ee3": invalid StorageClass paramaters; specify either IOPS or IOPSPerGb, not both
```

*Signed-off-by: Eddie Torres <torredil@amazon.com>*
