### PR TITLE
Use K8s `stable-1.27` for External Storage tests on Windows

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -222,6 +222,9 @@ else
   if [[ $TEST_PATH == "./tests/e2e-kubernetes/..." ]]; then
     pushd ${PWD}/tests/e2e-kubernetes
     packageVersion=$(echo $(cut -d '.' -f 1,2 <<< $K8S_VERSION))
+    if [[ "${WINDOWS}" == true ]]; then
+      packageVersion="1.27"
+    fi
 
     set -x
     set +e


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- For `kubetest2`, the `--test-package-version` should be set to 1.27 for Windows as this version of K8s released the changes necessary to run the External Storage testing pods on a EKS Windows nodegroup: https://github.com/kubernetes/kubernetes/pull/115443

**What testing is done?** 
```
CLUSTER_TYPE=eksctl HELM_VALUES_FILE=./hack/values_eksctl.yaml make test-e2e-external-eks-windows
```