### PR TITLE
Remove compatibility matrix reference

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -44,7 +44,6 @@ kubectl create secret generic aws-secret \
 By default, the driver controller tolerates taint `CriticalAddonsOnly` and has `tolerationSeconds` configured as `300`; and the driver node tolerates all taints. If you don't want to deploy the driver node on all nodes, please set Helm `Value.node.tolerateAllTaints` to false before deployment. Add policies to `Value.node.tolerations` to configure customized toleration for nodes.
 
 #### Deploy driver
-Please see the compatibility matrix before you deploy the driver
 
 To deploy the CSI driver:
 ```sh


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- The compatibility matrix was removed in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1465. This PR removes a leftover reference to this matrix.

Signed-off-by: Eddie Torres <torredil@amazon.com>


