### PR TITLE
Stop treating prefixes as magic in DeviceManager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION?=v1.15.0
+VERSION?=v1.16.1
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -721,7 +721,7 @@ func TestAttachDisk(t *testing.T) {
 
 			vol := &ec2.Volume{
 				VolumeId:    aws.String(tc.volumeID),
-				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdba"), InstanceId: aws.String("node-1234"), State: aws.String("attached")}},
+				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("node-1234"), State: aws.String("attached")}},
 			}
 
 			ctx := context.Background()
@@ -1614,7 +1614,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      false,
 		},
@@ -1623,7 +1623,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeDetachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      false,
 		},
@@ -1632,7 +1632,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeDetachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      false,
 		},
@@ -1641,7 +1641,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      true,
 		},
@@ -1650,7 +1650,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdbb",
+			expectedDevice:   "/dev/xvdab",
 			alreadyAssigned:  false,
 			expectError:      true,
 		},
@@ -1659,7 +1659,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1235",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      true,
 		},
@@ -1668,7 +1668,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  true,
 			expectError:      true,
 		},
@@ -1677,7 +1677,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      false,
 		},
@@ -1686,7 +1686,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 			volumeID:         "vol-test-1234",
 			expectedState:    volumeAttachedState,
 			expectedInstance: "1234",
-			expectedDevice:   "/dev/xvdba",
+			expectedDevice:   "/dev/xvdaa",
 			alreadyAssigned:  false,
 			expectError:      true,
 		},
@@ -1702,22 +1702,22 @@ func TestWaitForAttachmentState(t *testing.T) {
 
 			attachedVol := &ec2.Volume{
 				VolumeId:    aws.String(tc.volumeID),
-				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdba"), InstanceId: aws.String("1234"), State: aws.String("attached")}},
+				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1234"), State: aws.String("attached")}},
 			}
 
 			attachingVol := &ec2.Volume{
 				VolumeId:    aws.String(tc.volumeID),
-				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdba"), InstanceId: aws.String("1234"), State: aws.String("attaching")}},
+				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1234"), State: aws.String("attaching")}},
 			}
 
 			detachedVol := &ec2.Volume{
 				VolumeId:    aws.String(tc.volumeID),
-				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdba"), InstanceId: aws.String("1234"), State: aws.String("detached")}},
+				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1234"), State: aws.String("detached")}},
 			}
 
 			multipleAttachmentsVol := &ec2.Volume{
 				VolumeId:    aws.String(tc.volumeID),
-				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdba"), InstanceId: aws.String("1235"), State: aws.String("attached")}, {Device: aws.String("/dev/xvdba"), InstanceId: aws.String("1234"), State: aws.String("attached")}},
+				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1235"), State: aws.String("attached")}, {Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1234"), State: aws.String("attached")}},
 			}
 
 			ctx := context.Background()

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -27,12 +27,18 @@ func TestNameAllocator(t *testing.T) {
 	tests := []struct {
 		expectedName string
 	}{
+		{"aa"}, {"ab"}, {"ac"}, {"ad"}, {"ae"}, {"af"}, {"ag"}, {"ah"}, {"ai"}, {"aj"},
+		{"ak"}, {"al"}, {"am"}, {"an"}, {"ao"}, {"ap"}, {"aq"}, {"ar"}, {"as"}, {"at"},
+		{"au"}, {"av"}, {"aw"}, {"ax"}, {"ay"}, {"az"},
 		{"ba"}, {"bb"}, {"bc"}, {"bd"}, {"be"}, {"bf"}, {"bg"}, {"bh"}, {"bi"}, {"bj"},
 		{"bk"}, {"bl"}, {"bm"}, {"bn"}, {"bo"}, {"bp"}, {"bq"}, {"br"}, {"bs"}, {"bt"},
 		{"bu"}, {"bv"}, {"bw"}, {"bx"}, {"by"}, {"bz"},
 		{"ca"}, {"cb"}, {"cc"}, {"cd"}, {"ce"}, {"cf"}, {"cg"}, {"ch"}, {"ci"}, {"cj"},
 		{"ck"}, {"cl"}, {"cm"}, {"cn"}, {"co"}, {"cp"}, {"cq"}, {"cr"}, {"cs"}, {"ct"},
 		{"cu"}, {"cv"}, {"cw"}, {"cx"}, {"cy"}, {"cz"},
+		{"da"}, {"db"}, {"dc"}, {"dd"}, {"de"}, {"df"}, {"dg"}, {"dh"}, {"di"}, {"dj"},
+		{"dk"}, {"dl"}, {"dm"}, {"dn"}, {"do"}, {"dp"}, {"dq"}, {"dr"}, {"ds"}, {"dt"},
+		{"du"}, {"dv"}, {"dw"}, {"dx"},
 	}
 
 	for _, test := range tests {
@@ -53,10 +59,8 @@ func TestNameAllocatorError(t *testing.T) {
 	allocator := nameAllocator{}
 	existingNames := map[string]string{}
 
-	// Allocator goes from ba, bb, bc, ..., bz, ca, ..., cz, ..., ..., zz
-	// Thus 25*26 for the maximum number of allocatable volumes (25 for the
-	// first letter as it starts on 'b'
-	for i := 0; i < 25*26; i++ {
+	// 102 == number of allocations from aa ... dx (see allocator.go for why we stop at dx)
+	for i := 0; i < 102; i++ {
 		name, _ := allocator.GetNext(existingNames, "/dev/xvd")
 		existingNames[name] = ""
 	}

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -37,7 +37,7 @@ func TestNameAllocator(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expectedName, func(t *testing.T) {
-			actual, err := allocator.GetNext(existingNames)
+			actual, err := allocator.GetNext(existingNames, "")
 			if err != nil {
 				t.Errorf("test %q: unexpected error: %v", test.expectedName, err)
 			}
@@ -53,11 +53,14 @@ func TestNameAllocatorError(t *testing.T) {
 	allocator := nameAllocator{}
 	existingNames := map[string]string{}
 
-	for i := 0; i < 52; i++ {
-		name, _ := allocator.GetNext(existingNames)
+	// Allocator goes from ba, bb, bc, ..., bz, ca, ..., cz, ..., ..., zz
+	// Thus 25*26 for the maximum number of allocatable volumes (25 for the
+	// first letter as it starts on 'b'
+	for i := 0; i < 25*26; i++ {
+		name, _ := allocator.GetNext(existingNames, "/dev/xvd")
 		existingNames[name] = ""
 	}
-	name, err := allocator.GetNext(existingNames)
+	name, err := allocator.GetNext(existingNames, "/dev/xvd")
 	if err == nil {
 		t.Errorf("expected error, got device  %q", name)
 	}

--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -103,16 +103,16 @@ func TestNewDeviceWithExistingDevice(t *testing.T) {
 		{
 			name:         "success: different volumes",
 			existingID:   "vol-1",
-			existingPath: "/dev/xvdba",
+			existingPath: "/dev/xvdaa",
 			volumeID:     "vol-2",
-			expectedPath: "/dev/xvdbb",
+			expectedPath: "/dev/xvdab",
 		},
 		{
 			name:         "success: same volumes",
 			existingID:   "vol-1",
-			existingPath: "/dev/xvdba",
+			existingPath: "/dev/xvdcc",
 			volumeID:     "vol-1",
-			expectedPath: "/dev/xvdba",
+			expectedPath: "/dev/xvdcc",
 		},
 		{
 			name:         "success: same volumes with /dev/sdX path",

--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -92,6 +92,60 @@ func TestNewDevice(t *testing.T) {
 	}
 }
 
+func TestNewDeviceWithExistingDevice(t *testing.T) {
+	testCases := []struct {
+		name         string
+		existingID   string
+		existingPath string
+		volumeID     string
+		expectedPath string
+	}{
+		{
+			name:         "success: different volumes",
+			existingID:   "vol-1",
+			existingPath: "/dev/xvdba",
+			volumeID:     "vol-2",
+			expectedPath: "/dev/xvdbb",
+		},
+		{
+			name:         "success: same volumes",
+			existingID:   "vol-1",
+			existingPath: "/dev/xvdba",
+			volumeID:     "vol-1",
+			expectedPath: "/dev/xvdba",
+		},
+		{
+			name:         "success: same volumes with /dev/sdX path",
+			existingID:   "vol-3",
+			existingPath: "/dev/sdf",
+			volumeID:     "vol-3",
+			expectedPath: "/dev/sdf",
+		},
+		{
+			name:         "success: same volumes with weird path",
+			existingID:   "vol-42",
+			existingPath: "/weird/path",
+			volumeID:     "vol-42",
+			expectedPath: "/weird/path",
+		},
+	}
+	// Use a shared DeviceManager to make sure that there are no race conditions
+	dm := NewDeviceManager()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeInstance := newFakeInstance("fake-instance", tc.existingID, tc.existingPath)
+
+			dev, err := dm.NewDevice(fakeInstance, tc.volumeID)
+			assertDevice(t, dev, tc.existingID == tc.volumeID, err)
+
+			if dev.Path != tc.expectedPath {
+				t.Fatalf("Expected path %v got %v", tc.expectedPath, dev.Path)
+			}
+		})
+	}
+}
+
 func TestGetDevice(t *testing.T) {
 	testCases := []struct {
 		name               string


### PR DESCRIPTION
DM treats the prefixes "/dev/xvd" and "/dev/sd" as magic. This leads to a bug where volumes with a prefix starting with "/dev/sd" (for example, "/dev/sdf") will get incorrectly mangled into a "/dev/xvd" form (i.e. converting "/dev/sdf" to "/dev/xvdf"). This will cause a volume that is already mounted and prefixed with "/dev/sd" (for example, a volume manually mounted via the AWS console) to get stuck in an infinite loop as the node will believe it is mounted at the wrong path.

With this change, instead of storing only the end of the path in the inflight and existing volumes map, we instead store the entire device path. The previously leaky abstraction from the allocator to store only the end of the path is contained to the allocator, which has a new parameter for the desired prefix.

This commit also vastly increases the range of paths the allocator can generate from 52 simultaneously mounted volumes to 650.

Signed-off-by: Connor Catlett <conncatl@amazon.com>