### PR TITLE
feature: remove depricated kubernetes api

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,7 +1,7 @@
 {{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{- else }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
The PodDisruptionBudget api "policy/v1" is deprecated since v1.21 and will be removed with v1.25.
This API is available since v1.21
