### PR TITLE
Use test driver image when testing upgrades with CT

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -122,12 +122,12 @@ else
     GOPATH=${TEST_DIR} GOBIN=${BIN_DIR} go install sigs.k8s.io/kubetest2/...@latest
     popd
   fi
-
-  ecr_build_and_push "${REGION}" \
-    "${AWS_ACCOUNT_ID}" \
-    "${IMAGE_NAME}" \
-    "${IMAGE_TAG}"
 fi
+
+ecr_build_and_push "${REGION}" \
+  "${AWS_ACCOUNT_ID}" \
+  "${IMAGE_NAME}" \
+  "${IMAGE_TAG}"
 
 if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   kops_create_cluster \
@@ -183,6 +183,7 @@ if [[ "${HELM_CT_TEST}" == true ]]; then
     export CT_REMOTE="ct"
     export CT_TARGET_BRANCH="${PULL_BASE_REF}"
   fi
+  yq -i ".image.repository = \"$IMAGE_NAME\" | .image.tag = \"$IMAGE_TAG\"" ${PWD}/charts/aws-ebs-csi-driver/values.yaml
   set -x
   set +e
   export KUBECONFIG="${KUBECONFIG}"
@@ -190,6 +191,7 @@ if [[ "${HELM_CT_TEST}" == true ]]; then
   TEST_PASSED=$?
   set -e
   set +x
+  git checkout -- ${PWD}/charts/aws-ebs-csi-driver/values.yaml
 else
   loudecho "Deploying driver"
   startSec=$(date +'%s')


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

- When performing upgrade tests, `ct` needs to use the test driver image created by `ecr_build_and_push` to correctly test changes made to the Helm chart and container image in the same PR.

**What testing is done?** 
- CI
- https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1467

Signed-off-by: Eddie Torres <torredil@amazon.com>