### PR TITLE
Drop support for Windows 20H2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,6 @@ FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:lat
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 
-FROM mcr.microsoft.com/windows/servercore:20H2 AS windows-20H2
-COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
-ENTRYPOINT ["/aws-ebs-csi-driver.exe"]
-
 FROM mcr.microsoft.com/windows/servercore:ltsc2019 AS windows-ltsc2019
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ALL_OSVERSION_linux?=amazon
 ALL_OS_ARCH_OSVERSION_linux=$(foreach arch, $(ALL_ARCH_linux), $(foreach osversion, ${ALL_OSVERSION_linux}, linux-$(arch)-${osversion}))
 
 ALL_ARCH_windows?=amd64
-ALL_OSVERSION_windows?=20H2 ltsc2019 ltsc2022
+ALL_OSVERSION_windows?=ltsc2019 ltsc2022
 ALL_OS_ARCH_OSVERSION_windows=$(foreach arch, $(ALL_ARCH_windows), $(foreach osversion, ${ALL_OSVERSION_windows}, windows-$(arch)-${osversion}))
 
 ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

As mentioned in the [release notes](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md), v1.18.0 is the last minor release of the AWS EBS CSI Driver to support Windows 20H2.


