### PR TITLE
Minor CI Fixes

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Configure Git

--- a/.github/workflows/publish-ecr.yaml
+++ b/.github/workflows/publish-ecr.yaml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -52,7 +52,7 @@ jobs:
       uses: imjasonh/setup-crane@v0.1
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           echo "::set-output name=go-build::$(go env GOCACHE)"
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
@@ -25,7 +25,7 @@ jobs:
           go-version: 1.19
 
       - name: Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.go-cache-paths.outputs.go-build }}
           key: ${{ runner.os }}-cache-${{ hashFiles('**/go.sum') }}

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ image: .image-$(TAG)-$(OS)-$(ARCH)-$(OSVERSION)
 		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
 		--build-arg=GOPROXY=$(GOPROXY) \
 		--build-arg=VERSION=$(VERSION) \
+		`./hack/provenance` \
 		.
 	touch $@
 

--- a/hack/provenance
+++ b/hack/provenance
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# There is no reliable way to check if a buildx installation supports
+# --provenance other than trying to execute it. You cannot even rely
+# on the version, because buildx's own installation docs will result
+# in installations of buildx that do not correctly report their version
+# via `docker buildx version`.
+#
+# Thus, this script echos back the flag `--provenance=false` if and only
+# if the local buildx installation supports it. If not, it exits silently.
+
+BUILDX_TEST=`docker buildx build --provenance=false 2>&1`
+if [[ "${BUILDX_TEST}" == *"See 'docker buildx build --help'."* ]]; then
+  if [[ "${BUILDX_TEST}" == *"requires exactly 1 argument"* ]]; then
+    echo "--provenance=false"
+  fi
+else
+  echo "Local buildx installation broken?" >&2
+  exit 1
+fi


### PR DESCRIPTION
- Fixes #1489  by building with `--provenance=false`
- Bumps Github Actions versions to non-deprecated versions