### PR TITLE
Fix --version output

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -111,11 +111,13 @@ func GetOptions(fs *flag.FlagSet) *Options {
 	}
 
 	if *version {
-		info, err := driver.GetVersionJSON()
+		versionInfo, err := driver.GetVersionJSON()
 		if err != nil {
-			klog.ErrorS(err, "failed to get version", "version", info)
+			klog.ErrorS(err, "failed to get version")
 			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
+		fmt.Println(versionInfo)
+		osExit(0)
 	}
 
 	if *toStderr {

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -163,8 +163,10 @@ func TestGetOptions(t *testing.T) {
 				defer func() { osExit = oldOSExit }()
 
 				var exitCode int
+				calledExit := false
 				testExit := func(code int) {
 					exitCode = code
+					calledExit = true
 				}
 				osExit = testExit
 
@@ -180,6 +182,9 @@ func TestGetOptions(t *testing.T) {
 
 				if exitCode != 0 {
 					t.Fatalf("expected exit code 0 but got %d", exitCode)
+				}
+				if !calledExit {
+					t.Fatalf("expect osExit to be called, but wasn't")
 				}
 			},
 		},


### PR DESCRIPTION
Fix version handling code to output version info, which was inadvertantly removed in ad25982

Signed-off-by: Connor Catlett <conncatl@amazon.com>
