### PR TITLE
[BUG] pkg/driver/controller.go uses ToLower

### DIFF
--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -70,7 +70,7 @@ const (
 	PVNameKey = "csi.storage.k8s.io/pv/name"
 
 	// BlockExpressKey increases the iops limit for io2 volumes to the block express limit
-	BlockExpressKey = "blockExpress"
+	BlockExpressKey = "blockexpress"
 
 	// TagKeyPrefix contains the prefix of a volume parameter that designates it as
 	// a tag to be attached to the resource


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
BUG

**What is this PR about? / Why do we need it?**
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/pkg/driver/controller.go#L139 All the parameters transformed to lower key, thus they should be compared to strings in lower key

