### PR TITLE
Allow customize secret name and keys in Helm Chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -101,18 +101,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
-                  key: key_id
+                  name: {{ .name }}
+                  key: {{ .keyId }}
                   optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aws-secret
-                  key: access_key
+                  name: {{ .name }}
+                  key: {{ .accessKey }}
                   optional: true
+            {{- end }}
             - name: AWS_EC2_ENDPOINT
               valueFrom:
                 configMapKeyRef:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -109,6 +109,11 @@ imagePullSecrets: []
 nameOverride:
 fullnameOverride:
 
+awsAccessSecret: 
+  name: aws-secret
+  keyId: key_id
+  accessKey: access_key
+
 controller:
   additionalArgs: []
   sdkDebugLog: false

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,7 +30,8 @@ For more information, review ["Creating the Amazon EBS CSI driver IAM role for s
 There are several methods to grant the driver IAM permissions:
 * Using IAM [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) - attach the policy to the instance profile IAM role and turn on access to [instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the instance(s) on which the driver Deployment will run
 * EKS only: Using [IAM roles for ServiceAccounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) - create an IAM role, attach the policy to it, then follow the IRSA documentation to associate the IAM role with the driver Deployment service account, which if you are installing via Helm is determined by value `controller.serviceAccount.name`, `ebs-csi-controller-sa` by default
-* Using secret object - create an IAM user, attach the policy to it, then create a generic secret called `aws-secret` in the `kube-system` namespace with the user's credentials
+* Using secret object - create an IAM user, attach the policy to it, create a generic secret with a customized name (by default it will be `aws-secret`) in the `kube-system` namespace with the user's credentials, and configure the secret name for Helm by setting `Value.awsAccessSecret.name` to the customized secret name. Or use an existing secret with aws access key by configuring `Value.awsAccessSecret.name`, `Value.awsAccessSecret.keyId` with the key of the AWS_ACCESS_KEY_ID, and `Value.awsAccessSecret.accessKey` with the key of the AWS_SECRET_ACCESS_KEY.
+
 ```sh
 kubectl create secret generic aws-secret \
     --namespace kube-system \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
 feature
**What is this PR about? / Why do we need it?**
 close #1492
This PR allows user to customize the aws-access secret name and it's keys, and configure the driver's access_key with existing secret

**What testing is done?** 
manifest parsed correctly with dry run