### PR TITLE
Cleanup OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,16 @@
 approvers:
-- bertinatto
-- jsafrane
-- gnufied
-- leakingtapan
-- wongma7
 - AndyXiangLi
-- gtxu
-- torredil
-- rdpsin
+- bertinatto
 - ConnorJC3
+- gnufied
+- gtxu
+- jsafrane
+- leakingtapan
+- rdpsin
+- torredil
+- wongma7
 reviewers:
-- bertinatto
-- jsafrane
-- gnufied
-- leakingtapan
-- wongma7
-- AndyXiangLi
-- gtxu
-- torredil
-- rdpsin
 - ConnorJC3
+- gtxu
+- rdpsin
+- torredil


### PR DESCRIPTION
Changes `reviewers` in `OWNERS` to only full-time maintainers so they are the only ones the bot auto-assigns for PR reviews (`approvers` list left as-is). Also re-sorted reviewers and approvers list to be in alphabetical order.