### PR TITLE
Kustomize: use 'resources' instead of deprecated 'bases'

### DIFF
--- a/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr-public/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../../../base

--- a/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/ecr/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../ecr-public
 images:
   - name: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver

--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../ecr-public
 images:
   - name: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- `bases` has been deprecated and replaced by `resources`: https://github.com/kubernetes-sigs/kustomize/blob/2a8a17e3af263c8cd61452bd2fc5e2e7d7bc5330/api/types/kustomization.go#L85-L88.
- We use `resources` for some Kustomization objects and `bases` for others. This PR replaces all instances of `bases` with `resources`.
