### PR TITLE
Allow customize secret name in Helm Chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -101,18 +101,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
-                  key: key_id
+                  name: {{ .name }}
+                  key: {{ .keyId }}
                   optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
-                  key: access_key
+                  name: {{ .name }}
+                  key: {{ .accessKey }}
                   optional: true
+            {{- end }}
             - name: AWS_EC2_ENDPOINT
               valueFrom:
                 configMapKeyRef:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -109,6 +109,11 @@ imagePullSecrets: []
 nameOverride:
 fullnameOverride:
 
+awsAccessSecret: 
+  name: aws-secret
+  keyId: key_id
+  accessKey: access_key
+
 controller:
   additionalArgs: []
   sdkDebugLog: false

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,17 +2,20 @@
 
 ## Prerequisites
 
-* Kubernetes Version >= 1.20 
+* Kubernetes Version >= 1.20
 
 * If you are using a self managed cluster, ensure the flag `--allow-privileged=true` for `kube-apiserver`.
 
 * Important: If you intend to use the Volume Snapshot feature, the [Kubernetes Volume Snapshot CRDs](https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd) must be installed **before** the EBS CSI driver. For installation instructions, see [CSI Snapshotter Usage](https://github.com/kubernetes-csi/external-snapshotter#usage).
 
 ## Installation
-### Set up driver permissions
-The driver requires IAM permissions to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./example-iam-policy.json) defines these permissions. AWS maintains a managed policy, available at ARN `arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`. 
 
-Note: Add the below statement to the example policy if you want to encrypt the EBS drives. 
+### Set up driver permissions
+
+The driver requires IAM permissions to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./example-iam-policy.json) defines these permissions. AWS maintains a managed policy, available at ARN `arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`.
+
+Note: Add the below statement to the example policy if you want to encrypt the EBS drives.
+
 ```
 {
   "Effect": "Allow",
@@ -25,12 +28,14 @@ Note: Add the below statement to the example policy if you want to encrypt the E
 }
 ```
 
-For more information, review ["Creating the Amazon EBS CSI driver IAM role for service accounts" from the EKS User Guide.](https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html) 
+For more information, review ["Creating the Amazon EBS CSI driver IAM role for service accounts" from the EKS User Guide.](https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html)
 
 There are several methods to grant the driver IAM permissions:
+
 * Using IAM [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) - attach the policy to the instance profile IAM role and turn on access to [instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the instance(s) on which the driver Deployment will run
 * EKS only: Using [IAM roles for ServiceAccounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) - create an IAM role, attach the policy to it, then follow the IRSA documentation to associate the IAM role with the driver Deployment service account, which if you are installing via Helm is determined by value `controller.serviceAccount.name`, `ebs-csi-controller-sa` by default
-* Using secret object - create an IAM user, attach the policy to it, then create a generic secret called `aws-secret` in the `kube-system` namespace with the user's credentials
+* Using secret object - create an IAM user, attach the policy to it, create a generic secret with a customized name (by default it will be `aws-secret`) in the `kube-system` namespace with the user's credentials, and configure the secret name for Helm by setting `Value.awsAccessSecret.name` to the customized secret name. Or use an existing secret with aws access key by configuring `Value.awsAccessSecret.name`, `Value.awsAccessSecret.keyId` with the key of the AWS_ACCESS_KEY_ID, and `Value.awsAccessSecret.accessKey` with the key of the AWS_SECRET_ACCESS_KEY.
+
 ```sh
 kubectl create secret generic aws-secret \
     --namespace kube-system \
@@ -39,12 +44,15 @@ kubectl create secret generic aws-secret \
 ```
 
 ### Configure driver toleration settings
+
 By default, the driver controller tolerates taint `CriticalAddonsOnly` and has `tolerationSeconds` configured as `300`; and the driver node tolerates all taints. If you don't want to deploy the driver node on all nodes, please set Helm `Value.node.tolerateAllTaints` to false before deployment. Add policies to `Value.node.tolerations` to configure customized toleration for nodes.
 
 ### Deploy driver
+
 You may deploy the EBS CSI driver via Kustomize, Helm, or as an [Amazon EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html).
 
 #### Kustomize
+
 ```sh
 kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.17"
 ```
@@ -52,13 +60,16 @@ kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernete
 *Note: Using the master branch to deploy the driver is not supported as the master branch may contain upcoming features incompatible with the currently released stable version of the driver.*
 
 #### Helm
-- Add the `aws-ebs-csi-driver` Helm repository.
+
+* Add the `aws-ebs-csi-driver` Helm repository.
+
 ```sh
 helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
 helm repo update
 ```
 
-- Install the latest release of the driver.
+* Install the latest release of the driver.
+
 ```sh
 helm upgrade --install aws-ebs-csi-driver \
     --namespace kube-system \
@@ -67,17 +78,20 @@ helm upgrade --install aws-ebs-csi-driver \
 
 Review the [configuration values](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.yaml) for the Helm chart.
 
-#### Once the driver has been deployed, verify the pods are running:
+#### Once the driver has been deployed, verify the pods are running
+
 ```sh
 kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
 ```
 
 ### Upgrading from version 1.X to 2.X of the Helm chart
+
 Version 2.0.0 removed support for Helm v2 and now requires Helm v3 or above.
 
 The [CSI Snapshotter](https://github.com/kubernetes-csi/external-snapshotter) controller and CRDs will no longer be installed as part of this chart and moving forward will be a prerequisite of using the snap shotting functionality.
 
 The following deprecated values have been removed and users upgrading from version 1.x must now use their counterparts under the `controller` and `node` maps.
+
 * affinity
 * extraCreateMetadata
 * extraVolumeTags
@@ -96,6 +110,7 @@ The values under `serviceAccount.controller` have been relocated to `controller.
 The values under `serviceAccount.node` have been relocated to `node.serviceAccount`
 
 The following `sidecars` values have been reorganized from
+
 ```yaml
 sidecars:
   provisionerImage:
@@ -105,7 +120,9 @@ sidecars:
   resizerImage:
   nodeDriverRegistrarImage:
 ```
+
 to
+
 ```yaml
 sidecars:
   provisioner:
@@ -123,6 +140,7 @@ sidecars:
 ```
 
 With the above reorganization `controller.containerResources`, `controller.env`, `node.containerResources`, and `node.env` were also moved into the sidecars structure as follows
+
 ```yaml
 sidecars:
   provisioner:
@@ -145,11 +163,14 @@ sidecars:
 ```
 
 ## Migrating from in-tree EBS plugin
+
 Starting from Kubernetes 1.17, CSI migration is supported as beta feature (alpha since 1.14). If you have persistent volumes that are created with in-tree `kubernetes.io/aws-ebs` plugin, you can migrate to use EBS CSI driver. To turn on the migration, set `CSIMigration` and `CSIMigrationAWS` feature gates to `true` for `kube-controller-manager`. Then drain Nodes and set the same feature gates to `true` for `kubelet`.
 
 To make sure dynamically provisioned EBS volumes have all tags that the in-tree volume plugin used:
+
 * Run the external-provisioner sidecar with `--extra-create-metadata=true` cmdline option. The Helm chart sets this option true by default.
 * Run the CSI driver with `--k8s-tag-cluster-id=<ID of the Kubernetes cluster>` command line option.
 
 **Warning**:
+
 * kubelet *must* be drained of all pods with mounted EBS volumes ***before*** changing its CSI migration feature flags.  Failure to do this will cause deleted pods to get stuck in `Terminating`, requiring a forced delete which can cause filesystem corruption. See [#679](../../../issues/679) for more details.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feature
**What is this PR about? / Why do we need it?**
Allow user set customized aws access secret name in Helm values, the default secret name in value set to `aws-secret` so this should not break existing workflows.
close #1492 
**What testing is done?** 
Helm dry-run checked, manifests correctly parsed