### PR TITLE
Fix VolumeSnapshotClass tagging

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -622,10 +622,6 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid tag value: %v", err)
 	}
 
-	for k, v := range addTags {
-		snapshotTags[k] = v
-	}
-
 	if d.driverOptions.kubernetesClusterID != "" {
 		resourceLifecycleTag := ResourceLifecycleTagPrefix + d.driverOptions.kubernetesClusterID
 		snapshotTags[resourceLifecycleTag] = ResourceLifecycleOwned
@@ -634,6 +630,11 @@ func (d *controllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	for k, v := range d.driverOptions.extraTags {
 		snapshotTags[k] = v
 	}
+
+	for k, v := range addTags {
+		snapshotTags[k] = v
+	}
+
 	opts := &cloud.SnapshotOptions{
 		Tags: snapshotTags,
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix for #1545 

**What is this PR about? / Why do we need it?**
When users set "Name" tag for a snapshot via `VolumeSnapshotClass.parameters`, the value of the Name tag is overwritten by [the value automatically populated by the Driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/5d75bf4be309d3b554d3959a79cc8f05ed65d4d2/pkg/driver/controller.go#L632), which is unexpected behavior.
This PR fixes the bug by setting the tags from VolumeSnapshotClass.parameters _after_ the Driver automatically populates the Name tag.

**What testing is done?** 
Added unit test & 
1. Built and installed the driver that has the changes. 
2. Followed the repro steps in #1545 to create a snapshot with "Name" tag in ``VolumeSnapshotClass.parameters``.
3.  Confirmed the name of the snapshot and the tags of the snapshot in the EC2 console are the values from ``VolumeSnapshotClass.parameters``.
