### PR TITLE
[BACKPORT] k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -4,22 +4,22 @@ bases:
   - ../ecr-public
 images:
   - name: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver
-    newName: k8s.gcr.io/provider-aws/aws-ebs-csi-driver
+    newName: registry.k8s.io/provider-aws/aws-ebs-csi-driver
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-    newName: k8s.gcr.io/sig-storage/csi-provisioner
+    newName: registry.k8s.io/sig-storage/csi-provisioner
     newTag: v3.3.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-    newName: k8s.gcr.io/sig-storage/csi-attacher
+    newName: registry.k8s.io/sig-storage/csi-attacher
     newTag: v4.0.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-    newName: k8s.gcr.io/sig-storage/livenessprobe
+    newName: registry.k8s.io/sig-storage/livenessprobe
     newTag: v2.8.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-    newName: k8s.gcr.io/sig-storage/csi-snapshotter
+    newName: registry.k8s.io/sig-storage/csi-snapshotter
     newTag: v6.1.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-    newName: k8s.gcr.io/sig-storage/csi-resizer
+    newName: registry.k8s.io/sig-storage/csi-resizer
     newTag: v1.6.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-    newName: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    newName: registry.k8s.io/sig-storage/csi-node-driver-registrar
     newTag: v2.6.2


### PR DESCRIPTION
Backport of #1488 to (currently) supported 1.15 branch