### PR TITLE
Add version information from tag to GCR build

### DIFF
--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -41,4 +41,5 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 loudecho "Push manifest list containing amazon linux and windows based images to GCR"
 export REGISTRY=$REGISTRY_NAME
 export TAG=$GIT_TAG
+export VERSION=$GIT_TAG
 IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make all-push


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Grabs the version information from the tag for GCR, as we no longer do a pre-release commit

**What is this PR about? / Why do we need it?**

Fixes #1423 

**What testing is done?** 

Manual build