### PR TITLE
Support interpolated snapshot tags

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -268,6 +268,9 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
+            {{- if .Values.controller.extraCreateMetadata }}
+            - --extra-create-metadata
+            {{- end}}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -184,6 +184,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
+            - --extra-create-metadata
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -69,6 +69,16 @@ const (
 	// provisioned volume
 	PVNameKey = "csi.storage.k8s.io/pv/name"
 
+	// VolumeSnapshotNameKey contains name of the snapshot
+	VolumeSnapshotNameKey = "csi.storage.k8s.io/volumesnapshot/name"
+
+	// VolumeSnapshotNamespaceKey contains namespace of the snapshot
+	VolumeSnapshotNamespaceKey = "csi.storage.k8s.io/volumesnapshot/namespace"
+
+	// VolumeSnapshotCotentNameKey contains name of the VolumeSnapshotContent that is the source
+	// for the snapshot
+	VolumeSnapshotContentNameKey = "csi.storage.k8s.io/volumesnapshotcontent/name"
+
 	// BlockExpressKey increases the iops limit for io2 volumes to the block express limit
 	BlockExpressKey = "blockexpress"
 

--- a/pkg/util/template/template.go
+++ b/pkg/util/template/template.go
@@ -8,13 +8,19 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type Props struct {
+type PVProps struct {
 	PVCName      string
 	PVCNamespace string
 	PVName       string
 }
 
-func Evaluate(tm []string, props *Props, warnOnly bool) (map[string]string, error) {
+type VolumeSnapshotProps struct {
+	VolumeSnapshotName        string
+	VolumeSnapshotNamespace   string
+	VolumeSnapshotContentName string
+}
+
+func Evaluate(tm []string, props interface{}, warnOnly bool) (map[string]string, error) {
 	md := make(map[string]string)
 	for _, s := range tm {
 		st := strings.SplitN(s, "=", 2)
@@ -39,7 +45,7 @@ func Evaluate(tm []string, props *Props, warnOnly bool) (map[string]string, erro
 	return md, nil
 }
 
-func execTemplate(value string, props *Props, t *template.Template) (string, error) {
+func execTemplate(value string, props interface{}, t *template.Template) (string, error) {
 	tmpl, err := t.Parse(value)
 	if err != nil {
 		return "", err

--- a/pkg/util/template/template_test.go
+++ b/pkg/util/template/template_test.go
@@ -189,10 +189,151 @@ func TestEvaluate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			props := &Props{
+			props := &PVProps{
 				PVCName:      tc.pvcName,
 				PVCNamespace: tc.pvcNamespace,
 				PVName:       tc.pvName,
+			}
+
+			tags, err := Evaluate(tc.input, props, tc.warnOnly)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected an error; got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("err is not nil; err = %v", err)
+				}
+				if diff := cmp.Diff(tc.expectedTags, tags); diff != "" {
+					t.Fatalf("tags are different; diff = %v", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateVolumeSnapshotTemplate(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		input                     []string
+		volumeSnapshotName        string
+		volumeSnapshotNamespace   string
+		volumeSnapshotContentName string
+		warnOnly                  bool
+		expectErr                 bool
+		expectedTags              map[string]string
+	}{
+		{
+			name: "simple substitution",
+			input: []string{
+				"key1={{ .VolumeSnapshotName }}",
+				"key2={{ .VolumeSnapshotNamespace }}",
+				"key3={{ .VolumeSnapshotContentName }}",
+			},
+			volumeSnapshotName:        "ebs-vs",
+			volumeSnapshotNamespace:   "default",
+			volumeSnapshotContentName: "ebs-vs-content-012345",
+			expectedTags: map[string]string{
+				"key1": "ebs-vs",
+				"key2": "default",
+				"key3": "ebs-vs-content-012345",
+			},
+		},
+		{
+			name: "template parsing error",
+			input: []string{
+				"key1={{ .VolumeSnapshotName }",
+			},
+			expectErr: true,
+		},
+		{
+			name: "template parsing error warn only",
+			input: []string{
+				"key1={{ .VolumeSnapshotName }",
+				"key2={{ .VolumeSnapshotNamespace }}",
+			},
+			volumeSnapshotName:      "ebs-vs",
+			volumeSnapshotNamespace: "default",
+			warnOnly:                true,
+			expectedTags: map[string]string{
+				"key2": "default",
+			},
+		},
+		{
+			name: "test unsupported func - returns error",
+			input: []string{
+				`backup={{ .VolumeSnapshotNamespace | html }}`,
+			},
+			volumeSnapshotNamespace: "ns-prod",
+			expectErr:               true,
+		},
+		{
+			name: "test function - contains",
+			input: []string{
+				`backup={{ .VolumeSnapshotNamespace | contains "prod" }}`,
+			},
+			volumeSnapshotNamespace: "ns-prod",
+			expectedTags: map[string]string{
+				"backup": "true",
+			},
+		},
+		{
+			name: "test function - toUpper",
+			input: []string{
+				`backup={{ .VolumeSnapshotNamespace | toUpper }}`,
+			},
+			volumeSnapshotNamespace: "ns-prod",
+			expectedTags: map[string]string{
+				"backup": "NS-PROD",
+			},
+		},
+		{
+			name: "test function - toLower",
+			input: []string{
+				`backup={{ .VolumeSnapshotNamespace | toLower }}`,
+			},
+			volumeSnapshotNamespace: "ns-PROD",
+			expectedTags: map[string]string{
+				"backup": "ns-prod",
+			},
+		},
+		{
+			name: "test function - field",
+			input: []string{
+				`backup={{ .VolumeSnapshotNamespace | field "-" 1 }}`,
+			},
+			volumeSnapshotNamespace: "ns-prod-default",
+			expectedTags: map[string]string{
+				"backup": "prod",
+			},
+		},
+		{
+			name: "test function - substring",
+			input: []string{
+				`key1={{ .VolumeSnapshotNamespace | substring 0 4 }}`,
+			},
+			volumeSnapshotNamespace: "prod-12345",
+			expectedTags: map[string]string{
+				"key1": "prod",
+			},
+		},
+		{
+			name: "field returns error",
+			input: []string{
+				`key1={{ .VolumeSnapshotNamespace | field "-" 1 }}`,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			props := &VolumeSnapshotProps{
+				VolumeSnapshotName:        tc.volumeSnapshotName,
+				VolumeSnapshotNamespace:   tc.volumeSnapshotNamespace,
+				VolumeSnapshotContentName: tc.volumeSnapshotContentName,
 			}
 
 			tags, err := Evaluate(tc.input, props, tc.warnOnly)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature. 

**What is this PR about? / Why do we need it?**
For more details, see issue #1553 
1. Added support for interpolated snapshot tags that are dynamically computed at runtime using ``VolumeSnapshot`` name, namespace and ``VolumeSnapshotContent`` name.
2. Modified the helm chart template ``controller.yaml`` to allow setting ``--extra-create-metadata`` for ``csi-snapshotter`` sidecar. It enables ``external-snapshotter`` to pass the snapshot parameters to CSI Driver.
3. Added the documentation for Snapshot Tagging.

**What testing is done?** 
1. Added unit tests of string interpolation on the VolumeSnapshot template.
2. E2E tests. Deployed the Driver with the changes. Provisioned a snapshot using this VolumeSnapshotClass
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: csi-aws-vsc
driver: ebs.csi.aws.com
deletionPolicy: Delete
parameters:
  tagSpecification_1: "key1={{ .VolumeSnapshotNamespace }}"
  tagSpecification_2: "key2={{ .VolumeSnapshotName }}"
  tagSpecification_3: "key3={{ .VolumeSnapshotContentName }}"
  tagSpecification_4: 'key4={{ .VolumeSnapshotName |  contains "ebs"}}'
```
and this VolumeSnapshot
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: ebs-volume-snapshot
spec:
  volumeSnapshotClassName: csi-aws-vsc
  source:
    persistentVolumeClaimName: ebs-claim
```
The tags for the snapshot in the AWS EC2 console were created as expected:
```
key2 | ebs-volume-snapshot
key1 | default
key3 | snapcontent-97516503-aa32-4fc5-96ae-3e694d2519d7
key4 | true
```
