### PR TITLE
The conditional API version is not necessary since the driver is requ…

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,8 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: ebs-csi-controller


### PR DESCRIPTION
…ired starting from 1.23 which already has the policy/v1

**Is this a bug fix or adding new feature?**
Syntax fix
**What is this PR about? / Why do we need it?**
The conditional API version is not necessary since the driver is required starting from 1.23 which already has the policy/v1
**What testing is done?** 
N/A
