### PR TITLE
Default to EKS-D sidecars

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -4,8 +4,8 @@
 
 image:
   # Container registry to be used, will prefix all repositories (including sidecars)
-  containerRegistry: ""
-  repository: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
+  containerRegistry: "public.ecr.aws"
+  repository: /ebs-csi-driver/aws-ebs-csi-driver
   # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
   tag: ""
   pullPolicy: IfNotPresent
@@ -20,8 +20,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: "v3.1.0"
+      repository: /eks-distro/kubernetes-csi/external-provisioner
+      tag: "v3.3.0-eks-1-25-1"
     logLevel: 2
     resources: {}
     # Tune leader lease election for csi-provisioner.
@@ -41,8 +41,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-attacher
-      tag: "v3.4.0"
+      repository: /eks-distro/kubernetes-csi/external-attacher
+      tag: "v4.0.0-eks-1-25-1"
     # Tune leader lease election for csi-attacher.
     # Leader election is on by default.
     leaderElection:
@@ -64,8 +64,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-snapshotter
-      tag: "v6.0.1"
+      repository: /eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
+      tag: "v6.1.0-eks-1-25-1"
     logLevel: 2
     resources: {}
     securityContext:
@@ -74,8 +74,8 @@ sidecars:
   livenessProbe:
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/livenessprobe
-      tag: "v2.6.0"
+      repository: /eks-distro/kubernetes-csi/livenessprobe
+      tag: "v2.8.0-eks-1-25-1"
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -84,8 +84,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-resizer
-      tag: "v1.4.0"
+      repository: /eks-distro/kubernetes-csi/external-resizer
+      tag: "v1.6.0-eks-1-25-1"
     logLevel: 2
     resources: {}
     securityContext:
@@ -95,8 +95,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-      tag: "v2.5.1"
+      repository: /eks-distro/kubernetes-csi/node-driver-registrar
+      tag: "v2.6.2-eks-1-25-1"
     logLevel: 2
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -61,7 +61,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+          image: public.ecr.awsk8s.gcr.io/provider-aws/aws-ebs-csi-driver
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode
@@ -128,7 +128,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -155,7 +155,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -179,7 +179,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -202,7 +202,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -226,7 +226,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -44,7 +44,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+          image: public.ecr.awsk8s.gcr.io/provider-aws/aws-ebs-csi-driver
           imagePullPolicy: IfNotPresent
           args:
             - node
@@ -90,7 +90,7 @@ spec:
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -118,7 +118,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

- This PR updates the sidecar images. Additionally, it sets the `containerRegistry` parameter to pull sidecar container images from `public.ecr.aws`.
- closes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1456

Signed-off-by: Eddie Torres <torredil@amazon.com>

**What testing is done?** 
- External Storage tests.
- Manual validation.
