### PR TITLE
Support VolumeSnapshotClass in Helm Chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/volumesnapshotclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/volumesnapshotclass.yaml
@@ -1,0 +1,17 @@
+{{- if or .Values.sidecars.snapshotter.forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
+{{- range .Values.volumeSnapshotClasses }}
+---
+kind: VolumeSnapshotClass
+apiVersion: snapshot.storage.k8s.io/v1
+metadata:
+  name: {{ .name }}
+  {{- with .annotations }}
+  annotations: {{- . | toYaml | trim | nindent 4 }}
+  {{- end }}
+driver: ebs.csi.aws.com
+deletionPolicy: {{ .deletionPolicy }}
+{{- with .parameters }}
+parameters: {{- . | toYaml | trim | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -305,6 +305,16 @@ storageClasses: []
 #   parameters:
 #     encrypted: "true"
 
+volumeSnapshotClasses: []
+# Add VolumeSnapshotClass resources like:
+# - name: ebs-vsc
+#   # annotation metadata
+#   annotations:
+#     snapshot.storage.kubernetes.io/is-default-class: "true"
+#   # deletionPolicy must be specified
+#   deletionPolicy: Delete
+#   parameters:
+
 # Use old CSIDriver without an fsGroupPolicy set
 # Intended for use with older clusters that cannot easily replace the CSIDriver object
 # This parameter should always be false for new installations


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**  
New feature.

**What is this PR about? / Why do we need it?**
Allow defining VolumeSnapshotClass in Helm Chart. #1459 

**What testing is done?** 
1. Modified ``values.yaml`` to declare VolumeSnapshotClass like this 
```
volumeSnapshotClasses:
- name: ebs-vsc
  annotations:
    snapshot.storage.kubernetes.io/is-default-class: "true"
  deletionPolicy: Delete
  parameters:
    testKey: testValue
```
2.  Installed the helm chart. 
``helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --values ./charts/aws-ebs-csi-driver/values.yaml``
3. Ran ``kubectl get volumesnapshotclass -n kube-system`` and verified VolumeSnapshotClass is installed as expected:
```
NAME      DRIVER            DELETIONPOLICY   AGE
ebs-vsc   ebs.csi.aws.com   Delete           29s
```
To verify ``annotations`` and ``parameters`` fields in the VSC, ran ``kubectl describe volumesnapshotclass ebs-vsc -n kube-system``. Got this
```
Annotations:      
                  snapshot.storage.kubernetes.io/is-default-class: true
```
```
Parameters:
  Test Key:  testValue
```