### PR TITLE
Update install.md & options.md docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -152,7 +152,5 @@ To make sure dynamically provisioned EBS volumes have all tags that the in-tree 
 * Run the external-provisioner sidecar with `--extra-create-metadata=true` cmdline option. The Helm chart sets this option true by default.
 * Run the CSI driver with `--k8s-tag-cluster-id=<ID of the Kubernetes cluster>` command line option.
 
-To make sure that the CSI driver has permission to Attach, Detach, and Delete volumes that were dynamically provisioned and tagged by the in-tree plugin prior to migration being turned on, the IAM policy has to grant permission to operate on volumes with tag `kubernetes.io/cluster/<ID of the Kubernetes cluster>": "owned"` like in [the example policy](./example-iam-policy.json#L85).
-
 **Warning**:
 * kubelet *must* be drained of all pods with mounted EBS volumes ***before*** changing its CSI migration feature flags.  Failure to do this will cause deleted pods to get stuck in `Terminating`, requiring a forced delete which can cause filesystem corruption. See [#679](../../../issues/679) for more details.

--- a/docs/options.md
+++ b/docs/options.md
@@ -3,7 +3,7 @@ There are a couple of driver options that can be passed as arguments when starti
 
 | Option argument             | value sample                                      | default                                             | Description         |
 |-----------------------------|---------------------------------------------------|-----------------------------------------------------|---------------------|
-| endpoint                    | tcp://127.0.0.1:10000/                            | unix:///var/lib/csi/sockets/pluginproxy/csi.sock    | Added to all volumes to check if a given volume has already been created and ensure ControllerPublish/CreateVolume is idempotent|
+| endpoint                    | tcp://127.0.0.1:10000/                            | unix:///var/lib/csi/sockets/pluginproxy/csi.sock    | The socket on which the driver will listen for CSI RPCs|
 | volume-attach-limit         | 1,2,3 ...                                         | -1                                                  | Value for the maximum number of volumes attachable per node. If specified, the limit applies to all nodes. If not specified, the value is approximated from the instance type|
 | extra-tags                  | key1=value1,key2=value2                           |                                                     | Tags attached to each dynamically provisioned resource|
 | k8s-tag-cluster-id          | aws-cluster-id-1                                  |                                                     | ID of the Kubernetes cluster used for tagging provisioned EBS volumes|


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- Update `docs/install.md` - The policy was updated in #1450 which introduced a new condition for managing volumes created by the in-tree driver. The removed section is no longer relevant. See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1450#issuecomment-1349539639
- Update `docs/options.md` - Sneaking this change in here as well, the current description for the endpoint driver option is not accurate.

Signed-off-by: Eddie Torres <torredil@amazon.com>