### PR TITLE
Always log driver information

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -70,7 +70,7 @@ type DriverOptions struct {
 }
 
 func NewDriver(options ...func(*DriverOptions)) (*Driver, error) {
-	klog.V(4).InfoS("Driver Information", "Driver", DriverName, "Version", driverVersion)
+	klog.InfoS("Driver Information", "Driver", DriverName, "Version", driverVersion)
 
 	driverOptions := DriverOptions{
 		endpoint: DefaultCSIEndpoint,


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- This information helps with debugging. The current default is `--v=2` which unfortunately does not log this information.

**What testing is done?** 
```
$ kubectl describe pod ebs-csi-controller-5b7b77b787-d4ml5 -n kube-system
Name:                 ebs-csi-controller-5b7b77b787-d4ml5
Namespace:            kube-system
Containers:
  ebs-plugin:
...
    Args:
      controller
      --endpoint=$(CSI_ENDPOINT)
      --logging-format=text
      --v=0

$ kubectl logs ebs-csi-controller-5b7b77b787-d4ml5 -n kube-system -c ebs-plugin

I0309 16:01:08.462742       1 driver.go:73] "Driver Information" Driver="ebs.csi.aws.com" Version="v1.16.0"
```
