### PR TITLE
Add warning to README about k8s.gcr.io deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **Warning**
+> 
+> [`k8s.gcr.io` will be frozen on April 3rd](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/), and may stop working in the near future. We strongly encourage any users still using `k8s.gcr.io` to [move to `registry.k8s.io`](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) as soon as possible. `k8s.gcr.io` will not be supported in any capacity by the EBS CSI Driver after release `v1.17.0`.
+
 # Amazon Elastic Block Store (EBS) CSI driver
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kubernetes-sigs/aws-ebs-csi-driver)](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases)
 [![Coverage Status](https://coveralls.io/repos/github/kubernetes-sigs/aws-ebs-csi-driver/badge.svg?branch=master)](https://coveralls.io/github/kubernetes-sigs/aws-ebs-csi-driver?branch=master)


### PR DESCRIPTION
sig-infra is now considering [drastic changes](https://kubernetes.slack.com/archives/CCK68P2Q2/p1677709804935919) such as deleting existing high-cost images on `k8s.gcr.io` (like ours). This PR adds a warning about the issue to the most visible place possible, the top of the README.