### PR TITLE
Change default sidecars to EKS-D

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,9 @@ generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-provisioner.yaml > ../../deploy/kubernetes/base/clusterrolebinding-provisioner.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-resizer.yaml > ../../deploy/kubernetes/base/clusterrolebinding-resizer.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/clusterrolebinding-snapshotter.yaml > ../../deploy/kubernetes/base/clusterrolebinding-snapshotter.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/controller.yaml --set "image.repository=k8s.gcr.io/provider-aws/aws-ebs-csi-driver" --api-versions 'snapshot.storage.k8s.io/v1' | sed -e "/namespace: /d" | sed -e "s/:v.*$$//g" > ../../deploy/kubernetes/base/controller.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/controller.yaml --api-versions 'snapshot.storage.k8s.io/v1' | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/csidriver.yaml > ../../deploy/kubernetes/base/csidriver.yaml
-	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/node.yaml --set "image.repository=k8s.gcr.io/provider-aws/aws-ebs-csi-driver" | sed -e "/namespace: /d" | sed -e "s/:v.*$$//g" > ../../deploy/kubernetes/base/node.yaml
+	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/node.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/node.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/poddisruptionbudget-controller.yaml --api-versions 'policy/v1/PodDisruptionBudget' | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/poddisruptionbudget-controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-controller.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-controller.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 
 image:
-  # Container registry to be used, will prefix all repositories (including sidecars)
-  containerRegistry: ""
   repository: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
   # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
   tag: ""
@@ -20,8 +18,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-provisioner
-      tag: "v3.1.0"
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+      tag: "v3.3.0-eks-1-25-latest"
     logLevel: 2
     resources: {}
     # Tune leader lease election for csi-provisioner.
@@ -41,8 +39,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-attacher
-      tag: "v3.4.0"
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+      tag: "v4.0.0-eks-1-25-latest"
     # Tune leader lease election for csi-attacher.
     # Leader election is on by default.
     leaderElection:
@@ -64,8 +62,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-snapshotter
-      tag: "v6.0.1"
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
+      tag: "v6.1.0-eks-1-25-latest"
     logLevel: 2
     resources: {}
     securityContext:
@@ -74,8 +72,8 @@ sidecars:
   livenessProbe:
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/livenessprobe
-      tag: "v2.6.0"
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+      tag: "v2.8.0-eks-1-25-latest"
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -84,8 +82,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-resizer
-      tag: "v1.4.0"
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
+      tag: "v1.6.0-eks-1-25-latest"
     logLevel: 2
     resources: {}
     securityContext:
@@ -95,8 +93,8 @@ sidecars:
     env: []
     image:
       pullPolicy: IfNotPresent
-      repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-      tag: "v2.5.1"
+      repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+      tag: "v2.6.2-eks-1-25-latest"
     logLevel: 2
     resources: {}
     securityContext:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -61,7 +61,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.14.1
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode
@@ -128,7 +128,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.3.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -155,7 +155,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.0.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -179,7 +179,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v6.1.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -202,7 +202,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.6.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -226,7 +226,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -44,7 +44,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.14.1
           imagePullPolicy: IfNotPresent
           args:
             - node
@@ -90,7 +90,7 @@ spec:
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.6.2-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -118,7 +118,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.8.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,25 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../ecr
-images:
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-    newName: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newTag: v3.1.0-eks-1-20-15
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    newTag: v3.4.0-eks-1-20-15
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newTag: v2.6.0-eks-1-20-15
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newTag: v6.0.1-eks-1-20-17
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newTag: v1.4.0-eks-1-20-15
-  - name: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar
-    newName: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newTag: v2.5.1-eks-1-20-17
+  - ../../../base

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,19 +1,19 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../gcr
+  - ../ecr-public
 images:
-  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  - name: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-provisioner
-  - name: k8s.gcr.io/sig-storage/csi-attacher
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-attacher
-  - name: k8s.gcr.io/sig-storage/livenessprobe
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/livenessprobe
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-snapshotter
-  - name: k8s.gcr.io/sig-storage/csi-resizer
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-resizer
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
     newName: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/csi-node-driver-registrar

--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -1,19 +1,25 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-  - ../../../base
+  - ../ecr-public
 images:
-  - name: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
-    newTag: v1.14.1
-  - name: k8s.gcr.io/sig-storage/csi-attacher
-    newTag: v3.4.0
-  - name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    newTag: v2.5.1
-  - name: k8s.gcr.io/sig-storage/csi-provisioner
-    newTag: v3.1.0
-  - name: k8s.gcr.io/sig-storage/csi-resizer
-    newTag: v1.4.0
-  - name: k8s.gcr.io/sig-storage/csi-snapshotter
-    newTag: v6.0.1
-  - name: k8s.gcr.io/sig-storage/livenessprobe
-    newTag: v2.6.0
+  - name: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
+    newName: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
+    newName: k8s.gcr.io/sig-storage/csi-provisioner
+    newTag: v3.3.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
+    newName: k8s.gcr.io/sig-storage/csi-attacher
+    newTag: v4.0.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
+    newName: k8s.gcr.io/sig-storage/livenessprobe
+    newTag: v2.8.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
+    newName: k8s.gcr.io/sig-storage/csi-snapshotter
+    newTag: v6.1.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
+    newName: k8s.gcr.io/sig-storage/csi-resizer
+    newTag: v1.6.0
+  - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
+    newName: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newTag: v2.6.2


### PR DESCRIPTION
Signed-off-by: Connor Catlett <conncatl@amazon.com>

Fixes #1456 and also bumps the sidecar versions. New ECR (private) sidecars need promotion on AWS side (these will be the same images as the Public ECR deployment). All other deployment methods tested and working.