### PR TITLE
remove condition on iopspergb key being mandatory for io1 volumes

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -214,12 +214,6 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	if volumeType == cloud.VolumeTypeIO1 {
-		if iopsPerGB == 0 {
-			return nil, status.Errorf(codes.InvalidArgument, "The parameter IOPSPerGB must be specified for io1 volumes")
-		}
-	}
-
 	if blockExpress && volumeType != cloud.VolumeTypeIO2 {
 		return nil, status.Errorf(codes.InvalidArgument, "Block Express is only supported on io2 volumes")
 	}


### PR DESCRIPTION
Condition on iopsPerGB key being mandatory for io1 volumes introduced by https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/767 is irrelevant and should be removed as it's possible to create a io1 volume by specifying the desired number of iops.

```
$ aws ec2 create-volume --availability-zone eu-west-3a --iops 1337 --size 100 --volume-type io1
{
    "AvailabilityZone": "eu-west-3a",
    "CreateTime": "2023-05-04T12:30:04+00:00",
    "Encrypted": false,
    "Size": 100,
    "SnapshotId": "",
    "State": "creating",
    "VolumeId": "vol-0cba6d099003264f2",
    "Iops": 1337,
    "Tags": [],
    "VolumeType": "io1",
    "MultiAttachEnabled": false
}
```

The documentation updated by https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1409 is also already mentioning that iopPerGB **or** iops can be used for io1 volumes but it's today impossible to use the iops key because of this condition.