### PR TITLE
refactor: Move the default controller tolerations in the helm chart values

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -41,11 +41,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - operator: Exists
-          effect: NoExecute
-          tolerationSeconds: 300
         {{- with .Values.controller.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -186,7 +186,12 @@ controller:
     create: true # A service account will be created for you if set to true. Set to false if you want to use your own.
     name: ebs-csi-controller-sa # Name of the service-account to be used/created.
     annotations: {}
-  tolerations: []
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - effect: NoExecute
+      operator: Exists
+      tolerationSeconds: 300
   # TSCs without the label selector stanza
   #
   # Example:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -36,8 +36,8 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - operator: Exists
-          effect: NoExecute
+        - effect: NoExecute
+          operator: Exists
           tolerationSeconds: 300
       securityContext:
         fsGroup: 1000


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Give more flexibility to the helm chart users for the csi-controller tolerations.
The default values remains unchanged and the default behavior is also unchanged.
However, one with different needs regarding those tolerations can modify them at will.