### PR TITLE
* Fix CVE's in glibc, zlib in amazon-linux latest.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG TARGETARCH
 ARG VERSION
 RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest.2 AS linux-amazon
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al23 AS linux-amazon
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a CVE fix in glibc 2.26 version
**What is this PR about? / Why do we need it?**
Upgrading amazon-linux to latest image which has glibc-2.34 and latest zlib
**What testing is done?** 
```
make image
trivy image --scanners vuln gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:ed338464d5cd73d7bdbb5cf711c3e3cbf8078456-linux-amd64-amazon

2023-05-31T21:28:45.460+0530	INFO	Vulnerability scanning is enabled
2023-05-31T21:28:46.925+0530	INFO	Detected OS: amazon
2023-05-31T21:28:46.925+0530	INFO	Detecting Amazon Linux vulnerabilities...
2023-05-31T21:28:46.933+0530	INFO	Number of language-specific files: 1
2023-05-31T21:28:46.933+0530	INFO	Detecting gobinary vulnerabilities...

aws-ebs-csi-driver:v1.20.0 (amazon 2023 (Amazon Linux))

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/bin/aws-ebs-csi-driver (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 1, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌───────────────────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│          Library          │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├───────────────────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ github.com/aws/aws-sdk-go │ CVE-2020-8911 │ MEDIUM   │ v1.44.262         │               │ aws/aws-sdk-go: CBC padding oracle issue in AWS S3 Crypto  │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8911                  │
│                           ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│                           │ CVE-2020-8912 │ LOW      │                   │               │ aws-sdk-go: In-band key negotiation issue in AWS S3 Crypto │
│                           │               │          │                   │               │ SDK for golang...                                          │
│                           │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2020-8912                  │
└───────────────────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```