### PR TITLE
Add support for tuning leader election to the helm chart for  csi-provisioner and csi-attacher

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -167,7 +167,18 @@ spec:
             {{- if .Values.controller.extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}
-            - --leader-election=true
+            - --leader-election={{ .Values.sidecars.provisioner.leaderElection.enabled | required "leader election state for csi-provisioner is required, must be set to true || false." }}
+            {{- if .Values.sidecars.provisioner.leaderElection.enabled }}
+            {{- if .Values.sidecars.provisioner.leaderElection.leaseDuration }}
+            - --leader-election-lease-duration={{ .Values.sidecars.provisioner.leaderElection.leaseDuration }}
+            {{- end }}
+            {{- if .Values.sidecars.provisioner.leaderElection.renewDeadline}}
+            - --leader-election-renew-deadline={{ .Values.sidecars.provisioner.leaderElection.renewDeadline }}
+            {{- end }}
+            {{- if .Values.sidecars.provisioner.leaderElection.retryPeriod }}
+            - --leader-election-retry-period={{ .Values.sidecars.provisioner.leaderElection.retryPeriod }}
+            {{- end }}
+            {{- end }}
             - --default-fstype={{ .Values.controller.defaultFsType }}
           env:
             - name: ADDRESS
@@ -199,7 +210,18 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.attacher.logLevel }}
-            - --leader-election=true
+            - --leader-election={{ .Values.sidecars.attacher.leaderElection.enabled | required "leader election state for csi-attacher is required, must be set to true || false." }}
+            {{- if .Values.sidecars.attacher.leaderElection.enabled }}
+            {{- if .Values.sidecars.attacher.leaderElection.leaseDuration }}
+            - --leader-election-lease-duration={{ .Values.sidecars.attacher.leaderElection.leaseDuration }}
+            {{- end }}
+            {{- if .Values.sidecars.attacher.leaderElection.renewDeadline}}
+            - --leader-election-renew-deadline={{ .Values.sidecars.attacher.leaderElection.renewDeadline }}
+            {{- end }}
+            {{- if .Values.sidecars.attacher.leaderElection.retryPeriod }}
+            - --leader-election-retry-period={{ .Values.sidecars.attacher.leaderElection.retryPeriod }}
+            {{- end }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -22,6 +22,16 @@ sidecars:
       tag: "v3.1.0"
     logLevel: 2
     resources: {}
+    # Tune leader lease election for csi-provisioner.
+    # Leader election is on by default.
+    leaderElection:
+      enabled: true
+      # Optional values to tune lease behavior.
+      # The arguments provided must be in an acceptable time.ParseDuration format.
+      # Ref: https://pkg.go.dev/flag#Duration
+      # leaseDuration: "15s"
+      # renewDeadline: "10s"
+      # retryPeriod: "5s"
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
@@ -31,6 +41,16 @@ sidecars:
       pullPolicy: IfNotPresent
       repository: k8s.gcr.io/sig-storage/csi-attacher
       tag: "v3.4.0"
+    # Tune leader lease election for csi-attacher.
+    # Leader election is on by default.
+    leaderElection:
+      enabled: true
+      # Optional values to tune lease behavior.
+      # The arguments provided must be in an acceptable time.ParseDuration format.
+      # Ref: https://pkg.go.dev/flag#Duration
+      # leaseDuration: "15s"
+      # renewDeadline: "10s"
+      # retryPeriod: "5s"
     logLevel: 2
     resources: {}
     securityContext:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Adding support to the helm chart for granular tuning of the leader election flags that the `csi-provisioner` and `csi-attacher` use.

Issue lodged: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1368

**What is this PR about? / Why do we need it?**

The flags exist for tuning the behaviour of lease lock logic in the csi-provisioner and csi-attacher code. We have been observing lease issues due to a control plane issue that our manged provider is investigating. Therefore we want to tune these flags but need support for them in the helm chart.

This PR aims to implement this so that anyone using this chart can tune the flags when needed.

**What testing is done?** 

I've tested the chart logic with our local deployment:

// Default only `leader-election:true` enabeld (no diff).
```
 $ helmfile diff --context 1                                                                                                                                                                                                                                                                                                                                                                                                
Adding repo aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
"aws-ebs-csi-driver" has been added to your repositories

Building dependency release=aws-ebs-csi-driver, chart=../../../../../personal/oss/aws-ebs-csi-driver/charts/aws-ebs-csi-driver
Comparing release=aws-ebs-csi-driver, chart=../../../../../personal/oss/aws-ebs-csi-driver/charts/aws-ebs-csi-driver
```

// Adding flags successfully

```
$ helmfile diff --context 1                                                                                                                                                                                                                                                                                                                                                                                                
Adding repo aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
"aws-ebs-csi-driver" has been added to your repositories

Building dependency release=aws-ebs-csi-driver, chart=../../../../../personal/oss/aws-ebs-csi-driver/charts/aws-ebs-csi-driver
Comparing release=aws-ebs-csi-driver, chart=../../../../../personal/oss/aws-ebs-csi-driver/charts/aws-ebs-csi-driver
kube-system, ebs-csi-controller, Deployment (apps) has changed:
...
              - --leader-election=true
+             - --leader-election-lease-duration=20s
+             - --leader-election-renew-deadline=15s
+             - --leader-election-retry-period=10s
              - --default-fstype=ext4
...
```

// Disabling leader election, only configures the `leader-election=false` flag and doesn't add any others.

```
$ helmfile diff --context 1      
Adding repo aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
"aws-ebs-csi-driver" has been added to your repositories

Building dependency release=aws-ebs-csi-driver, chart=../../../../../personal/oss/aws-ebs-csi-driver/charts/aws-ebs-csi-driver
Comparing release=aws-ebs-csi-driver, chart=../../../../../personal/oss/aws-ebs-csi-driver/charts/aws-ebs-csi-driver
kube-system, ebs-csi-controller, Deployment (apps) has changed:
...
              - --v=2
-             - --leader-election=true
+             - --leader-election=false
            env:
...
```

