### PR TITLE
Fix e2e test flakes due to volume node affinity conflict

### DIFF
--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -140,23 +140,26 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 	})
 
 	It("should create multiple PV objects, bind to PVCs and attach all to a single pod", func() {
+		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "echo 'hello world' > /mnt/test-1/data && echo 'hello world' > /mnt/test-2/data && grep 'hello world' /mnt/test-1/data  && grep 'hello world' /mnt/test-2/data",
 				Volumes: []testsuites.VolumeDetails{
 					{
-						VolumeType: awscloud.VolumeTypeGP2,
-						FSType:     ebscsidriver.FSTypeExt3,
-						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP2),
+						VolumeType:        awscloud.VolumeTypeGP2,
+						FSType:            ebscsidriver.FSTypeExt3,
+						VolumeBindingMode: &volumeBindingMode,
+						ClaimSize:         driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP2),
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
 						},
 					},
 					{
-						VolumeType: awscloud.VolumeTypeIO1,
-						FSType:     ebscsidriver.FSTypeExt4,
-						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO1),
+						VolumeType:        awscloud.VolumeTypeIO1,
+						FSType:            ebscsidriver.FSTypeExt4,
+						ClaimSize:         driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO1),
+						VolumeBindingMode: &volumeBindingMode,
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
@@ -236,25 +239,28 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 	})
 
 	It("should create a raw block volume and a filesystem volume on demand and bind to the same pod", func() {
+		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 		pods := []testsuites.PodDetails{
 			{
 				Cmd: "dd if=/dev/zero of=/dev/xvda bs=1024k count=100 && echo 'hello world' > /mnt/test-1/data && grep 'hello world' /mnt/test-1/data",
 				Volumes: []testsuites.VolumeDetails{
 					{
-						VolumeType: awscloud.VolumeTypeIO1,
-						FSType:     ebscsidriver.FSTypeExt4,
-						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO1),
+						VolumeType:        awscloud.VolumeTypeIO1,
+						FSType:            ebscsidriver.FSTypeExt4,
+						ClaimSize:         driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO1),
+						VolumeBindingMode: &volumeBindingMode,
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
 						},
 					},
 					{
-						VolumeType:   awscloud.VolumeTypeGP2,
-						FSType:       ebscsidriver.FSTypeExt4,
-						MountOptions: []string{"rw"},
-						ClaimSize:    driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP2),
-						VolumeMode:   testsuites.Block,
+						VolumeType:        awscloud.VolumeTypeGP2,
+						FSType:            ebscsidriver.FSTypeExt4,
+						MountOptions:      []string{"rw"},
+						ClaimSize:         driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP2),
+						VolumeBindingMode: &volumeBindingMode,
+						VolumeMode:        testsuites.Block,
 						VolumeDevice: testsuites.VolumeDeviceDetails{
 							NameGenerate: "test-block-volume-",
 							DevicePath:   "/dev/xvda",


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
- Bug fix.

**What is this PR about? / Why do we need it?**
- closes #1559 

**What testing is done?** 
```
$ ginkgo run --until-it-fails \
  --focus='should create multiple PV objects, bind to PVCs and attach all to a single pod' \
  --focus='should create a raw block volume and a filesystem volume on demand and bind to the same pod' \
  tests/e2e
  
Will run 2 of 33 specs
SSSSSSSSSSSSSSS•SS•SSSSSSSSSSSSSS

Ran 2 of 33 Specs in 60.476 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 31 Skipped
PASS

All tests passed...
Will keep running them until they fail.
This was attempt #50
No, seriously... you can probably stop now.
```
