### PR TITLE
Allow all taint for toleration csi-node by default

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -40,8 +40,6 @@ spec:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        - key: CriticalAddonsOnly
-          operator: Exists
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -40,8 +40,6 @@ spec:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        - key: CriticalAddonsOnly
-          operator: Exists
         - operator: Exists
           effect: NoExecute
           tolerationSeconds: 300

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -203,7 +203,7 @@ node:
   nodeSelector: {}
   podAnnotations: {}
   podLabels: {}
-  tolerateAllTaints: false
+  tolerateAllTaints: true
   tolerations: []
   resources: {}
   serviceAccount:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -36,11 +36,7 @@ spec:
       serviceAccountName: ebs-csi-node-sa
       priorityClassName: system-node-critical
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
         - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
       securityContext:
         fsGroup: 0
         runAsGroup: 0

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,8 +36,8 @@ kubectl create secret generic aws-secret \
     --from-literal "access_key=${AWS_SECRET_ACCESS_KEY}"
 ```
 
-#### Config node toleration settings
-By default, driver tolerates taint `CriticalAddonsOnly` and has `tolerationSeconds` configured as `300`, to deploy the driver on all nodes, please set Helm `Value.node.tolerateAllTaints` to true before deployment
+#### Configure driver toleration settings
+By default, the driver controller tolerates taint `CriticalAddonsOnly` and has `tolerationSeconds` configured as `300`; and the driver node tolerates all taints. If you don't want to deploy the driver node on all nodes, please set Helm `Value.node.tolerateAllTaints` to false before deployment. Add policies to `Value.node.tolerations` to configure customized toleration for nodes.
 
 #### Deploy driver
 Please see the compatibility matrix before you deploy the driver


### PR DESCRIPTION
Signed-off-by: Gengtao Xu <gengtaox@amazon.com>

**What is this PR about? / Why do we need it?**
This PR removed the previous policy of csi-node taint toleration and make allowing all taint by default. For csi-node, unless customized configuration, we should allow all nodes taint for PV availability.

