### PR TITLE
helm: Expose volumes and volumeMounts for the ebs-csi-controller deployment

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -54,7 +54,7 @@ spec:
         {{- $constraints | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.securityContext }}
-      securityContext:  
+      securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.initContainers }}
@@ -131,6 +131,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- with .Values.controller.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: healthz
               containerPort: 9808
@@ -161,7 +164,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.controller.containerSecurityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-provisioner
@@ -208,7 +211,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.provisioner.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: csi-attacher
@@ -250,7 +253,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.attacher.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- if or .Values.sidecars.snapshotter.forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
@@ -281,7 +284,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.snapshotter.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
@@ -313,7 +316,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.resizer.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: liveness-probe
@@ -333,7 +336,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.sidecars.livenessProbe.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- if .Values.imagePullSecrets }}
@@ -345,3 +348,6 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
+        {{- with .Values.controller.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -138,7 +138,7 @@ controller:
   extraVolumeTags: {}
   httpEndpoint:
   # (deprecated) The TCP network address where the prometheus metrics endpoint
-  # will run (example: `:8080` which corresponds to port 8080 on local host). 
+  # will run (example: `:8080` which corresponds to port 8080 on local host).
   # The default is empty string, which means metrics endpoint is disabled.
   # ---
   enableMetrics: false
@@ -148,7 +148,7 @@ controller:
     # Additional labels for ServiceMonitor object
     labels:
       release: prometheus
-  # If set to true, AWS API call metrics will be exported to the following 
+  # If set to true, AWS API call metrics will be exported to the following
   # TCP endpoint: "0.0.0.0:3301"
   # ---
   # ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).
@@ -210,6 +210,8 @@ controller:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
+  volumes: []
+  volumeMounts: []
   # securityContext on the controller container (see sidecars for securityContext on sidecar containers)
   containerSecurityContext:
     readOnlyRootFilesystem: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature. 

**What is this PR about? / Why do we need it?**
Allows users who wish to integrate the controller with IRSA authentication manually (i.e not using the https://github.com/aws/amazon-eks-pod-identity-webhook) to configure the controller with the correct mounts for authentication. For example:
```
    volumes:
    - name: aws-token
      projected:
        sources:
        - serviceAccountToken:
            audience: "sts.amazonaws.com"
            expirationSeconds: 86400
            path: token
    volumeMounts:
    - mountPath: "/var/run/secrets/eks.amazonaws.com/serviceaccount/"
      name: aws-token
  ```

**What testing is done?** 
 Helm template verification.