### PR TITLE
Reduce scope of testing for test-helm-chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -120,6 +120,10 @@ rules:
     resources:
       - clusterrolebindings
     verbs: [ "create" ]
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources:
+      - customresourcedefinitions
+    verbs: [ "get" ]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -201,9 +205,13 @@ spec:
           kubectl config set-cluster cluster --server=https://kubernetes.default --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           kubectl config set-context kubetest2 --cluster=cluster
           kubectl config set-credentials sa --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-          kubectl config set-context kubetest2 --user=sa
-          kubectl config use-context kubetest2
-          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex='External.Storage' --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
+          kubectl config set-context kubetest2 --user=sa && kubectl config use-context kubetest2
+          kubectl get crd volumesnapshots.snapshot.storage.k8s.io
+          if [ $? -eq 0 ]; then 
+            SNAPSHOTS="|snapshot fields"
+          fi
+          export FOCUS_REGEX="\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data$SNAPSHOTS)"
+          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- Currently, we run the entire External.Storage e2e suite when testing Helm chart changes / upgrades -- overkill. This PR significantly reduces the number of tests we run to a select few that still cover all the functionality:
  - `Kubernetes e2e suite: [It] External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (default fs)] volumes should store data`
  - `Kubernetes e2e suite: [It] External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (delayed binding)] topology should provision a volume and schedule a pod with AllowedTopologies`
  - `Kubernetes e2e suite: [It] External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand Verify if offline PVC expansion works`
  - `Kubernetes e2e suite: [It] External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand should resize volume when PVC is edited while pod is using it`
  - `Kubernetes e2e suite: [It] External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (default fs)] volumeIO should write files of various sizes, verify size, validate content [Slow]`
  - `Kubernetes e2e suite: [It] External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic Snapshot (delete policy)] snapshottable[Feature:VolumeSnapshotDataSource] volume snapshot controller should check snapshot fields, check restore correctly works after modifying source data, check deletion (persistent)`

- Only run snapshot tests if CRDs detected.
- closes #1522 

**What testing is done?** 
```
// volumesnapshots.snapshot.storage.k8s.io CRD not installed.
I0313 23:28:16.880359    1970 ginkgo.go:111] Running ginkgo test as /workspace/_rundir/e2e-kubernetes/ginkgo [--nodes=25 /workspace/_rundir/e2e-kubernetes/e2e.test -- --kubeconfig=/root/.kube/config --kubectl-path=/workspace/_rundir/e2e-kubernetes/kubectl --ginkgo.skip=\[Disruptive\]|\[Serial\] --ginkgo.focus=\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data) --report-dir=/workspace/_artifacts --ginkgo.timeout=24h --ginkgo.flake-attempts=1 -storage.testdriver=/etc/config/manifests.yaml]

Ran 11 of 7332 Specs in 177.293 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 7321 Skipped

// volumesnapshots.snapshot.storage.k8s.io CRD installed.
I0313 23:34:27.447735    1952 ginkgo.go:111] Running ginkgo test as /workspace/_rundir/e2e-kubernetes/ginkgo [--nodes=25 /workspace/_rundir/e2e-kubernetes/e2e.test -- --kubeconfig=/root/.kube/config --kubectl-path=/workspace/_rundir/e2e-kubernetes/kubectl --ginkgo.skip=\[Disruptive\]|\[Serial\] --ginkgo.focus=\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data|snapshot fields) --report-dir=/workspace/_artifacts --ginkgo.timeout=24h --ginkgo.flake-attempts=1 -storage.testdriver=/etc/config/manifests.yaml]

Ran 17 of 7332 Specs in 268.808 seconds
SUCCESS! -- 17 Passed | 0 Failed | 0 Pending | 7315 Skipped
```
