### PR TITLE
Update logline to remove "formatted"

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -238,7 +238,7 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	}
 
 	// FormatAndMount will format only if needed
-	klog.V(4).InfoS("NodeStageVolume: formatting and mounting with fstype", "source", source, "volumeID", volumeID, "target", target, "fstype", fsType)
+	klog.V(4).InfoS("NodeStageVolume: staging volume", "source", source, "volumeID", volumeID, "target", target, "fstype", fsType)
 	formatOptions := []string{}
 	if len(blockSize) > 0 {
 		if fsType == FSTypeXfs {
@@ -267,7 +267,7 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 			return nil, status.Errorf(codes.Internal, "Could not resize volume %q (%q):  %v", volumeID, source, err)
 		}
 	}
-	klog.V(4).InfoS("NodeStageVolume: successfully formatted and mounted volume", "source", source, "volumeID", volumeID, "target", target, "fstype", fsType)
+	klog.V(4).InfoS("NodeStageVolume: successfully staged volume", "source", source, "volumeID", volumeID, "target", target, "fstype", fsType)
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Just updating a logline.

**What is this PR about? / Why do we need it?**

This code path is always hit when mounting, even when the filesystem was already present, and we just mount it.

Reading these log lines for existing PVCs makes my heart miss a beat, when I realize that the volume was indeed not formatted before mounting. If its being formatted, its already present in logs above when on v=4.

**What testing is done?** 

n/a