### PR TITLE
Helm allowed topologies

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.15.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.16.0
+version: 2.16.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -15,5 +15,5 @@ allowedTopologies:
 {{- toYaml .allowedTopologies | nindent 0 }}
 {{- end }}
 provisioner: ebs.csi.aws.com
-{{ omit (dict "volumeBindingMode" "WaitForFirstConsumer" | merge .) "name" "annotations" "labels" | toYaml }}
+{{ omit (dict "volumeBindingMode" "WaitForFirstConsumer" | merge .) "name" "annotations" "labels" "allowedTopologies" | toYaml }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -10,6 +10,10 @@ metadata:
   {{- with .labels }}
   labels: {{- . | toYaml | trim | nindent 4 }}
   {{- end }}
+{{- if .allowedTopologies }}
+allowedTopologies:
+{{- toYaml .allowedTopologies | nindent 0 }}
+{{- end }}
 provisioner: ebs.csi.aws.com
 {{ omit (dict "volumeBindingMode" "WaitForFirstConsumer" | merge .) "name" "annotations" "labels" | toYaml }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/storageclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/storageclass.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 {{- if .allowedTopologies }}
 allowedTopologies:
-{{- toYaml .allowedTopologies | nindent 0 }}
+{{- toYaml .allowedTopologies | nindent 2 }}
 {{- end }}
 provisioner: ebs.csi.aws.com
 {{ omit (dict "volumeBindingMode" "WaitForFirstConsumer" | merge .) "name" "annotations" "labels" "allowedTopologies" | toYaml }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -302,6 +302,11 @@ storageClasses: []
 #   volumeBindingMode: WaitForFirstConsumer
 #   # defaults to Delete
 #   reclaimPolicy: Retain
+#   allowedTopologies:
+#   - matchLabelExpressions:
+#     - key: topology.ebs.csi.aws.com/zone
+#       values:
+#       - us-east-2a
 #   parameters:
 #     encrypted: "true"
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This is a small fix for Helm chart.

**What is this PR about? / Why do we need it?**

This PR is just a small addition to the Helm chart. The `storageClass` template was missing the `allowedTopologies` field. `allowedTopologies` is a feature relevant for EBS storage classes because it allows choice of a specific availability zone (AZ) when provisioning `PersistentVolumes` (PV). Selecting a specific AZ can prevent edge cases where a PV was once provisioned in some AZ and is later supposed to be reused by some other EC2 instance which cannot provisioned to same AZ (certain EC2 instance types are not available in all AZs).

**What testing is done?** 

Deployed to an EKS v1.23.14 cluster for testing. I ran `make generate-kustomize` but kustomize manifests are not affected because per default, Helm chart does not render any `storageClass` manifests.