### PR TITLE
Use dl.k8s.io instead of kubernetes-release bucket

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -211,7 +211,7 @@ spec:
             SNAPSHOTS="|snapshot fields"
           fi
           export FOCUS_REGEX="\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data$SNAPSHOTS)"
-          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl https://storage.googleapis.com/kubernetes-release/release/stable-1.25.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
+          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl -L https://dl.k8s.io/release/stable-1.25.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -234,7 +234,7 @@ else
       -- \
       --skip-regex="${GINKGO_SKIP}" \
       --focus-regex="${GINKGO_FOCUS}" \
-      --test-package-version=$(curl https://storage.googleapis.com/kubernetes-release/release/stable-$packageVersion.txt) \
+      --test-package-version=$(curl -L https://dl.k8s.io/release/stable-$packageVersion.txt) \
       --parallel=${GINKGO_PARALLEL} \
       --test-args="-storage.testdriver=${PWD}/manifests.yaml -kubeconfig=$KUBECONFIG -node-os-distro=${NODE_OS_DISTRO}"
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This PR replaces references of https://storage.googleapis.com/kubernetes-release with https://dl.k8s.io/

**What is this PR about? / Why do we need it?**
https://github.com/kubernetes/k8s.io/issues/2396
**What testing is done?** 
