### PR TITLE
chore: Allow to set automountServiceAccountToken in ServiceAccount

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -15,4 +15,7 @@ metadata:
   #annotations:
   #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
   {{- end }}
+{{- if .Values.controller.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -10,4 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if .Values.node.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.node.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 {{- end -}}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -227,6 +227,7 @@ controller:
     create: true
     name: ebs-csi-controller-sa
     annotations: {}
+    automountServiceAccountToken: true
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
@@ -300,6 +301,7 @@ node:
     create: true
     name: ebs-csi-node-sa
     annotations: {}
+    automountServiceAccountToken: true
   enableWindows: false
   # The "maximum number of attachable volumes" per node
   volumeAttachLimit:

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -9,3 +9,4 @@ metadata:
   #Enable if EKS IAM roles for service accounts (IRSA) is used. See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
   #annotations:
   #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
+automountServiceAccountToken: true

--- a/deploy/kubernetes/base/serviceaccount-csi-node.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-node.yaml
@@ -6,3 +6,4 @@ metadata:
   name: ebs-csi-node-sa
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
+automountServiceAccountToken: true

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,8 @@ For more information, review ["Creating the Amazon EBS CSI driver IAM role for s
 
 There are several methods to grant the driver IAM permissions:
 * Using IAM [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) - attach the policy to the instance profile IAM role and turn on access to [instance metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for the instance(s) on which the driver Deployment will run
-* EKS only: Using [IAM roles for ServiceAccounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) - create an IAM role, attach the policy to it, then follow the IRSA documentation to associate the IAM role with the driver Deployment service account, which if you are installing via Helm is determined by value `controller.serviceAccount.name`, `ebs-csi-controller-sa` by default
+* EKS only: Using [IAM roles for ServiceAccounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) - create an IAM role, attach the policy to it, then follow the IRSA documentation to associate the IAM role with the driver Deployment service account, which if you are installing via Helm is determined by value `controller.serviceAccount.name`, `ebs-csi-controller-sa` by default. If you are using k8s 1.24 or higher, the ServiceAccountToken is not mounted because the `LegacyServiceAccountTokenNoAutoGeneration` feature gate is enabled.
+Therefore, if you are using k8s 1.24 or higher, you need to set `true` to `controller.serviceAccount.autoMountServiceAccountToken`.
 * Using secret object - create an IAM user, attach the policy to it, then create a generic secret called `aws-secret` in the `kube-system` namespace with the user's credentials
 ```sh
 kubectl create secret generic aws-secret \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

new feature

**What is this PR about? / Why do we need it?**

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes

> The LegacyServiceAccountTokenNoAutoGeneration feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every ServiceAccount. Use the [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this [guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets). (https://github.com/kubernetes/kubernetes/pull/108309, [@zshihang](https://github.com/zshihang))

Since k8s 1.24, TOKEN is not mounted automatically.
If you want to access with IRSA, you need to use a token.

Allow to set automountServiceAccountToken in ServiceAccount
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/

**What testing is done?** 

done.
