### PR TITLE
Add serviceMonitor.labels parameter

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ebs-csi-controller
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: ebs-csi-controller
 spec:
@@ -16,22 +16,24 @@ spec:
       targetPort: 3301
   type: ClusterIP
 ---
-{{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+{{- if or .Values.controller.serviceMonitor.forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: ebs-csi-controller
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     app: ebs-csi-controller
-    release: prometheus
+    {{- if .Values.controller.serviceMonitor.labels }}
+    {{- toYaml .Values.controller.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       app: ebs-csi-controller
   namespaceSelector:
     matchNames:
-      - kube-system
+      - {{ .Release.Namespace }}
   endpoints:
     - targetPort: 3301
       path: /metrics

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -140,6 +140,12 @@ controller:
   # The default is empty string, which means metrics endpoint is disabled.
   # ---
   enableMetrics: false
+  serviceMonitor:
+    # Enables the ServiceMonitor resource even if the prometheus-operator CRDs are not installed
+    forceEnable: false
+    # Additional labels for ServiceMonitor object
+    labels:
+      release: prometheus
   # If set to true, AWS API call metrics will be exported to the following 
   # TCP endpoint: "0.0.0.0:3301"
   # ---


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

- Allow modifying `labels` for the `ServiceMonitor` object. 
- Parameterize the hardcoded namespace in `metrics.yaml`.
- Address https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1380#discussion_r988904466
- closes  #1420

**What testing is done?** 
- Rendered Helm chart.

Signed-off-by: Eddie Torres <torredil@amazon.com>