### PR TITLE
Add support for XFS custom block sizes

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -229,6 +229,9 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	klog.V(4).InfoS("NodeStageVolume: formatting and mounting with fstype", "source", source, "target", target, "fstype", fsType)
 	formatOptions := []string{}
 	if len(blockSize) > 0 {
+		if fsType == FSTypeXfs {
+			blockSize = "size=" + blockSize
+		}
 		formatOptions = append(formatOptions, "-b", blockSize)
 	}
 	err = d.mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fsType, mountOptions, nil, formatOptions)


### PR DESCRIPTION
XFS requires "size=" prepended to the size passsed to -b for mkfs.xfs
