### PR TITLE
Update module k8s.io/klog to v2

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 	"k8s.io/component-base/metrics/legacyregistry"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func main() {

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -25,7 +25,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/cmd/options"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Options is the combined set of options for all operating modes.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	k8s.io/apimachinery v0.22.11
 	k8s.io/client-go v1.22.11
 	k8s.io/component-base v0.22.11
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.70.0
 	k8s.io/kubernetes v1.22.11
 	k8s.io/mount-utils v0.22.11

--- a/go.sum
+++ b/go.sum
@@ -1026,8 +1026,6 @@ k8s.io/csi-translation-lib v0.22.11 h1:wJa0zE16oBjfvkPXoJhjtpreK3hU6osJYrAxW6Tg1
 k8s.io/csi-translation-lib v0.22.11/go.mod h1:nGPFKRU7GUqQyQsPINnPoVllhAAkX7627UHK/eMEv2E=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -34,7 +34,7 @@ import (
 	dm "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/devicemanager"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // AWS volume types

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const devPreffix = "/dev/xvd"

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/request"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // RecordRequestsComplete is added to the Complete chain; called after any request

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Metadata is info about the ec2 instance on which the driver is running

--- a/pkg/cloud/metadata_ec2.go
+++ b/pkg/cloud/metadata_ec2.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type EC2MetadataClient func() (EC2Metadata, error)

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util/template"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 var (

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -24,7 +24,7 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"google.golang.org/grpc"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // Mode is the operating mode of the CSI driver.

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {

--- a/pkg/driver/internal/inflight.go
+++ b/pkg/driver/internal/inflight.go
@@ -17,8 +17,9 @@ limitations under the License.
 package internal
 
 import (
-	"k8s.io/klog"
 	"sync"
+
+	"k8s.io/klog/v2"
 )
 
 // Idempotent is the interface required to manage in flight requests.

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 )
 

--- a/pkg/driver/node_linux.go
+++ b/pkg/driver/node_linux.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"golang.org/x/sys/unix"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func (d *nodeService) appendPartition(devicePath, partition string) string {

--- a/pkg/driver/node_windows.go
+++ b/pkg/driver/node_windows.go
@@ -28,7 +28,7 @@ import (
 	diskapi "github.com/kubernetes-csi/csi-proxy/client/api/disk/v1"
 	diskclient "github.com/kubernetes-csi/csi-proxy/client/groups/disk/v1"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/mounter"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // findDevicePath finds disk number of device

--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func ValidateDriverOptions(options *DriverOptions) error {

--- a/pkg/resizefs/resizefs_windows.go
+++ b/pkg/resizefs/resizefs_windows.go
@@ -5,7 +5,7 @@ package resizefs
 
 import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/mounter"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // resizeFs provides support for resizing file systems


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
- Bug fix.

**What is this PR about? / Why do we need it?**
- closes #1369 

**What testing is done?** 

```
//current logging with --v=5

kubectl logs ebs-csi-node-5dfp2 -n kube-system -c ebs-plugin
I0901 00:11:25.194251       1 driver.go:73] Driver: ebs.csi.aws.com Version: v1.11.2
I0901 00:11:25.194302       1 node.go:96] [Debug] Retrieving node info from metadata service
I0901 00:11:25.194307       1 node.go:98] regionFromSession Node service
I0901 00:11:25.194319       1 metadata.go:85] retrieving instance data from ec2 metadata
W0901 00:11:28.364912       1 metadata.go:88] ec2 metadata is not available
I0901 00:11:28.364931       1 metadata.go:96] retrieving instance data from kubernetes api
I0901 00:11:28.369502       1 metadata.go:101] kubernetes api is available
I0901 00:11:28.385065       1 driver.go:143] Listening for connections on address: &net.UnixAddr{Name:"/csi/csi.sock", Net:"unix"}
I0901 00:11:28.848232       1 node.go:533] NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:13:31.591618       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:13:31.598301       1 node.go:119] NodeStageVolume: called with args {VolumeId:vol-0bc4f2e94e89e01cc PublishContext:map[devicePath:/dev/xvdba] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/globalmount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1661991051451-8081-ebs.csi.aws.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:13:31.598409       1 node_linux.go:82] [Debug] Falling back to nvme volume ID lookup for: "/dev/xvdba"
I0901 00:13:31.598457       1 node_linux.go:95] [Debug] successfully resolved nvmeName="nvme-Amazon_Elastic_Block_Store_vol0bc4f2e94e89e01cc" to "/dev/nvme1n1"
I0901 00:13:31.598469       1 node.go:194] NodeStageVolume: find device path /dev/xvdba -> /dev/nvme1n1
I0901 00:13:31.598817       1 node.go:228] NodeStageVolume: formatting /dev/nvme1n1 and mounting at /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/globalmount with fstype ext4
I0901 00:13:31.626521       1 mount_linux.go:443] Disk "/dev/nvme1n1" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/nvme1n1]
I0901 00:13:31.981175       1 mount_linux.go:453] Disk successfully formatted (mkfs): ext4 - /dev/nvme1n1 /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/globalmount
I0901 00:13:32.032874       1 node.go:171] NodeStageVolume: volume="vol-0bc4f2e94e89e01cc" operation finished
I0901 00:13:32.032897       1 inflight.go:73] Node Service: volume="vol-0bc4f2e94e89e01cc" operation finished
I0901 00:13:32.038077       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:13:32.041927       1 node.go:373] NodePublishVolume: called with args {VolumeId:vol-0bc4f2e94e89e01cc PublishContext:map[devicePath:/dev/xvdba] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/globalmount TargetPath:/var/lib/kubelet/pods/16b06431-97a2-496d-a0a6-425cdf44b0e9/volumes/kubernetes.io~csi/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/mount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1661991051451-8081-ebs.csi.aws.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:13:32.041990       1 node_linux.go:151] NodePublishVolume: creating dir /var/lib/kubelet/pods/16b06431-97a2-496d-a0a6-425cdf44b0e9/volumes/kubernetes.io~csi/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/mount
I0901 00:13:32.042076       1 node.go:709] NodePublishVolume: mounting /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/globalmount at /var/lib/kubelet/pods/16b06431-97a2-496d-a0a6-425cdf44b0e9/volumes/kubernetes.io~csi/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/mount with option [bind] as fstype ext4
I0901 00:13:32.050986       1 node.go:402] NodePublishVolume: volume="vol-0bc4f2e94e89e01cc" operation finished
I0901 00:13:32.051013       1 inflight.go:73] Node Service: volume="vol-0bc4f2e94e89e01cc" operation finished
I0901 00:14:14.324013       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:14:14.325880       1 node.go:454] NodeGetVolumeStats: called with args {VolumeId:vol-0bc4f2e94e89e01cc VolumePath:/var/lib/kubelet/pods/16b06431-97a2-496d-a0a6-425cdf44b0e9/volumes/kubernetes.io~csi/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/mount StagingTargetPath: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:14:36.456053       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:14:36.457510       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:14:36.458984       1 node.go:304] NodeExpandVolume: called with args {VolumeId:vol-0bc4f2e94e89e01cc VolumePath:/var/lib/kubelet/pods/16b06431-97a2-496d-a0a6-425cdf44b0e9/volumes/kubernetes.io~csi/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/mount CapacityRange:required_bytes:8589934592  StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8fbc2661-7b24-4ee0-9e2a-458abd20fb6d/globalmount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0901 00:14:36.459680       1 node_linux.go:78] [Debug] The canonical device path for "/dev/nvme1n1" was resolved to: "/dev/nvme1n1"


//updated logging with --v=5

kubectl logs ebs-csi-node-l7h5q -n kube-system -c ebs-plugin
I0831 23:36:05.256149       1 driver.go:73] Driver: ebs.csi.aws.com Version: v1.11.2
I0831 23:36:05.256183       1 node.go:96] [Debug] Retrieving node info from metadata service
I0831 23:36:05.256192       1 node.go:98] regionFromSession Node service
I0831 23:36:05.256201       1 metadata.go:85] retrieving instance data from ec2 metadata
W0831 23:36:08.416398       1 metadata.go:88] ec2 metadata is not available
I0831 23:36:08.416411       1 metadata.go:96] retrieving instance data from kubernetes api
I0831 23:36:08.417334       1 metadata.go:101] kubernetes api is available
I0831 23:36:08.436894       1 mount_linux.go:207] Detected OS without systemd
I0831 23:36:08.437108       1 driver.go:143] Listening for connections on address: &net.UnixAddr{Name:"/csi/csi.sock", Net:"unix"}
I0831 23:36:09.490995       1 node.go:533] NodeGetInfo: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:44:46.164730       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:44:46.181531       1 node.go:119] NodeStageVolume: called with args {VolumeId:vol-04e07f8fead3c5190 PublishContext:map[devicePath:/dev/xvdba] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1661988980628-8081-ebs.csi.aws.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:44:46.181852       1 node_linux.go:82] [Debug] Falling back to nvme volume ID lookup for: "/dev/xvdba"
I0831 23:44:46.181900       1 node_linux.go:95] [Debug] successfully resolved nvmeName="nvme-Amazon_Elastic_Block_Store_vol04e07f8fead3c5190" to "/dev/nvme1n1"
I0831 23:44:46.182313       1 node.go:194] NodeStageVolume: find device path /dev/xvdba -> /dev/nvme1n1
I0831 23:44:46.183160       1 node.go:228] NodeStageVolume: formatting /dev/nvme1n1 and mounting at /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount with fstype ext4
I0831 23:44:46.183322       1 mount_linux.go:481] Attempting to determine if disk "/dev/nvme1n1" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/nvme1n1])
I0831 23:44:46.236983       1 mount_linux.go:484] Output: ""
I0831 23:44:46.237022       1 mount_linux.go:443] Disk "/dev/nvme1n1" appears to be unformatted, attempting to format as type: "ext4" with options: [-F -m0 /dev/nvme1n1]
I0831 23:44:46.809025       1 mount_linux.go:453] Disk successfully formatted (mkfs): ext4 - /dev/nvme1n1 /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount
I0831 23:44:46.809171       1 mount_linux.go:471] Attempting to mount disk /dev/nvme1n1 in ext4 format at /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount
I0831 23:44:46.809209       1 mount_linux.go:182] Mounting cmd (mount) with arguments (-t ext4 -o defaults /dev/nvme1n1 /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount)
I0831 23:44:46.856041       1 mount_linux.go:481] Attempting to determine if disk "/dev/nvme1n1" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/nvme1n1])
I0831 23:44:46.865671       1 mount_linux.go:484] Output: "DEVNAME=/dev/nvme1n1\nTYPE=ext4\n"
I0831 23:44:46.865696       1 resizefs_linux.go:123] ResizeFs.needResize - checking mounted volume /dev/nvme1n1
I0831 23:44:46.877216       1 resizefs_linux.go:127] Ext size: filesystem size=4294967296, block size=4096
I0831 23:44:46.877232       1 resizefs_linux.go:139] Volume /dev/nvme1n1: device size=4294967296, filesystem size=4294967296, block size=4096
I0831 23:44:46.877239       1 node.go:171] NodeStageVolume: volume="vol-04e07f8fead3c5190" operation finished
I0831 23:44:46.877247       1 inflight.go:74] Node Service: volume="vol-04e07f8fead3c5190" operation finished
I0831 23:44:46.885809       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:44:46.905320       1 node.go:373] NodePublishVolume: called with args {VolumeId:vol-04e07f8fead3c5190 PublishContext:map[devicePath:/dev/xvdba] StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount TargetPath:/var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Readonly:false Secrets:map[] VolumeContext:map[storage.kubernetes.io/csiProvisionerIdentity:1661988980628-8081-ebs.csi.aws.com] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:44:46.905402       1 node_linux.go:151] NodePublishVolume: creating dir /var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount
I0831 23:44:46.905493       1 node.go:709] NodePublishVolume: mounting /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount at /var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount with option [bind] as fstype ext4
I0831 23:44:46.905508       1 mount_linux.go:182] Mounting cmd (mount) with arguments (-t ext4 -o bind /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount /var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount)
I0831 23:44:46.907297       1 mount_linux.go:182] Mounting cmd (mount) with arguments (-t ext4 -o bind,remount /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount /var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount)
I0831 23:44:46.913215       1 node.go:402] NodePublishVolume: volume="vol-04e07f8fead3c5190" operation finished
I0831 23:44:46.913237       1 inflight.go:74] Node Service: volume="vol-04e07f8fead3c5190" operation finished
I0831 23:45:14.315672       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:45:14.318712       1 node.go:454] NodeGetVolumeStats: called with args {VolumeId:vol-04e07f8fead3c5190 VolumePath:/var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount StagingTargetPath: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:46:06.490722       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:46:06.491993       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:46:06.497168       1 node.go:304] NodeExpandVolume: called with args {VolumeId:vol-04e07f8fead3c5190 VolumePath:/var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount CapacityRange:required_bytes:8589934592  StagingTargetPath:/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/globalmount VolumeCapability:mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER >  Secrets:map[] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:46:06.497795       1 node_linux.go:78] [Debug] The canonical device path for "/dev/nvme1n1" was resolved to: "/dev/nvme1n1"
I0831 23:46:06.497817       1 mount_linux.go:481] Attempting to determine if disk "/dev/nvme1n1" is formatted using blkid with args: ([-p -s TYPE -s PTTYPE -o export /dev/nvme1n1])
I0831 23:46:06.500237       1 mount_linux.go:484] Output: "DEVNAME=/dev/nvme1n1\nTYPE=ext4\n"
I0831 23:46:06.500253       1 resizefs_linux.go:55] ResizeFS.Resize - Expanding mounted volume /dev/nvme1n1
I0831 23:46:06.763942       1 resizefs_linux.go:70] Device /dev/nvme1n1 resized successfully
I0831 23:46:28.141252       1 node.go:517] NodeGetCapabilities: called with args {XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0831 23:46:28.143110       1 node.go:454] NodeGetVolumeStats: called with args {VolumeId:vol-04e07f8fead3c5190 VolumePath:/var/lib/kubelet/pods/58964bc2-ac3b-4eeb-a215-d3a371d5c232/volumes/kubernetes.io~csi/pvc-d3efa2d8-4829-48d4-9dd4-5a032ac6226f/mount StagingTargetPath: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
```

_Signed-off-by: Eddie Torres <torredil@amazon.com>_
