### PR TITLE
configure lievness probe check for node-driver-registrar

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -117,11 +117,21 @@ spec:
             {{- with .Values.sidecars.nodeDriverRegistrar.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi
             - name: registration-dir
               mountPath: C:\registration
+            - name: probe-dir
+              mountPath: C:\var\lib\kubelet\plugins\ebs.csi.aws.com
           {{- with default .Values.node.resources .Values.sidecars.nodeDriverRegistrar.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -169,4 +179,6 @@ spec:
           hostPath:
             path: \\.\pipe\csi-proxy-filesystem-v1
             type: ""
+        - name: probe-dir
+          emptyDir: {}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -129,11 +129,21 @@ spec:
             {{- with .Values.controller.envFrom }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+            - name: probe-dir
+              mountPath: {{ printf "%s/plugins/ebs.csi.aws.com/" (trimSuffix "/" .Values.node.kubeletPath) }}
           {{- with default .Values.node.resources .Values.sidecars.nodeDriverRegistrar.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -185,3 +195,5 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: probe-dir
+          emptyDir: {}

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -102,11 +102,21 @@ spec:
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
           envFrom:
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+            - name: probe-dir
+              mountPath: /var/lib/kubelet/plugins/ebs.csi.aws.com/
           resources:
             limits:
               cpu: 100m
@@ -153,3 +163,5 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: probe-dir
+          emptyDir: {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Feature
**What is this PR about? / Why do we need it?**
Adding configure map for liveness-probe check in node-driver-registrar
**What testing is done?** 
Block the CSI socket `/csi/csi.sock` access, after `csi-node` pod start up, `node-driver-registrar` reports log as following:
```
I0413 21:54:55.333415       1 main.go:167] Version: v2.7.0
I0413 21:54:55.333449       1 main.go:168] Running node-driver-registrar in mode=registration
I0413 21:54:55.333810       1 main.go:192] Attempting to open a gRPC connection with: "/csi/csi"
W0413 21:55:05.334651       1 connection.go:173] Still connecting to unix:///csi/csi.sock
W0413 21:55:15.334376       1 connection.go:173] Still connecting to unix:///csi/csi.sock
W0413 21:55:25.333936       1 connection.go:173] Still connecting to unix:///csi/csi.sock
W0413 21:55:35.334818       1 connection.go:173] Still connecting to unix:///csi/csi.sock
```
After 30s initial delay, `csi-node` pod get restarted as node failed to register:
```
NAME                                  READY   STATUS    RESTARTS      AGE
ebs-csi-controller-7b4cd58f49-2rl5h   5/5     Running   0             67m
ebs-csi-controller-7b4cd58f49-679fg   5/5     Running   0             67m
ebs-csi-node-5zsdw                    3/3     Running   2 (44s ago)   2m25s
ebs-csi-node-bjpr2                    3/3     Running   2 (42s ago)   2m23s
ebs-csi-node-ppq9v                    3/3     Running   2 (27s ago)   2m28s
ebs-csi-node-q5ht5                    3/3     Running   2 (26s ago)   2m26s
```
Without liveness probe configured, csi-node pod running without further action.
