### PR TITLE
Prevent WaitForAttachmentState from being piled up

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -606,6 +606,8 @@ func (c *cloud) WaitForAttachmentState(ctx context.Context, volumeID, expectedSt
 					klog.Warningf("Waiting for volume %q to be attached but the volume does not exist", volumeID)
 					return false, err
 				}
+			} else if errors.Is(err, context.Canceled) {
+				return true, nil
 			}
 
 			klog.Warningf("Ignoring error from describe volume for volume %q; will retry: %q", volumeID, err)


### PR DESCRIPTION
Close #1482

**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
We should cancel `WaitForAttachmentState` to prevent it from being piled up. It is not related to operation completion, so this PR won't affect [the behavior](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/3ce83e588de90bb4eac34af17122b0f0e56aa2fa/docs/design.md?plain=1#L47).
