### PR TITLE
Add test-helm-chart target to Makefile to test Helm chart upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,14 @@ test-e2e-external-eks:
 	GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
 	./hack/e2e/run.sh
 
+.PHONY: test-helm-chart
+test-helm-chart:
+	AWS_REGION=us-west-2 \
+	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
+	EBS_INSTALL_SNAPSHOT="true" \
+	HELM_CT_TEST="true" \
+	./hack/e2e/run.sh
+
 .PHONY: verify-vendor
 test: verify-vendor
 verify: verify-vendor

--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm-sa
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-role
+rules:
+  - apiGroups: [ "" ]
+    resources:
+      - events
+      - nodes
+      - pods
+      - replicationcontrollers
+      - serviceaccounts
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs: [ "list" ]
+  - apiGroups: [ "" ]
+    resources:
+      - services
+      - nodes
+      - nodes/proxy
+      - persistentvolumes
+      - persistentvolumeclaims
+      - pods
+      - pods/log
+    verbs: [ "get" ]
+  - apiGroups: [ "" ]
+    resources:
+      - namespaces
+      - persistentvolumes
+      - persistentvolumeclaims
+      - pods
+      - pods/exec
+    verbs: [ "create" ]
+  - apiGroups: [ "" ]
+    resources:
+      - namespaces
+      - persistentvolumes
+      - persistentvolumeclaims
+      - pods
+    verbs: [ "delete" ]
+  - apiGroups: [ "" ]
+    resources:
+      - persistentvolumeclaims
+    verbs: [ "update" ]
+  - apiGroups: [ "" ]
+    resources:
+      - pods/ephemeralcontainers
+    verbs: [ "patch" ]
+  - apiGroups: [ "" ]
+    resources:
+      - serviceaccounts
+      - configmaps
+    verbs: [ "watch" ]
+  - apiGroups: [ "apps" ]
+    resources:
+      - replicasets
+      - daemonsets
+    verbs: [ "list" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources:
+      - storageclasses
+    verbs: [ "create" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources:
+      - storageclasses
+      - csinodes
+    verbs: [ "get" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources:
+      - storageclasses
+    verbs: [ "delete" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources:
+      - volumesnapshots
+      - volumesnapshotclasses
+      - volumesnapshotcontents
+    verbs: [ "create" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources:
+      - volumesnapshots
+      - volumesnapshotclasses
+      - volumesnapshotcontents
+    verbs: [ "get" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources:
+      - volumesnapshotcontents
+    verbs: [ "update" ]
+  - apiGroups: [ "snapshot.storage.k8s.io" ]
+    resources:
+      - volumesnapshots
+      - volumesnapshotclasses
+      - volumesnapshotcontents
+    verbs: [ "delete" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - clusterroles
+    verbs: [ "list" ]
+  - apiGroups: [ "authorization.k8s.io" ]
+    resources:
+      - subjectaccessreviews
+    verbs: [ "create" ]
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources:
+      - clusterroles
+    verbs: [ "list" ]
+  - apiGroups: [ "rbac.authorization.k8s.io" ]
+    resources:
+      - clusterrolebindings
+    verbs: [ "create" ]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: helm-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: test-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  manifests.yaml: |
+    ShortName: ebs
+    StorageClass:
+      FromFile: storageclass.yaml
+    SnapshotClass:
+      FromName: true
+    DriverInfo:
+      Name: ebs.csi.aws.com
+      SupportedSizeRange:
+        Min: 1Gi
+        Max: 16Ti
+      SupportedFsType:
+        xfs: {}
+        ext4: {}
+      SupportedMountOption:
+        dirsync: {}
+      TopologyKeys: ["topology.ebs.csi.aws.com/zone"]
+      Capabilities:
+        persistence: true
+        fsGroup: true
+        block: true
+        exec: true
+        snapshotDataSource: true
+        pvcDataSource: false
+        multipods: true
+        controllerExpansion: true
+        nodeExpansion: true
+        volumeLimits: true
+        topology: true
+  storageclass.yaml: |
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      name: ebs.csi.aws.com
+    provisioner: ebs.csi.aws.com
+    volumeBindingMode: WaitForFirstConsumer
+metadata:
+  name: manifest-config
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: helm-test
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: helm-test
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-master
+      command: [ "/bin/sh", "-c" ]
+      args:
+        - |
+          cp /etc/config/storageclass.yaml /workspace/storageclass.yaml
+          go install sigs.k8s.io/kubetest2/...@latest
+          kubectl config set-cluster cluster --server=https://kubernetes.default --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl config set-context kubetest2 --cluster=cluster
+          kubectl config set-credentials sa --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          kubectl config set-context kubetest2 --user=sa
+          kubectl config use-context kubetest2
+          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex='External.Storage' --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
+      volumeMounts:
+      - name: config-vol
+        mountPath: /etc/config
+  serviceAccountName: helm-sa
+  volumes:
+    - name: config-vol
+      configMap:
+        name: manifest-config
+  restartPolicy: Never

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -183,8 +183,9 @@ controller:
   #   cpu: 100m
   #   memory: 128Mi
   serviceAccount:
-    create: true # A service account will be created for you if set to true. Set to false if you want to use your own.
-    name: ebs-csi-controller-sa # Name of the service-account to be used/created.
+  # A service account will be created for you if set to true. Set to false if you want to use your own.
+    create: true
+    name: ebs-csi-controller-sa
     annotations: {}
   tolerations:
     - key: CriticalAddonsOnly

--- a/hack/e2e/chart-testing.sh
+++ b/hack/e2e/chart-testing.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -uo pipefail
+
+function ct_install() {
+  INSTALL_PATH=${1}
+  CHART_TESTING_VERSION=${2}
+  if [[ ! -e ${INSTALL_PATH}/chart-testing ]]; then
+    CHART_TESTING_DOWNLOAD_URL="https://github.com/helm/chart-testing/releases/download/v${CHART_TESTING_VERSION}/chart-testing_${CHART_TESTING_VERSION}_linux_amd64.tar.gz"
+    curl --silent --location "${CHART_TESTING_DOWNLOAD_URL}" | tar xz -C "${INSTALL_PATH}"
+    chmod +x "${INSTALL_PATH}"/ct
+  fi
+
+  python3 -m pip install yamllint yamale
+}

--- a/tests/ct-config.yaml
+++ b/tests/ct-config.yaml
@@ -1,0 +1,18 @@
+remote: origin
+since: HEAD~1
+github-instance: https://github.com
+lint-conf: tests/ct-lintconfig.yaml
+validate-chart-schema: false
+validate-yaml: false
+check-version-increment: false
+charts:
+  - charts/aws-ebs-csi-driver
+helm-extra-args: "--timeout 3000s"
+upgrade: true
+skip-missing-values: true
+namespace: kube-system
+release-label: release
+kubectl-timeout: 3000s
+skip-clean-up: false
+print-logs: true
+debug: false


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- Add test-helm-chart target to Makefile to test Helm chart upgrades
- Prevent this class of issue: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1390

**What testing is done?** 
- Manual
- CI

1. Pull changes locally.
2. Run `CLUSTER_TYPE=kops KOPS_STATE_FILE="s3://devcluster-state-e2e" make test-helm-chart`

Signed-off-by: Eddie Torres <torredil@amazon.com>