### PR TITLE
Add initContainer parameter to the controller's template

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -62,6 +62,10 @@ spec:
       securityContext:  
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.controller.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ebs-plugin
           image: {{ printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -184,6 +184,14 @@ controller:
   containerSecurityContext:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
+  initContainers: []
+  # containers to be run before the controller's container starts.
+  #
+  # Example:
+  #
+  # - name: wait
+  #   image: busybox
+  #   command: [ 'sh', '-c', "sleep 20" ]
 
 node:
   env: []


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

- adding new feature

**What is this PR about? / Why do we need it?**

- Make the chart able to accept custom initContainers for the controller

see: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1378

**What testing is done?** 

Manually tested by helm template: 

`helm template .` with `initContainers: []`

```
# Source: aws-ebs-csi-driver/templates/controller.yaml
# Controller Service
kind: Deployment
apiVersion: apps/v1
  ...
      containers:
        - name: ebs-plugin
          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.11.2
          imagePullPolicy: IfNotPresent
          args:
            - controller
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=2
  ...
```

`helm template .` with

```
- name: wait
  image: busybox
  command: [ 'sh', '-c', "sleep 20" ]
```

```
---
# Source: aws-ebs-csi-driver/templates/controller.yaml
# Controller Service
kind: Deployment
apiVersion: apps/v1
    spec:
      nodeSelector:
        kubernetes.io/os: linux
      serviceAccountName: ebs-csi-controller-sa
      initContainers:
        - command:
          - sh
          - -c
          - sleep 20
          image: busybox
          name: wait
      containers:
        - name: ebs-plugin
          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.11.2
          imagePullPolicy: IfNotPresent
          args:
            - controller
            - --endpoint=$(CSI_ENDPOINT)
            - --logtostderr
            - --v=2
            ...
---
```
