### PR TITLE
Increase cloudbuild timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 3600s
+timeout: 5400s
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94
     entrypoint: ./hack/prow.sh


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

- The additional windows build `windows-ltsc2022` is causing our cloudbuild to timeout. This PR increases the amount of time that the build is allowed to run by 1800 seconds (30 minutes) to account for the additional image.

Signed-off-by: Eddie Torres <torredil@amazon.com>
