### PR TITLE
Grab version via tag directly from git

### DIFF
--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -41,5 +41,5 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 loudecho "Push manifest list containing amazon linux and windows based images to GCR"
 export REGISTRY=$REGISTRY_NAME
 export TAG=$GIT_TAG
-export VERSION=$PULL_BASE_REF
+export VERSION=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)
 IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make all-push


### PR DESCRIPTION
Signed-off-by: Connor Catlett <conncatl@amazon.com>

**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

`PULL_BASE_REF` is unreliable, switching to grabbing the version directly from git via `git describe`

**What testing is done?** 

CI/Manual
