### PR TITLE
Fix CI; Upgrade golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ bin/mockgen: | bin
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.50.1
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.51.1
 
 .PHONY: kubeval
 kubeval: bin/kubeval

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -252,7 +252,7 @@ func newEC2Cloud(region string, awsSdkDebugLog bool) (Cloud, error) {
 	endpoint := os.Getenv("AWS_EC2_ENDPOINT")
 	if endpoint != "" {
 		customResolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
-			if service == endpoints.Ec2ServiceID {
+			if service == ec2.EndpointsID {
 				return endpoints.ResolvedEndpoint{
 					URL:           endpoint,
 					SigningRegion: region,

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -33,7 +33,7 @@ import (
 const kubeconfigEnvVar = "KUBECONFIG"
 
 func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	testing.Init()
 	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
 	// it does not fall back to defaults


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

- Fix CI, see: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1503#issuecomment-1422822965
- [endpoints.Ec2ServiceID](https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/) is deprecated: Use client package's [EndpointsID](https://github.com/aws/aws-sdk-go/blob/1c759fb5b09ba21a4a82883f8a2a1a411c814ad4/service/ec2/service.go#L33) value instead of `ServiceIDs`.
- `rand.Seed` is deprecated; use `rand.New(NewSource(seed))`. Per https://go.dev/doc/go1.20, "_Programs that need a reproducible sequence of random numbers should prefer to allocate their own random source, using `rand.New(rand.NewSource(seed))`._ "

**What testing is done?** 

```
$ docker run -it --rm --entrypoint /bin/bash gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
$ export GOPROXY=direct
$ git clone https://github.com/torredil/aws-ebs-csi-driver.git && cd aws-ebs-csi-driver && git checkout fix-ci
$ make verify

No issue found
echo "verifying and linting files ..."
verifying and linting files ...
./hack/verify-all
Verifying gofmt
No issue found
Verifying govet
Done
WARN [linters_context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
Repo uses 'go mod'.
+ env GO111MODULE=on go mod tidy
Go dependencies up-to-date.
echo "Congratulations! All Go source files have been linted."
Congratulations! All Go source files have been linted.
```


Signed-off-by: Eddie Torres <torredil@amazon.com>