### PR TITLE
helm: Move default toleration to values.yaml so it can be overriden

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -40,12 +40,9 @@ spec:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
-        {{- end }}
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
       containers:
         - name: ebs-plugin

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -40,12 +40,9 @@ spec:
         {{- if .Values.node.tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
-        {{- end }}
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
       {{- with .Values.node.securityContext }}
       securityContext:  

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -229,7 +229,10 @@ node:
   podAnnotations: {}
   podLabels: {}
   tolerateAllTaints: true
-  tolerations: []
+  tolerations:
+  - operator: Exists
+    effect: NoExecute
+    tolerationSeconds: 300
   resources: {}
   serviceAccount:
     create: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix. Users can not override or remove the default toleration for taints in the current helm chart.

**What is this PR about? / Why do we need it?**
Moves the default toleration for `NoExecute` for 300s to the values.yaml, which is where default values should be defined. This allows users to provide their own complete set of tolerations which can override the default toleration.

**What testing is done?** 
Helm template verification.
