### PR TITLE
Updating static example to include setting fsType

### DIFF
--- a/examples/kubernetes/static-provisioning/README.md
+++ b/examples/kubernetes/static-provisioning/README.md
@@ -1,4 +1,4 @@
-# Static Provisioning 
+# Static Provisioning
 
 ## Prerequisites
 
@@ -24,6 +24,7 @@ This example shows you how to create and consume a `PersistentVolume` from an ex
         storage: 5Gi
       csi:
         driver: ebs.csi.aws.com
+        fsType: ext4
         volumeHandle: {EBS volume ID}
       nodeAffinity:
         required:

--- a/examples/kubernetes/static-provisioning/manifests/pv.yaml
+++ b/examples/kubernetes/static-provisioning/manifests/pv.yaml
@@ -9,6 +9,7 @@ spec:
     storage: 5Gi
   csi:
     driver: ebs.csi.aws.com
+    fsType: ext4
     volumeHandle: vol-03c604538dd7d2f41
   nodeAffinity:
     required:


### PR DESCRIPTION
This is a very minor update to address a documentation issue that was raised as part of issue #1365 

Setting spec.csi.fsType is required when defining the PV if the end user plans on using spec.securityContext.fsGroup in their deployment to set correct permissions on their EBS volume mount.