### PR TITLE
Upgrade golangci-lint; Fix linter errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ bin/mockgen: | bin
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.21.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.50.1
 
 .PHONY: kubeval
 kubeval: bin/kubeval

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/aws/aws-sdk-go v1.44.122
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/kubernetes-csi/csi-proxy/client v1.1.2
 	github.com/kubernetes-csi/csi-test v2.2.0+incompatible
@@ -14,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/sys v0.1.0
 	google.golang.org/grpc v1.50.1
+	google.golang.org/protobuf v1.28.1
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v1.22.11
@@ -43,6 +43,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
@@ -91,7 +92,6 @@ require (
 	golang.org/x/tools v0.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221025140454-527a21cfbd71 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1582,8 +1582,9 @@ func TestListSnapshots(t *testing.T) {
 
 				mockEC2.EXPECT().DescribeSnapshotsWithContext(gomock.Eq(ctx), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{}, nil)
 
-				if _, err := c.ListSnapshots(ctx, "", 0, ""); err != nil {
-					if err != ErrNotFound {
+				_, err := c.ListSnapshots(ctx, "", 0, "")
+				if err != nil {
+					if !errors.Is(err, ErrNotFound) {
 						t.Fatalf("Expected error %v, got %v", ErrNotFound, err)
 					}
 				} else {

--- a/pkg/cloud/metadata_k8s.go
+++ b/pkg/cloud/metadata_k8s.go
@@ -37,7 +37,7 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface) (*Metadata, error
 	// get node with k8s API
 	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting Node %v: %v", nodeName, err)
+		return nil, fmt.Errorf("error getting Node %v: %w", nodeName, err)
 	}
 
 	providerID := node.Spec.ProviderID

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -49,7 +49,7 @@ func TestNewControllerService(t *testing.T) {
 		testErr    = errors.New("test error")
 		testRegion = "test-region"
 
-		getNewCloudFunc = func(expectedRegion string, awsSdkDebugLog bool) func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
+		getNewCloudFunc = func(expectedRegion string, _ bool) func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
 			return func(region string, awsSdkDebugLog bool) (cloud.Cloud, error) {
 				if region != expectedRegion {
 					t.Fatalf("expected region %q but got %q", expectedRegion, region)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -81,7 +81,7 @@ func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
 	}
 
 	if err := ValidateDriverOptions(&driverOptions); err != nil {
-		return nil, fmt.Errorf("Invalid driver options: %v", err)
+		return nil, fmt.Errorf("Invalid driver options: %w", err)
 	}
 
 	driver := Driver{

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -24,8 +24,6 @@ import (
 	mountutils "k8s.io/mount-utils"
 )
 
-type mountInterface = mountutils.Interface
-
 // Mounter is the interface implemented by NodeMounter.
 // A mix & match of functions defined in upstream libraries. (FormatAndMount
 // from struct SafeFormatAndMount, PathExists from an old edition of

--- a/pkg/driver/mount_linux.go
+++ b/pkg/driver/mount_linux.go
@@ -75,23 +75,10 @@ func (m *NodeMounter) NeedResize(devicePath string, deviceMountPath string) (boo
 	return mountutils.NewResizeFs(m.Exec).NeedResize(devicePath, deviceMountPath)
 }
 
-func (m *NodeMounter) getDeviceSize(devicePath string) (uint64, error) {
-	output, err := m.SafeFormatAndMount.Exec.Command("blockdev", "--getsize64", devicePath).CombinedOutput()
-	outStr := strings.TrimSpace(string(output))
-	if err != nil {
-		return 0, fmt.Errorf("failed to read size of device %s: %s: %s", devicePath, err, outStr)
-	}
-	size, err := strconv.ParseUint(outStr, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse size of device %s %s: %s", devicePath, outStr, err)
-	}
-	return size, nil
-}
-
 func (m *NodeMounter) getExtSize(devicePath string) (uint64, uint64, error) {
 	output, err := m.SafeFormatAndMount.Exec.Command("dumpe2fs", "-h", devicePath).CombinedOutput()
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to read size of filesystem on %s: %s: %s", devicePath, err, string(output))
+		return 0, 0, fmt.Errorf("failed to read size of filesystem on %s: %w: %s", devicePath, err, string(output))
 	}
 
 	blockSize, blockCount, _ := m.parseFsInfoOutput(string(output), ":", "block size", "block count")
@@ -108,7 +95,7 @@ func (m *NodeMounter) getExtSize(devicePath string) (uint64, uint64, error) {
 func (m *NodeMounter) getXFSSize(devicePath string) (uint64, uint64, error) {
 	output, err := m.SafeFormatAndMount.Exec.Command("xfs_io", "-c", "statfs", devicePath).CombinedOutput()
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to read size of filesystem on %s: %s: %s", devicePath, err, string(output))
+		return 0, 0, fmt.Errorf("failed to read size of filesystem on %s: %w: %s", devicePath, err, string(output))
 	}
 
 	blockSize, blockCount, _ := m.parseFsInfoOutput(string(output), "=", "geom.bsize", "geom.datablocks")
@@ -136,13 +123,13 @@ func (m *NodeMounter) parseFsInfoOutput(cmdOutput string, spliter string, blockS
 		if key == blockSizeKey {
 			blockSize, err = strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return 0, 0, fmt.Errorf("failed to parse block size %s: %s", value, err)
+				return 0, 0, fmt.Errorf("failed to parse block size %s: %w", value, err)
 			}
 		}
 		if key == blockCountKey {
 			blockCount, err = strconv.ParseUint(value, 10, 64)
 			if err != nil {
-				return 0, 0, fmt.Errorf("failed to parse block count %s: %s", value, err)
+				return 0, 0, fmt.Errorf("failed to parse block count %s: %w", value, err)
 			}
 		}
 	}

--- a/pkg/driver/mount_test.go
+++ b/pkg/driver/mount_test.go
@@ -20,11 +20,11 @@ limitations under the License.
 package driver
 
 import (
-	"io/ioutil"
-	"k8s.io/mount-utils"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/mount-utils"
 
 	utilexec "k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
@@ -316,7 +316,7 @@ func TestNeedResize(t *testing.T) {
 
 func TestMakeDir(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-ebs-csi")
+	dir, err := os.MkdirTemp("", "mount-ebs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
@@ -344,7 +344,7 @@ func TestMakeDir(t *testing.T) {
 
 func TestMakeFile(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-ebs-csi")
+	dir, err := os.MkdirTemp("", "mount-ebs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
@@ -373,7 +373,7 @@ func TestMakeFile(t *testing.T) {
 
 func TestPathExists(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-ebs-csi")
+	dir, err := os.MkdirTemp("", "mount-ebs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
@@ -400,7 +400,7 @@ func TestPathExists(t *testing.T) {
 
 func TestGetDeviceName(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "mount-ebs-csi")
+	dir, err := os.MkdirTemp("", "mount-ebs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -6,7 +6,6 @@ package driver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -24,7 +23,7 @@ import (
 
 func TestSanity(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := ioutil.TempDir("", "sanity-ebs-csi")
+	dir, err := os.MkdirTemp("", "sanity-ebs-csi")
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}

--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -27,11 +27,11 @@ import (
 
 func ValidateDriverOptions(options *DriverOptions) error {
 	if err := validateExtraTags(options.extraTags, false); err != nil {
-		return fmt.Errorf("Invalid extra tags: %v", err)
+		return fmt.Errorf("Invalid extra tags: %w", err)
 	}
 
 	if err := validateMode(options.mode); err != nil {
-		return fmt.Errorf("Invalid mode: %v", err)
+		return fmt.Errorf("Invalid mode: %w", err)
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func validateExtraTags(tags map[string]string, warnOnly bool) error {
 		err := validate(k, v)
 		if err != nil {
 			if warnOnly {
-				klog.Warningf("Skipping tag: the following key-value pair is not valid: (%s, %s): (%v)", k, v, err)
+				klog.Warningf("Skipping tag: the following key-value pair is not valid: (%s, %s): (%w)", k, v, err)
 			} else {
 				return err
 			}

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -169,7 +169,7 @@ func TestValidateDriverOptions(t *testing.T) {
 		{
 			name:   "fail because validateMode fails",
 			mode:   Mode("unknown"),
-			expErr: fmt.Errorf("Invalid mode: Mode is not supported (actual: unknown, supported: %v)", []Mode{AllMode, ControllerMode, NodeMode}),
+			expErr: fmt.Errorf("Invalid mode: %w", fmt.Errorf("Mode is not supported (actual: unknown, supported: %v)", []Mode{AllMode, ControllerMode, NodeMode})),
 		},
 		{
 			name: "fail because validateExtraVolumeTags fails",
@@ -177,7 +177,7 @@ func TestValidateDriverOptions(t *testing.T) {
 			extraVolumeTags: map[string]string{
 				randomString(cloud.MaxTagKeyLength + 1): "extra-tag-value",
 			},
-			expErr: fmt.Errorf("Invalid extra tags: Tag key too long (actual: %d, limit: %d)", cloud.MaxTagKeyLength+1, cloud.MaxTagKeyLength),
+			expErr: fmt.Errorf("Invalid extra tags: %w", fmt.Errorf("Tag key too long (actual: %d, limit: %d)", cloud.MaxTagKeyLength+1, cloud.MaxTagKeyLength)),
 		},
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -55,7 +55,7 @@ func GiBToBytes(volumeSizeGiB int64) int64 {
 func ParseEndpoint(endpoint string) (string, string, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", "", fmt.Errorf("could not parse endpoint: %v", err)
+		return "", "", fmt.Errorf("could not parse endpoint: %w", err)
 	}
 
 	addr := filepath.Join(u.Host, filepath.FromSlash(u.Path))
@@ -66,7 +66,7 @@ func ParseEndpoint(endpoint string) (string, string, error) {
 	case "unix":
 		addr = filepath.Join("/", addr)
 		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) {
-			return "", "", fmt.Errorf("could not remove unix domain socket %q: %v", addr, err)
+			return "", "", fmt.Errorf("could not remove unix domain socket %q: %w", addr, err)
 		}
 	default:
 		return "", "", fmt.Errorf("unsupported protocol: %s", scheme)

--- a/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
@@ -46,7 +46,7 @@ func (t *DynamicallyProvisionedResizeVolumeTest) Run(client clientset.Interface,
 	defer tpvc.Cleanup()
 
 	pvcName := tpvc.persistentVolumeClaim.Name
-	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})
+	pvc, _ := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	By(fmt.Sprintf("Get pvc name: %v", pvc.Name))
 	originalSize := pvc.Spec.Resources.Requests["storage"]
 	delta := resource.Quantity{}

--- a/tests/e2e/testsuites/pre_provisioned_snapshot_volume_tester.go
+++ b/tests/e2e/testsuites/pre_provisioned_snapshot_volume_tester.go
@@ -24,8 +24,6 @@ import (
 	k8srestclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 
-	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
-
 	. "github.com/onsi/ginkgo/v2"
 )
 
@@ -33,10 +31,6 @@ type PreProvisionedVolumeSnapshotTest struct {
 	CSIDriver driver.PVTestDriver
 	Pod       PodDetails
 }
-
-var (
-	tCloud awscloud.Cloud
-)
 
 func (t *PreProvisionedVolumeSnapshotTest) Run(client clientset.Interface, restclient k8srestclient.Interface, namespace *v1.Namespace, snapshotId string) {
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -16,8 +16,8 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -158,10 +158,10 @@ func testAttachWriteReadDetach(volumeID, volName, nodeID string, readOnly bool) 
 		// Write a file
 		testFileContents := []byte("sample content")
 		testFile := filepath.Join(publishDir, "testfile")
-		err := ioutil.WriteFile(testFile, testFileContents, 0644)
+		err := os.WriteFile(testFile, testFileContents, 0644)
 		Expect(err).To(BeNil(), "Failed to write file")
 		// Read the file and check if content is correct
-		data, err := ioutil.ReadFile(testFile)
+		data, err := os.ReadFile(testFile)
 		Expect(err).To(BeNil(), "Failed to read file")
 		Expect(data).To(Equal(testFileContents), "File content is incorrect")
 	}
@@ -181,7 +181,8 @@ func waitForVolume(volumeID string, nVolumes int) {
 		volumes, err := describeVolumes(params)
 		if err != nil {
 			if nVolumes == 0 {
-				if awsErr, ok := err.(awserr.Error); ok {
+				var awsErr awserr.Error
+				if errors.As(err, &awsErr) {
 					if awsErr.Code() == "InvalidVolume.NotFound" {
 						return true, nil
 					}

--- a/tests/integration/setup_test.go
+++ b/tests/integration/setup_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -84,7 +85,7 @@ type CSIClient struct {
 
 func newCSIClient() (*CSIClient, error) {
 	opts := []grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 		grpc.WithContextDialer(
 			func(context.Context, string) (net.Conn, error) {


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- Upgrade `golangci-lint`: `v1.21.0` ->  `v1.50.1`
- Fix linter errors.

**What testing is done?** 
- `make verify`
- `make test`
- `CI`

Signed-off-by: Eddie Torres <torredil@amazon.com>
