### PR TITLE
Grab snow device path via last character rather than trimming

### DIFF
--- a/pkg/driver/node_linux.go
+++ b/pkg/driver/node_linux.go
@@ -101,7 +101,11 @@ func (d *nodeService) findDevicePath(devicePath, volumeID, partition string) (st
 
 	if util.IsSBE(d.metadata.GetRegion()) {
 		klog.V(5).InfoS("[Debug] Falling back to snow volume lookup", "devicePath", devicePath)
-		canonicalDevicePath = "/dev/vd" + strings.TrimPrefix(devicePath, "/dev/xvdb")
+		// Snow completely ignores the requested device path and mounts volumes starting at /dev/vda .. /dev/vdb .. etc
+		// Morph the device path to the snow form by chopping off the last letter and prefixing with /dev/vd
+		// VMs on snow devices are currently limited to 10 block devices each - if that ever exceeds 26 this will need
+		// to be adapted
+		canonicalDevicePath = "/dev/vd" + devicePath[len(devicePath)-1:]
 	}
 
 	if canonicalDevicePath == "" {

--- a/pkg/driver/node_linux_test.go
+++ b/pkg/driver/node_linux_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestFindDevicePath(t *testing.T) {
-	devicePath := "/dev/xvdba"
+	devicePath := "/dev/xvdaa"
 	nvmeDevicePath := "/dev/nvme1n1"
 	snowDevicePath := "/dev/vda"
 	volumeID := "vol-test"
@@ -114,6 +114,20 @@ func TestFindDevicePath(t *testing.T) {
 			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
 				gomock.InOrder(
 					mockMounter.EXPECT().PathExists(gomock.Eq(devicePath)).Return(false, nil),
+
+					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(nil, os.ErrNotExist),
+				)
+			},
+			expectDevicePath: snowDevicePath,
+		},
+		{
+			name:       "success: non-standard snow device path",
+			devicePath: "/dev/sda",
+			volumeID:   volumeID,
+			partition:  "",
+			expectMock: func(mockMounter MockMounter, mockDeviceIdentifier MockDeviceIdentifier) {
+				gomock.InOrder(
+					mockMounter.EXPECT().PathExists(gomock.Eq("/dev/sda")).Return(false, nil),
 
 					mockDeviceIdentifier.EXPECT().Lstat(gomock.Eq(nvmeName)).Return(nil, os.ErrNotExist),
 				)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Due to #1518, volumes now start with /dev/xvda rather than /dev/xvdb. Because of this, the hardcoded path in the snow code stopped working, breaking mounting on snow devices. This change instead creates the snow device path based on the last character of the generated path, rather than trying to do it via trimming, which is unreliable.

Snow devices are currently limited to 10 volumes attached which makes this 100% safe, but this will need to be revisited if snow every adds suport for >26 volumes.

**What testing is done?** 

Manual (with snow customer), added additional unit test case