### PR TITLE
Set image repository/tag via `--helm-extra-set-args` param in CT

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -183,15 +183,13 @@ if [[ "${HELM_CT_TEST}" == true ]]; then
     export CT_REMOTE="ct"
     export CT_TARGET_BRANCH="${PULL_BASE_REF}"
   fi
-  yq -i ".image.repository = \"$IMAGE_NAME\" | .image.tag = \"$IMAGE_TAG\"" ${PWD}/charts/aws-ebs-csi-driver/values.yaml
   set -x
   set +e
   export KUBECONFIG="${KUBECONFIG}"
-  ${CHART_TESTING_BIN} lint-and-install --config ${PWD}/tests/ct-config.yaml
+  ${CHART_TESTING_BIN} lint-and-install --config ${PWD}/tests/ct-config.yaml --helm-extra-set-args="--set=image.repository=${IMAGE_NAME},image.tag=${IMAGE_TAG}"
   TEST_PASSED=$?
   set -e
   set +x
-  git checkout -- ${PWD}/charts/aws-ebs-csi-driver/values.yaml
 else
   loudecho "Deploying driver"
   startSec=$(date +'%s')


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**


If changes are made to the driver / chart simultaneously, testing should be performed against the newly built test image. This PR ensures this desired behavior via the [CT parameter](https://github.com/helm/chart-testing/blob/70acba19d18a72d456aab1b8739e8c6998225566/doc/ct_install.md?plain=1#L54) `--helm-extra-set-args`.

Currently, in the CT job we set the image repository / tag using yq. CT uses `--reuse-values` when performing helm upgrades, this parameter causes Helm to use the values in a previous release as the base, disregarding any changes that may have happened in the new chart version.

From the [Helm documentation](https://helm.sh/docs/helm/helm_upgrade/):

```
--reuse-values  when upgrading, reuse the last release's values and merge in any overrides from the command line via --set.
```
To illustrate this behavior:

![Screen Shot 2023-04-06 at 10 30 32 AM](https://user-images.githubusercontent.com/99845161/230409167-2997ae5f-b3db-446a-8889-8526a676d0d0.png)

**What testing is done?** 

Tested changes against https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1558.

```
$ kubectl describe pod ebs-csi-controller-6968954878-jsjkv -n kube-system     
Name:                 ebs-csi-controller-6968954878-jsjkv
Namespace:            kube-system
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Node:                 i-0c919e3d9816be598/172.20.82.42
Start Time:           Thu, 06 Apr 2023 13:50:59 +0000
Labels:               app=ebs-csi-controller
                      app.kubernetes.io/component=csi-driver
                      app.kubernetes.io/instance=aws-ebs-csi-driver-trglcao91t
                      app.kubernetes.io/managed-by=Helm
                      app.kubernetes.io/name=aws-ebs-csi-driver
                      app.kubernetes.io/version=1.17.0
                      helm.sh/chart=aws-ebs-csi-driver-2.17.2
                      pod-template-hash=6968954878
Annotations:          <none>
Status:               Running
IP:                   100.96.1.66
IPs:
  IP:           100.96.1.66
Controlled By:  ReplicaSet/ebs-csi-controller-6968954878
Containers:
  ebs-plugin:
    Container ID:  containerd://b166cfeb16882c34a84e169d1e1e61713dd576647132931cd83864502fe3db16
    Image:         xxxxxxxxxx.dkr.ecr.us-west-2.amazonaws.com/aws-ebs-csi-driver:19786  ✅
```

```
........................................................................................................................
<== Events of namespace kube-system
........................................................................................................................
========================================================================================================================
Deleting release "aws-ebs-csi-driver-pn92ef0xrs"...
release "aws-ebs-csi-driver-pn92ef0xrs" uninstalled
------------------------------------------------------------------------------------------------------------------------
 ✔︎ aws-ebs-csi-driver => (version: "2.17.2", path: "charts/aws-ebs-csi-driver")
------------------------------------------------------------------------------------------------------------------------
All charts linted and installed successfully
###
## SUCCESS!
#
```
