### PR TITLE
Fix volume attachment limit calculation

### DIFF
--- a/pkg/cloud/metadata_ec2.go
+++ b/pkg/cloud/metadata_ec2.go
@@ -61,17 +61,14 @@ func EC2MetadataInstanceInfo(svc EC2Metadata, regionFromSession string) (*Metada
 	}
 
 	attachedENIs := strings.Count(enis, "\n") + 1
-
-	//As block device mapping contains 1 volume for the AMI.
-	blockDevMappings := 1
+	blockDevMappings := 0
 
 	if !util.IsSBE(doc.Region) {
 		mappings, mapErr := svc.GetMetadata(blockDevicesEndpoint)
-		// The output contains 1 volume for the AMI. Any other block device contributes to the attachment limit
-		blockDevMappings = strings.Count(mappings, "\n")
 		if mapErr != nil {
 			return nil, fmt.Errorf("could not get number of block device mappings: %w", err)
 		}
+		blockDevMappings = strings.Count(mappings, "ebs")
 	}
 
 	instanceInfo := Metadata{

--- a/pkg/cloud/metadata_test.go
+++ b/pkg/cloud/metadata_test.go
@@ -330,7 +330,7 @@ func TestNewMetadataService(t *testing.T) {
 			imdsENIOutput:         "00:00:00:00:00:00",
 			expectedENIs:          1,
 			imdsBlockDeviceOutput: "ami\nroot\nebs1\nebs2",
-			expectedBlockDevices:  3,
+			expectedBlockDevices:  2,
 		},
 		{
 			name:                 "success: region from session is snow",
@@ -344,7 +344,7 @@ func TestNewMetadataService(t *testing.T) {
 			imdsENIOutput:        "00:00:00:00:00:00",
 			expectedENIs:         1,
 			regionFromSession:    snowRegion,
-			expectedBlockDevices: 1,
+			expectedBlockDevices: 0,
 		},
 	}
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -747,8 +747,7 @@ func (d *nodeService) getVolumesLimit() int64 {
 		nvmeInstanceStoreVolumes := cloud.GetNVMeInstanceStoreVolumesForInstanceType(instanceType)
 		availableAttachments = availableAttachments - enis - nvmeInstanceStoreVolumes
 	}
-	availableAttachments = availableAttachments - blockVolumes
-
+	availableAttachments = availableAttachments - blockVolumes - 1 // -1 for root device
 	if availableAttachments < 0 {
 		availableAttachments = 0
 	}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1941,7 +1941,7 @@ func TestNodeGetInfo(t *testing.T) {
 			availabilityZone:  "us-west-2b",
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
-			expMaxVolumes:     39,
+			expMaxVolumes:     38,
 			attachedENIs:      1,
 			outpostArn:        emptyOutpostArn,
 		},
@@ -1963,7 +1963,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      2,
-			expMaxVolumes:     26, // 28 (max) - 2 (enis)
+			expMaxVolumes:     25, // 28 (max) - 2 (enis) - 1 (root)
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -1974,7 +1974,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      2,
-			expMaxVolumes:     25,
+			expMaxVolumes:     24,
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -2005,7 +2005,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      1,
-			expMaxVolumes:     27, // 28 (max) - 1 (eni)
+			expMaxVolumes:     26, // 28 (max) - 1 (eni) - 1 (root)
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -2050,7 +2050,7 @@ func TestNodeGetInfo(t *testing.T) {
 			volumeAttachLimit: -1,
 			attachedENIs:      1,
 			blockDevices:      2,
-			expMaxVolumes:     25,
+			expMaxVolumes:     24,
 			outpostArn:        emptyOutpostArn,
 		},
 		{


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

- Bug fix.

**What is this PR about? / Why do we need it?**

Currently, the `blockVolumes` count returned from the ec2 metadata service is incorrect. 
https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/7db7d1a745abd1473eb86e63383c119209dcfc80/pkg/driver/node.go#L729

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/7db7d1a745abd1473eb86e63383c119209dcfc80/pkg/cloud/metadata_ec2.go#L71 

As an example, on Windows the virtual devices for [instance store](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html) volumes are counted which results in -1 as the attachment limit when block devices are subtracted from the available limit:
```
$ kubectl logs ebs-csi-node-windows-gjllb -n kube-system -c ebs-plugin
      
I0404 21:25:23.743697    2772 driver.go:73] "Driver Information" Driver="ebs.csi.aws.com" Version="v1.17.0"
I0404 21:25:25.521753    2772 node.go:81] "regionFromSession Node service" region=""
I0404 21:25:25.523961    2772 metadata.go:85] "retrieving instance data from ec2 metadata"
I0404 21:25:25.544851    2772 metadata.go:92] "ec2 metadata is available"
I0404 21:25:25.546760    2772 metadata_ec2.go:25] "Retrieving EC2 instance identity metadata" regionFromSession=""
I0404 21:25:25.549832    2772 metadata_ec2.go:70] "Retrieving EC2 block device mapping metadata" mappings=<
	ami
	ebs1
	ephemeral0
	ephemeral1
	ephemeral10
	ephemeral11
	ephemeral12
	ephemeral13
	ephemeral14
	ephemeral15
	ephemeral16
	ephemeral17
	ephemeral18
	ephemeral19
	ephemeral2
	ephemeral20
	ephemeral21
	ephemeral22
	ephemeral23
	ephemeral24
	ephemeral25
	ephemeral3
	ephemeral4
	ephemeral5
	ephemeral6
	ephemeral7
	ephemeral8
	ephemeral9
	root
 >
I0404 21:25:28.465190    2772 node.go:749] "blockVolumes count" blockVolumes=28
```

This explains the behavior we have observed with the CSINode Allocatable property not being set on Windows nodes. As a result of this change, only entries in the block device mapping that start with `ebs` are counted. This will fix issues with double counting the root volume and counting entries that should not be counted.

**What testing is done?** 
- `make test`
- External storage test: `volumeLimits [It] should verify that all csinodes have volume limits` ✅
- CSINode Allocatables count present and correct:
```
$ kubectl describe csinode

Name:               ip-192-168-50-216.ap-northeast-2.compute.internal
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins:
                      kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd
CreationTimestamp:  Thu, 06 Apr 2023 18:58:23 +0000
Spec:
  Drivers:
    ebs.csi.aws.com:
      Node ID:  i-0d5778d50d069306f
      Allocatables:
        Count:        37
```

