### PR TITLE
Fix staging / unmounting volume operations on Windows

### DIFF
--- a/pkg/driver/mount_windows.go
+++ b/pkg/driver/mount_windows.go
@@ -56,7 +56,7 @@ func (m NodeMounter) GetDeviceNameFromMount(mountPath string) (string, int, erro
 		// internal Get-Item cmdlet didn't fail but no item/device was found at the
 		// path so we should return empty string and nil error just like the Linux
 		// implementation would.
-		pattern := `(Get-Item -Path \S+).Target, output: , error: <nil>`
+		pattern := `(Get-Item -Path \S+).Target, output: , error: <nil>|because it does not exist`
 		matched, matchErr := regexp.MatchString(pattern, err.Error())
 		if matched {
 			return "", 0, nil
@@ -128,8 +128,6 @@ func (m *NodeMounter) Unpublish(target string) error {
 	if !ok {
 		return fmt.Errorf("failed to cast mounter to csi proxy mounter")
 	}
-	// WriteVolumeCache before unmount
-	proxyMounter.WriteVolumeCache(target)
 	// Remove symlink
 	err := proxyMounter.Rmdir(target)
 	if err != nil {
@@ -147,11 +145,6 @@ func (m *NodeMounter) Unstage(target string) error {
 	}
 	// Unmounts and offlines the disk via the CSI Proxy API
 	err := proxyMounter.Unmount(target)
-	if err != nil {
-		return err
-	}
-	// Cleanup stage path
-	err = proxyMounter.Rmdir(target)
 	if err != nil {
 		return err
 	}

--- a/pkg/mounter/safe_mounter_windows.go
+++ b/pkg/mounter/safe_mounter_windows.go
@@ -97,11 +97,13 @@ func (mounter *CSIProxyMounter) Unmount(target string) error {
 		TargetPath: normalizeWindowsPath(target),
 	}
 	volumeIdResponse, err := mounter.VolumeClient.GetVolumeIDFromTargetPath(context.Background(), getVolumeIdRequest)
-	volumeId := volumeIdResponse.GetVolumeId()
+	if err != nil {
+		return err
+	}
 
 	// Call UnmountVolume CSI proxy function which flushes data cache to disk and removes the global staging path
 	unmountVolumeRequest := &volume.UnmountVolumeRequest{
-		VolumeId:   volumeId,
+		VolumeId:   volumeIdResponse.VolumeId,
 		TargetPath: normalizeWindowsPath(target),
 	}
 	_, err = mounter.VolumeClient.UnmountVolume(context.Background(), unmountVolumeRequest)
@@ -109,25 +111,31 @@ func (mounter *CSIProxyMounter) Unmount(target string) error {
 		return err
 	}
 
+	// Cleanup stage path
+	err = mounter.Rmdir(target)
+	if err != nil {
+		return err
+	}
+
 	// Get disk number
 	getDiskNumberRequest := &volume.GetDiskNumberFromVolumeIDRequest{
-		VolumeId: volumeId,
+		VolumeId: volumeIdResponse.VolumeId,
 	}
 	getDiskNumberResponse, err := mounter.VolumeClient.GetDiskNumberFromVolumeID(context.Background(), getDiskNumberRequest)
-	diskNumber := getDiskNumberResponse.GetDiskNumber()
 	if err != nil {
 		return err
 	}
 
 	// Offline the disk
 	setDiskStateRequest := &disk.SetDiskStateRequest{
-		DiskNumber: diskNumber,
+		DiskNumber: getDiskNumberResponse.DiskNumber,
 		IsOnline:   false,
 	}
 	_, err = mounter.DiskClient.SetDiskState(context.Background(), setDiskStateRequest)
 	if err != nil {
 		return err
 	}
+	klog.V(4).InfoS("Successfully unmounted volume", "diskNumber", getDiskNumberResponse.DiskNumber, "volumeId", volumeIdResponse.VolumeId, "target", target)
 	return nil
 }
 
@@ -208,15 +216,23 @@ func (mounter *CSIProxyMounter) DeviceOpened(pathname string) (bool, error) {
 	return false, fmt.Errorf("DeviceOpened not implemented for CSIProxyMounter")
 }
 
-// GetDeviceNameFromMount returns the volume ID for a mount path.
-func (mounter *CSIProxyMounter) GetDeviceNameFromMount(mountPath, pluginMountDir string) (string, error) {
+// GetDeviceNameFromMount returns the disk number for a mount path.
+func (mounter *CSIProxyMounter) GetDeviceNameFromMount(mountPath, _ string) (string, error) {
 	req := &volume.GetVolumeIDFromTargetPathRequest{TargetPath: normalizeWindowsPath(mountPath)}
 	resp, err := mounter.VolumeClient.GetVolumeIDFromTargetPath(context.Background(), req)
 	if err != nil {
 		return "", err
 	}
-
-	return resp.VolumeId, nil
+	// Get disk number
+	getDiskNumberRequest := &volume.GetDiskNumberFromVolumeIDRequest{
+		VolumeId: resp.VolumeId,
+	}
+	getDiskNumberResponse, err := mounter.VolumeClient.GetDiskNumberFromVolumeID(context.Background(), getDiskNumberRequest)
+	if err != nil {
+		return "", err
+	}
+	klog.V(4).InfoS("GetDeviceNameFromMount called", "diskNumber", getDiskNumberResponse.DiskNumber, "volumeID", resp.VolumeId, "mountPath", mountPath)
+	return fmt.Sprint(getDiskNumberResponse.DiskNumber), nil
 }
 
 func (mounter *CSIProxyMounter) MakeRShared(path string) error {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
- Bug fix.

**What is this PR about?**

This PR fixes several bugs uncovered by running the external e2e tests on Windows. It will allow us to run the tests in parallel and should land before https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1521.

- `GetDeviceNameFromMount` now returns the disk number for a mount path on Windows.
- Cleanup the stage path via `Rmdir` in `proxyMounter.Unmount()` before offlining the disk.
- Remove unnecessary call to `proxyMounter.WriteVolumeCache()` when unpublishing a volume from the node.
- Return a nil error in `GetDeviceNameFromMount` if the target path does not exist, per the CSI spec: _If the volume corresponding to the volume_id is not staged to the staging_target_path, the Plugin MUST reply 0 OK._

**Why do we need it?**

To fix the following issues:
```
I0308 16:30:11.616491    6048 node.go:260] "NodeUnStageVolume: volume operation finished" volumeID="vol-0575b28e63a6f11a5"
I0308 16:30:11.616491    6048 inflight.go:74] "Node Service: volume operation finished" key="vol-0575b28e63a6f11a5"
E0308 16:30:11.616491    6048 driver.go:120] "GRPC error" err=<
	rpc error: code = Internal desc = failed to check if volume is mounted: error getting device name from mount: rpc error: code = Unknown desc = error getting the volume for the mount c:\var\lib\kubelet\plugins\kubernetes.io\csi\ebs.csi.aws.com\1610843f84a51551af6fe5a45ef0fc4afcc8ac37f65a219815fccad076ef7dcc\globalmount, internal error error getting volume from mount. cmd: (Get-Item -Path Get-Item : Cannot find path 'C:\var\lib\kubelet\plugins\kubernetes.io\csi\ebs.csi.aws.com\1610843f84a51551af6fe5a45ef0f
	922efd496ae6e73900f42d7ccc7ef58c003\globalmount' because it does not exist.
	At line:1 char:2
	+ (Get-Item -Path c:\var\lib\kubelet\plugins\kubernetes.io\csi\ebs.csi. ...
	+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	    + CategoryInfo          : ObjectNotFound: (C:\var\lib\kube...003\globalmount:String) [Get-Item], ItemNotFoundExcep
	   tion
	    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand).Target, output: At line:2 char:76
	+ ... 496ae6e73900f42d7ccc7ef58c003\globalmount' because it does not exist.
```

```
I0303 01:42:25.179841     652 node.go:172] "NodeStageVolume: volume operation finished" volumeID="vol-0ce949dffa97f251a"
I0303 01:42:25.180392     652 inflight.go:74] "Node Service: volume operation finished" key="vol-0ce949dffa97f251a"
E0303 01:42:25.180392     652 driver.go:120] "GRPC error" err=<
	rpc error: code = Internal desc = could not format "3" and mount it at "\\var\\lib\\kubelet\\plugins\\kubernetes.io\\csi\\ebs.csi.aws.com\\914755ec302b648ec6285e1fe8790121c95058c4e191a432214a2a3472aac79c\\globalmount": rpc error: code = Unknown desc = error mount volume to path. cmd: Get-Volume -UniqueId "\\?\Volume{5baf4ea8-203e-477a-845c-77a024150315}\" | Get-Partition | Add-PartitionAccessPath -AccessPath c:\var\lib\kubelet\plugins\kubernetes.io\csi\ebs.csi.aws.com\914755ec302b648ec6285e1fe8790121c95058c4e191a432214a2a3472aac79c\globalmount, output: Add-PartitionAccessPath : The requested access path is already in use.
	Activity ID: {cb64fe87-eb6f-42de-a3dc-d2505bb47395}
	At line:1 char:92
	+ ... Partition | Add-PartitionAccessPath -AccessPath c:\var\lib\kubelet\pl ...
	+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	    + CategoryInfo          : InvalidArgument: (StorageWMI:ROOT/Microsoft/.../MSFT_Partition) [Add-PartitionAccessPath
	   ], CimException
	    + FullyQualifiedErrorId : StorageWMI 42002,Add-PartitionAccessPath

	, error: exit status 1
```

**What testing is done?** 

```
$ kubetest2 noop \         
  --run-id="e2e-kubernetes" \
  --test=ginkgo \
  -- \
  --test-package-version=v1.27.0-alpha.3 \
  --skip-regex="\[Disruptive\]|\[Serial\]|\[LinuxOnly\]|\[Feature:VolumeSnapshotDataSource\]|(xfs)|(ext4)|(block volmode)|csinodes" \
  --focus-regex="External.Storage" \
  --parallel=15 \
  --test-args="-storage.testdriver=/home/torredil/go/src/github.com/torredil/aws-ebs-csi-driver/tests/e2e-kubernetes/manifests.yaml -node-os-distro=windows"
```

![Screen Shot 2023-03-09 at 5 35 43 PM](https://user-images.githubusercontent.com/99845161/224175906-0154630f-fe7d-4320-8085-01a9b8183506.png)

