### PR TITLE
Adds autoscaler annotation to the controller

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -167,7 +167,11 @@ controller:
   k8sTagClusterId:
   logLevel: 2
   nodeSelector: {}
-  podAnnotations: {}
+  podAnnotations: 
+    # Default allows the cluster-autoscaler to relocate the controller in accordance with the PDB 
+    # https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node 
+    cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: "socket-dir"
+
   podLabels: {}
   priorityClassName: system-cluster-critical
   # AWS region to use. If not specified then the region will be looked up via the AWS EC2 metadata


### PR DESCRIPTION
Adds a pod annotation that allows the cluster-autoscaler to relocate the ebs-csi-controller while still complying with the pod disruption budget.  This is still a fairly [new annotation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node), as in we had to build the cluster-autoscaler from source to confirm this works. The next release of the autoscaler should include it. 

In terms of why we're trying to add this -- we've noticed in our clusters that occasionally the controller prevents the cluster-autoscaler from reaping an under-utilized node. We're using the EKS managed add-on, which I believe uses this chart. The add-on configuration API doesn't seem to allow us to pass extra pod annotations like this, so hoping we can fix it in the chart or at least flag it here to see if this can get added to the EKS API :)
