### PR TITLE
Revert Increase external test pod start timeout #1586

### DIFF
--- a/tests/e2e-kubernetes/manifests.yaml
+++ b/tests/e2e-kubernetes/manifests.yaml
@@ -30,5 +30,3 @@ DriverInfo:
     nodeExpansion: true
     volumeLimits: true
     topology: true
-Timeouts:
-  PodStart: 10m


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Pod start timeout was increased in #1586 due to constant CI flakes, that issue has now been resolved.

This PR reverts the pod start timeout change to use the default timeout of 5 minutes.