### PR TITLE
fix: ./ecr-public is a base not a resource

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
+bases:
   - ./ecr-public


### PR DESCRIPTION
When I try to launch this command ```kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"``` or in local ```kubectl apply -k aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/```

I obtain:
```error: rawResources failed to read Resources: Load from path ./ecr-public failed: './ecr-public' must be a file (got d='/private/var/folders/fy/d843w2ds1l7gynxsknlfmsc80000gn/T/kustomize-998530352/deploy/kubernetes/overlays/stable/ecr-public')```

I propose to replace `resources` by `bases` as it is a folder

It works for me after
