### PR TITLE
Add target to run External Storage tests on Windows nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,22 @@ test-e2e-external-eks:
 	GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
 	./hack/e2e/run.sh
 
+.PHONY: test-e2e-external-eks-windows
+test-e2e-external-eks-windows:
+	CLUSTER_TYPE=eksctl \
+	WINDOWS=true \
+	HELM_VALUES_FILE="./hack/values_eksctl.yaml" \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
+	EKSCTL_ADMIN_ROLE="Infra-prod-KopsDeleteAllLambdaServiceRoleF1578477-1ELDFIB4KCMXV" \
+	AWS_REGION=us-west-2 \
+	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b \
+	TEST_PATH=./tests/e2e-kubernetes/... \
+	GINKGO_FOCUS="External.Storage" \
+	GINKGO_SKIP="\[Disruptive\]|\[Serial\]|\[LinuxOnly\]|\[Feature:VolumeSnapshotDataSource\]|\(xfs\)|\(ext4\)|\(block volmode\)" \
+	GINKGO_PARALLEL=15 \
+	NODE_OS_DISTRO="windows" \
+	./hack/e2e/run.sh
+
 .PHONY: test-helm-chart
 test-helm-chart:
 	AWS_REGION=us-west-2 \

--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -18,8 +18,18 @@ function ecr_build_and_push() {
     set -e
     loudecho "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
     aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}".dkr.ecr."${REGION}".amazonaws.com
-    IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=amazon make image
-    docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-amazon "${IMAGE_NAME}":"${IMAGE_TAG}"
-    docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
+    if [[ "$WINDOWS" == true ]]; then
+      export DOCKER_CLI_EXPERIMENTAL=enabled
+      export TAG=${IMAGE_TAG}
+      export IMAGE=${IMAGE_NAME}
+      trap "docker buildx rm multiarch-builder" EXIT
+      docker buildx create --use --name multiarch-builder
+      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      make all-push
+    else
+      IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=amazon make image
+      docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-amazon "${IMAGE_NAME}":"${IMAGE_TAG}"
+      docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
+    fi
   fi
 }

--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -23,6 +23,7 @@ function eksctl_create_cluster() {
   EKSCTL_PATCH_FILE=${8}
   EKSCTL_ADMIN_ROLE=${9}
   WINDOWS=${10}
+  VPC_CONFIGMAP_FILE=${11}
 
   CLUSTER_NAME="${CLUSTER_NAME//./-}"
 
@@ -63,15 +64,15 @@ function eksctl_create_cluster() {
 
   if [[ "$WINDOWS" == true ]]; then
     ${BIN} create nodegroup \
-      --managed=false \
+      --managed=true \
+      --ssh-access=false \
       --cluster="${CLUSTER_NAME}" \
-      --node-ami-family=WindowsServer2019FullContainer \
+      --node-ami-family=WindowsServer2022FullContainer \
       -n ng-windows \
-      -m 1 \
-      -M 1 \
-      --ssh-access \
-      --ssh-public-key "${SSH_KEY_PATH}".pub
-    ${BIN} utils install-vpc-controllers --cluster="${CLUSTER_NAME}" --approve
+      -m 3 \
+      -M 3 \
+
+    kubectl apply --kubeconfig "${KUBECONFIG}" -f "$VPC_CONFIGMAP_FILE"
   fi
 
   return $?

--- a/hack/vpc-resource-controller-configmap.yaml
+++ b/hack/vpc-resource-controller-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amazon-vpc-cni
+  namespace: kube-system
+data:
+  enable-windows-ipam: "true"

--- a/tests/e2e-kubernetes/manifests.yaml
+++ b/tests/e2e-kubernetes/manifests.yaml
@@ -14,6 +14,7 @@ DriverInfo:
   SupportedFsType:
     xfs: {}
     ext4: {}
+    ntfs: {}
   SupportedMountOption:
     dirsync: {}
   TopologyKeys: ["topology.ebs.csi.aws.com/zone"]


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- Add `test-e2e-external-eks-windows` target to run the External Storage tests on Windows nodes.
- Known issues: 
~1. `GINKGO_PARALLEL=1`. Running the tests in parallel will sometimes trigger a bug when mounting volumes:~
 
Fixed by https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1526.

~2. Skipped test `volumeLimits [It] should verify that all csinodes have volume limits` - Known bug; CSINode Allocatable property is not set on Windows nodes:~

Fixed by https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1561.
    
```
$ kubectl describe csinode                                             
Name:               ip-192-168-59-155.us-west-2.compute.internal
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins:
                      kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd
CreationTimestamp:  Thu, 26 Jan 2023 02:27:42 +0000
Spec:
  Drivers:
    ebs.csi.aws.com:
      Node ID:        i-010d661aaeceaa025
      Topology Keys:  [topology.ebs.csi.aws.com/zone]
Events:               <none>
```

**What testing is done?** 

```
$ docker run -it --privileged --rm --entrypoint /bin/bash gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230207-192d5afee3-master
$ git clone https://github.com/torredil/aws-ebs-csi-driver.git && cd aws-ebs-csi-driver && git checkout e2e-windows
$ export GOPROXY=direct && dockerd &
$ CLUSTER_TYPE=eksctl K8S_VERSION=1.24 HELM_VALUES_FILE=./hack/values_eksctl.yaml make test-e2e-external-eks-windows &
```