### PR TITLE
Fix context handling in WaitForVolumeAttachment & add in-flight checks to attachment/detachment operations

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -628,7 +628,7 @@ func (c *cloud) WaitForAttachmentState(ctx context.Context, volumeID, expectedSt
 
 	var attachment *ec2.VolumeAttachment
 
-	verifyVolumeFunc := func() (bool, error) {
+	verifyVolumeFunc := func(ctx context.Context) (bool, error) {
 		request := &ec2.DescribeVolumesInput{
 			VolumeIds: []*string{
 				aws.String(volumeID),
@@ -710,11 +710,11 @@ func (c *cloud) WaitForAttachmentState(ctx context.Context, volumeID, expectedSt
 			return true, nil
 		}
 		// continue waiting
-		klog.V(2).InfoS("Waiting for volume state", "volumeID", volumeID, "actual", attachmentState, "desired", expectedState)
+		klog.V(4).InfoS("Waiting for volume state", "volumeID", volumeID, "actual", attachmentState, "desired", expectedState)
 		return false, nil
 	}
 
-	return attachment, wait.ExponentialBackoff(backoff, verifyVolumeFunc)
+	return attachment, wait.ExponentialBackoffWithContext(ctx, backoff, verifyVolumeFunc)
 }
 
 func (c *cloud) GetDiskByName(ctx context.Context, name string, capacityBytes int64) (*Disk, error) {

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -32,12 +32,16 @@ import (
 	"github.com/golang/mock/gomock"
 	dm "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/devicemanager"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
-	defaultZone = "test-az"
-	expZone     = "us-west-2b"
-	snowZone    = "snow"
+	defaultZone     = "test-az"
+	expZone         = "us-west-2b"
+	snowZone        = "snow"
+	defaultVolumeID = "vol-test-1234"
+	defaultNodeID   = "node-1234"
+	defaultPath     = "/dev/xvdaa"
 )
 
 func TestCreateDisk(t *testing.T) {
@@ -711,25 +715,78 @@ func TestAttachDisk(t *testing.T) {
 		name     string
 		volumeID string
 		nodeID   string
+		path     string
 		expErr   error
+		mockFunc func(*MockEC2API, context.Context, string, string, string, dm.DeviceManager)
 	}{
 		{
-			name:     "success: normal",
-			volumeID: "vol-test-1234",
-			nodeID:   "node-1234",
+			name:     "success: AttachVolume normal",
+			volumeID: defaultVolumeID,
+			nodeID:   defaultNodeID,
+			path:     defaultPath,
 			expErr:   nil,
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, path string, dm dm.DeviceManager) {
+				volumeRequest := createVolumeRequest(volumeID)
+				instanceRequest := createInstanceRequest(nodeID)
+				attachRequest := createAttachRequest(volumeID, nodeID, path)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().AttachVolumeWithContext(ctx, attachRequest).Return(createAttachVolumeOutput(volumeID, nodeID, path, "attached"), nil),
+					mockEC2.EXPECT().DescribeVolumesWithContext(ctx, volumeRequest).Return(createDescribeVolumesOutput(volumeID, nodeID, path, "attached"), nil),
+				)
+			},
+		},
+		{
+			name:     "success: AttachVolume device already assigned",
+			volumeID: defaultVolumeID,
+			nodeID:   defaultNodeID,
+			path:     defaultPath,
+			expErr:   nil,
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, path string, dm dm.DeviceManager) {
+				volumeRequest := createVolumeRequest(volumeID)
+				instanceRequest := createInstanceRequest(nodeID)
+
+				fakeInstance := newFakeInstance(nodeID, volumeID, path)
+				_, err := dm.NewDevice(fakeInstance, volumeID)
+				assert.NoError(t, err)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID, volumeID), nil),
+					mockEC2.EXPECT().DescribeVolumesWithContext(ctx, volumeRequest).Return(createDescribeVolumesOutput(volumeID, nodeID, path, "attached"), nil))
+			},
 		},
 		{
 			name:     "fail: AttachVolume returned generic error",
-			volumeID: "vol-test-1234",
-			nodeID:   "node-1234",
-			expErr:   fmt.Errorf(""),
+			volumeID: defaultVolumeID,
+			nodeID:   defaultNodeID,
+			path:     defaultPath,
+			expErr:   fmt.Errorf("could not attach volume %q to node %q: %w", defaultVolumeID, defaultNodeID, errors.New("AttachVolume error")),
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, path string, dm dm.DeviceManager) {
+				instanceRequest := createInstanceRequest(nodeID)
+				attachRequest := createAttachRequest(volumeID, nodeID, path)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().AttachVolumeWithContext(ctx, attachRequest).Return(nil, errors.New("AttachVolume error")),
+				)
+			},
 		},
 		{
 			name:     "fail: AttachVolume returned error volumeInUse",
-			volumeID: "vol-test-1234",
-			nodeID:   "node-1234",
-			expErr:   awserr.New("VolumeInUse", "Volume is in use", nil),
+			volumeID: defaultVolumeID,
+			nodeID:   defaultNodeID,
+			path:     defaultPath,
+			expErr:   fmt.Errorf("could not attach volume %q to node %q: %w", defaultVolumeID, defaultNodeID, ErrVolumeInUse),
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, path string, dm dm.DeviceManager) {
+				instanceRequest := createInstanceRequest(nodeID)
+				attachRequest := createAttachRequest(volumeID, nodeID, path)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().AttachVolumeWithContext(ctx, attachRequest).Return(nil, ErrVolumeInUse),
+				)
+			},
 		},
 	}
 
@@ -739,28 +796,19 @@ func TestAttachDisk(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			vol := &ec2.Volume{
-				VolumeId:    aws.String(tc.volumeID),
-				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("node-1234"), State: aws.String("attached")}},
-			}
-
 			ctx := context.Background()
-			mockEC2.EXPECT().DescribeVolumesWithContext(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []*ec2.Volume{vol}}, nil).AnyTimes()
-			mockEC2.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any()).Return(newDescribeInstancesOutput(tc.nodeID), nil)
-			mockEC2.EXPECT().AttachVolumeWithContext(gomock.Any(), gomock.Any()).Return(&ec2.VolumeAttachment{}, tc.expErr)
+			dm := c.(*cloud).dm
+
+			tc.mockFunc(mockEC2, ctx, tc.volumeID, tc.nodeID, tc.path, dm)
 
 			devicePath, err := c.AttachDisk(ctx, tc.volumeID, tc.nodeID)
-			if err != nil {
-				if tc.expErr == nil {
-					t.Fatalf("AttachDisk() failed: expected no error, got: %v", err)
-				}
+
+			if tc.expErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expErr, err)
 			} else {
-				if tc.expErr != nil {
-					t.Fatal("AttachDisk() failed: expected error, got nothing")
-				}
-				if !strings.HasPrefix(devicePath, "/dev/") {
-					t.Fatal("AttachDisk() failed: expected valid device path, got empty string")
-				}
+				assert.NoError(t, err)
+				assert.Equal(t, tc.path, devicePath)
 			}
 
 			mockCtrl.Finish()
@@ -774,24 +822,54 @@ func TestDetachDisk(t *testing.T) {
 		volumeID string
 		nodeID   string
 		expErr   error
+		mockFunc func(*MockEC2API, context.Context, string, string)
 	}{
 		{
-			name:     "success: normal",
+			name:     "success: DetachDisk normal",
 			volumeID: "vol-test-1234",
 			nodeID:   "node-1234",
 			expErr:   nil,
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID string) {
+				volumeRequest := createVolumeRequest(volumeID)
+				instanceRequest := createInstanceRequest(nodeID)
+				detachRequest := createDetachRequest(volumeID, nodeID)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().DetachVolumeWithContext(ctx, detachRequest).Return(nil, nil),
+					mockEC2.EXPECT().DescribeVolumesWithContext(ctx, volumeRequest).Return(createDescribeVolumesOutput(volumeID, nodeID, "", "detached"), nil),
+				)
+			},
 		},
 		{
 			name:     "fail: DetachVolume returned generic error",
 			volumeID: "vol-test-1234",
 			nodeID:   "node-1234",
-			expErr:   fmt.Errorf("DetachVolume generic error"),
+			expErr:   fmt.Errorf("could not detach volume %q from node %q: %w", defaultVolumeID, defaultNodeID, errors.New("DetachVolume error")),
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID string) {
+				instanceRequest := createInstanceRequest(nodeID)
+				detachRequest := createDetachRequest(volumeID, nodeID)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().DetachVolumeWithContext(ctx, detachRequest).Return(nil, errors.New("DetachVolume error")),
+				)
+			},
 		},
 		{
 			name:     "fail: DetachVolume returned not found error",
 			volumeID: "vol-test-1234",
 			nodeID:   "node-1234",
-			expErr:   fmt.Errorf("DetachVolume not found error"),
+			expErr:   fmt.Errorf("could not detach volume %q from node %q: %w", defaultVolumeID, defaultNodeID, ErrNotFound),
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID string) {
+				instanceRequest := createInstanceRequest(nodeID)
+				detachRequest := createDetachRequest(volumeID, nodeID)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().DetachVolumeWithContext(ctx, detachRequest).Return(nil, ErrNotFound),
+				)
+			},
 		},
 	}
 
@@ -801,30 +879,16 @@ func TestDetachDisk(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			vol := &ec2.Volume{
-				VolumeId:    aws.String(tc.volumeID),
-				Attachments: nil,
-			}
-
 			ctx := context.Background()
-			mockEC2.EXPECT().DescribeVolumesWithContext(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []*ec2.Volume{vol}}, nil).AnyTimes()
-			mockEC2.EXPECT().DescribeInstancesWithContext(gomock.Any(), gomock.Any()).Return(newDescribeInstancesOutput(tc.nodeID), nil)
-			switch tc.name {
-			case "fail: DetachVolume returned not found error":
-				mockEC2.EXPECT().DetachVolumeWithContext(gomock.Any(), gomock.Any()).Return(nil, awserr.New("InvalidVolume.NotFound", "foo", fmt.Errorf("")))
-			default:
-				mockEC2.EXPECT().DetachVolumeWithContext(gomock.Any(), gomock.Any()).Return(&ec2.VolumeAttachment{}, tc.expErr)
-			}
+			tc.mockFunc(mockEC2, ctx, tc.volumeID, tc.nodeID)
 
 			err := c.DetachDisk(ctx, tc.volumeID, tc.nodeID)
-			if err != nil {
-				if tc.expErr == nil {
-					t.Fatalf("DetachDisk() failed: expected no error, got: %v", err)
-				}
+
+			if tc.expErr != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expErr, err)
 			} else {
-				if tc.expErr != nil {
-					t.Fatal("DetachDisk() failed: expected error, got nothing")
-				}
+				assert.NoError(t, err)
 			}
 
 			mockCtrl.Finish()
@@ -1846,6 +1910,15 @@ func TestWaitForAttachmentState(t *testing.T) {
 			alreadyAssigned:  false,
 			expectError:      true,
 		},
+		{
+			name:             "failure: context cancelled",
+			volumeID:         "vol-test-1234",
+			expectedState:    volumeAttachedState,
+			expectedInstance: "1234",
+			expectedDevice:   "/dev/xvdaa",
+			alreadyAssigned:  false,
+			expectError:      true,
+		},
 	}
 
 	volumeAttachmentStatePollSteps = 1
@@ -1876,7 +1949,8 @@ func TestWaitForAttachmentState(t *testing.T) {
 				Attachments: []*ec2.VolumeAttachment{{Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1235"), State: aws.String("attached")}, {Device: aws.String("/dev/xvdaa"), InstanceId: aws.String("1234"), State: aws.String("attached")}},
 			}
 
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			switch tc.name {
 			case "success: detached", "failure: already assigned but wrong state":
@@ -1887,11 +1961,15 @@ func TestWaitForAttachmentState(t *testing.T) {
 				mockEC2.EXPECT().DescribeVolumesWithContext(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []*ec2.Volume{multipleAttachmentsVol}}, nil).AnyTimes()
 			case "failure: disk still attaching":
 				mockEC2.EXPECT().DescribeVolumesWithContext(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []*ec2.Volume{attachingVol}}, nil).AnyTimes()
+			case "failure: context cancelled":
+				mockEC2.EXPECT().DescribeVolumesWithContext(ctx, gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []*ec2.Volume{attachingVol}}, nil).AnyTimes()
+				cancel()
 			default:
 				mockEC2.EXPECT().DescribeVolumesWithContext(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []*ec2.Volume{attachedVol}}, nil).AnyTimes()
 			}
 
 			attachment, err := c.WaitForAttachmentState(ctx, tc.volumeID, tc.expectedState, tc.expectedInstance, tc.expectedDevice, tc.alreadyAssigned)
+
 			if tc.expectError {
 				if err == nil {
 					t.Fatal("WaitForAttachmentState() failed: expected error, got nothing")
@@ -1923,13 +2001,99 @@ func newCloud(mockEC2 ec2iface.EC2API) Cloud {
 	}
 }
 
-func newDescribeInstancesOutput(nodeID string) *ec2.DescribeInstancesOutput {
-	return &ec2.DescribeInstancesOutput{
-		Reservations: []*ec2.Reservation{{
-			Instances: []*ec2.Instance{
-				{InstanceId: aws.String(nodeID)},
+func newDescribeInstancesOutput(nodeID string, volumeID ...string) *ec2.DescribeInstancesOutput {
+	instance := &ec2.Instance{
+		InstanceId: aws.String(nodeID),
+	}
+
+	if len(volumeID) > 0 && volumeID[0] != "" {
+		instance.BlockDeviceMappings = []*ec2.InstanceBlockDeviceMapping{
+			{
+				DeviceName: aws.String(defaultPath),
+				Ebs: &ec2.EbsInstanceBlockDevice{
+					VolumeId: aws.String(volumeID[0]),
+				},
 			},
-		}},
+		}
+	}
+
+	return &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					instance,
+				},
+			},
+		},
+	}
+}
+
+func newFakeInstance(instanceID, volumeID, devicePath string) *ec2.Instance {
+	return &ec2.Instance{
+		InstanceId: aws.String(instanceID),
+		BlockDeviceMappings: []*ec2.InstanceBlockDeviceMapping{
+			{
+				DeviceName: aws.String(devicePath),
+				Ebs:        &ec2.EbsInstanceBlockDevice{VolumeId: aws.String(volumeID)},
+			},
+		},
+	}
+}
+
+func createVolumeRequest(volumeID string) *ec2.DescribeVolumesInput {
+	return &ec2.DescribeVolumesInput{
+		VolumeIds: []*string{
+			aws.String(volumeID),
+		},
+	}
+}
+
+func createInstanceRequest(nodeID string) *ec2.DescribeInstancesInput {
+	return &ec2.DescribeInstancesInput{
+		InstanceIds: []*string{
+			aws.String(nodeID),
+		},
+	}
+}
+
+func createAttachRequest(volumeID, nodeID, path string) *ec2.AttachVolumeInput {
+	return &ec2.AttachVolumeInput{
+		Device:     aws.String(path),
+		InstanceId: aws.String(nodeID),
+		VolumeId:   aws.String(volumeID),
+	}
+}
+
+func createDetachRequest(volumeID, nodeID string) *ec2.DetachVolumeInput {
+	return &ec2.DetachVolumeInput{
+		VolumeId:   aws.String(volumeID),
+		InstanceId: aws.String(nodeID),
+	}
+}
+
+func createDescribeVolumesOutput(volumeID, nodeID, path, state string) *ec2.DescribeVolumesOutput {
+	return &ec2.DescribeVolumesOutput{
+		Volumes: []*ec2.Volume{
+			{
+				VolumeId: aws.String(volumeID),
+				Attachments: []*ec2.VolumeAttachment{
+					{
+						Device:     aws.String(path),
+						InstanceId: aws.String(nodeID),
+						State:      aws.String(state),
+					},
+				},
+			},
+		},
+	}
+}
+
+func createAttachVolumeOutput(volumeID, nodeID, path, state string) *ec2.VolumeAttachment {
+	return &ec2.VolumeAttachment{
+		VolumeId:   aws.String(volumeID),
+		Device:     aws.String(path),
+		InstanceId: aws.String(nodeID),
+		State:      aws.String(state),
 	}
 }
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -354,27 +354,20 @@ func (d *controllerService) ControllerPublishVolume(ctx context.Context, req *cs
 	volumeID := req.GetVolumeId()
 	nodeID := req.GetNodeId()
 
-	if !d.cloud.IsExistInstance(ctx, nodeID) {
-		return nil, status.Errorf(codes.NotFound, "Instance %q not found", nodeID)
+	if !d.inFlight.Insert(volumeID) {
+		return nil, status.Error(codes.Aborted, fmt.Sprintf(internal.VolumeOperationAlreadyExistsErrorMsg, volumeID))
 	}
-	disk, err := d.cloud.GetDiskByID(ctx, volumeID)
-	if err != nil {
-		if errors.Is(err, cloud.ErrNotFound) {
-			return nil, status.Error(codes.NotFound, "Volume not found")
-		}
-		return nil, status.Errorf(codes.Internal, "Could not get volume with ID %q: %v", volumeID, err)
-	}
+	defer d.inFlight.Delete(volumeID)
 
-	// If given volumeId already assigned to given node, will directly return current device path
+	klog.V(2).InfoS("ControllerPublishVolume: attaching", "volumeID", volumeID, "nodeID", nodeID)
 	devicePath, err := d.cloud.AttachDisk(ctx, volumeID, nodeID)
 	if err != nil {
 		if errors.Is(err, cloud.ErrVolumeInUse) {
-			return nil, status.Error(codes.FailedPrecondition, strings.Join(disk.Attachments, ","))
+			return nil, status.Errorf(codes.FailedPrecondition, "Volume %q is already attached to a different node, expected node: %q", volumeID, nodeID)
 		}
-		// TODO: Check volume capability matches for ALREADY_EXISTS
 		return nil, status.Errorf(codes.Internal, "Could not attach volume %q to node %q: %v", volumeID, nodeID, err)
 	}
-	klog.V(5).InfoS("[Debug] ControllerPublishVolume: attached to node", "volumeID", volumeID, "nodeID", nodeID, "devicePath", devicePath)
+	klog.V(2).InfoS("ControllerPublishVolume: attached", "volumeID", volumeID, "nodeID", nodeID, "devicePath", devicePath)
 
 	pvInfo := map[string]string{DevicePathKey: devicePath}
 	return &csi.ControllerPublishVolumeResponse{PublishContext: pvInfo}, nil
@@ -413,13 +406,20 @@ func (d *controllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	volumeID := req.GetVolumeId()
 	nodeID := req.GetNodeId()
 
+	if !d.inFlight.Insert(volumeID) {
+		return nil, status.Error(codes.Aborted, fmt.Sprintf(internal.VolumeOperationAlreadyExistsErrorMsg, volumeID))
+	}
+	defer d.inFlight.Delete(volumeID)
+
+	klog.V(2).InfoS("ControllerUnpublishVolume: detaching", "volumeID", volumeID, "nodeID", nodeID)
 	if err := d.cloud.DetachDisk(ctx, volumeID, nodeID); err != nil {
 		if errors.Is(err, cloud.ErrNotFound) {
+			klog.V(2).InfoS("ControllerUnpublishVolume: attachment not found", "volumeID", volumeID, "nodeID", nodeID)
 			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "Could not detach volume %q from node %q: %v", volumeID, nodeID, err)
 	}
-	klog.V(5).InfoS("[Debug] ControllerUnpublishVolume: detached from node", "volumeID", volumeID, "nodeID", nodeID)
+	klog.V(2).InfoS("ControllerUnpublishVolume: detached", "volumeID", volumeID, "nodeID", nodeID)
 
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -42,6 +43,7 @@ import (
 const (
 	expZone       = "us-west-2b"
 	expInstanceID = "i-123456789abcdef01"
+	expDevicePath = "/dev/xvda"
 )
 
 func TestNewControllerService(t *testing.T) {
@@ -3112,450 +3114,255 @@ func TestControllerPublishVolume(t *testing.T) {
 			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 		},
 	}
-	expDevicePath := "/dev/xvda"
 
 	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
+		name             string
+		volumeId         string
+		nodeId           string
+		volumeCapability *csi.VolumeCapability
+		mockAttach       func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string)
+		expResp          *csi.ControllerPublishVolumeResponse
+		errorCode        codes.Code
+		setupFunc        func(controllerService *controllerService)
 	}{
 		{
-			name: "success normal",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{
-					NodeId:           expInstanceID,
-					VolumeCapability: stdVolCap,
-					VolumeId:         "vol-test",
-				}
-				expResp := &csi.ControllerPublishVolumeResponse{
-					PublishContext: map[string]string{DevicePathKey: expDevicePath},
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().IsExistInstance(gomock.Eq(ctx), gomock.Eq(req.NodeId)).Return(true)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq(ctx), gomock.Any()).Return(&cloud.Disk{}, nil)
-				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Any(), gomock.Eq(req.NodeId)).Return(expDevicePath, nil)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				resp, err := awsDriver.ControllerPublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-
-				if !reflect.DeepEqual(resp, expResp) {
-					t.Fatalf("Expected resp to be %+v, got: %+v", expResp, resp)
-				}
+			name:             "AttachDisk successfully with valid volume ID, node ID, and volume capability",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), volumeId, gomock.Eq(nodeId)).Return(expDevicePath, nil)
 			},
+			expResp: &csi.ControllerPublishVolumeResponse{
+				PublishContext: map[string]string{DevicePathKey: expDevicePath},
+			},
+			errorCode: codes.OK,
 		},
 		{
-			name: "success when resource is not found",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerUnpublishVolumeRequest{
-					NodeId:   expInstanceID,
-					VolumeId: "vol-test",
-				}
-				expResp := &csi.ControllerUnpublishVolumeResponse{}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().DetachDisk(gomock.Eq(ctx), req.VolumeId, req.NodeId).Return(cloud.ErrNotFound)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-				resp, err := awsDriver.ControllerUnpublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-
-				if !reflect.DeepEqual(resp, expResp) {
-					t.Fatalf("Expected resp to be %+v, got: %+v", expResp, resp)
-				}
+			name:             "AttachDisk when volume is already attached to the node",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Eq(volumeId), gomock.Eq(expInstanceID)).Return(expDevicePath, nil)
 			},
+			expResp: &csi.ControllerPublishVolumeResponse{
+				PublishContext: map[string]string{DevicePathKey: expDevicePath},
+			},
+			errorCode: codes.OK,
+		},
+
+		{
+			name:             "Invalid argument error when no VolumeId provided",
+			volumeId:         "",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			errorCode:        codes.InvalidArgument,
 		},
 		{
-			name: "fail no VolumeId",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.InvalidArgument {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.InvalidArgument)
-				}
-			},
+			name:             "Invalid argument error when no NodeId provided",
+			volumeId:         "vol-test",
+			nodeId:           "",
+			volumeCapability: stdVolCap,
+			errorCode:        codes.InvalidArgument,
 		},
 		{
-			name: "fail no NodeId",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{
-					VolumeId: "vol-test",
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.InvalidArgument {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.InvalidArgument)
-				}
-			},
+			name:      "Invalid argument error when no VolumeCapability provided",
+			volumeId:  "vol-test",
+			nodeId:    expInstanceID,
+			errorCode: codes.InvalidArgument,
 		},
 		{
-			name: "fail no VolumeCapability",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{
-					NodeId:   expInstanceID,
-					VolumeId: "vol-test",
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.InvalidArgument {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.InvalidArgument)
-				}
+			name:     "Invalid argument error when invalid VolumeCapability provided",
+			volumeId: "vol-test",
+			nodeId:   expInstanceID,
+			volumeCapability: &csi.VolumeCapability{
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_UNKNOWN,
+				},
 			},
+			errorCode: codes.InvalidArgument,
 		},
 		{
-			name: "fail invalid VolumeCapability",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{
-					NodeId: expInstanceID,
-					VolumeCapability: &csi.VolumeCapability{
-						AccessMode: &csi.VolumeCapability_AccessMode{
-							Mode: csi.VolumeCapability_AccessMode_UNKNOWN,
-						},
-					},
-					VolumeId: "vol-test",
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.InvalidArgument {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.InvalidArgument)
-				}
+			name:             "Internal error when AttachDisk fails",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Eq(volumeId), gomock.Eq(expInstanceID)).Return("", status.Error(codes.Internal, "test error"))
 			},
+			errorCode: codes.Internal,
 		},
 		{
-			name: "fail instance not found",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{
-					NodeId:           "does-not-exist",
-					VolumeId:         "vol-test",
-					VolumeCapability: stdVolCap,
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().IsExistInstance(gomock.Eq(ctx), gomock.Eq(req.NodeId)).Return(false)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.NotFound {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.NotFound, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.NotFound)
-				}
+			name:             "Fail when node does not exist",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Eq(volumeId), gomock.Eq(nodeId)).Return("", status.Error(codes.Internal, "test error"))
 			},
+			errorCode: codes.Internal,
 		},
 		{
-			name: "fail volume not found",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerPublishVolumeRequest{
-					VolumeId:         "does-not-exist",
-					NodeId:           expInstanceID,
-					VolumeCapability: stdVolCap,
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().IsExistInstance(gomock.Eq(ctx), gomock.Eq(req.NodeId)).Return(true)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq(ctx), gomock.Any()).Return(nil, cloud.ErrNotFound)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.NotFound {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.NotFound, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.NotFound)
-				}
+			name:             "Fail when volume does not exist",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Eq(volumeId), gomock.Eq(expInstanceID)).Return("", status.Error(codes.Internal, "volume not found"))
 			},
+			errorCode: codes.Internal,
 		},
 		{
-			name: "fail attach disk with volume already in use error",
-			testFunc: func(t *testing.T) {
-				attachedInstancId := "test-instance-id-attached"
-				disk := &cloud.Disk{
-					Attachments: []string{attachedInstancId},
-				}
-				req := &csi.ControllerPublishVolumeRequest{
-					VolumeId:         "does-not-exist",
-					NodeId:           expInstanceID,
-					VolumeCapability: stdVolCap,
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().IsExistInstance(gomock.Eq(ctx), gomock.Eq(req.NodeId)).Return(true)
-				mockCloud.EXPECT().GetDiskByID(gomock.Eq(ctx), gomock.Any()).Return(disk, nil)
-				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Any(), gomock.Eq(req.NodeId)).Return("", cloud.ErrVolumeInUse)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerPublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.FailedPrecondition {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.FailedPrecondition, srvErr.Code(), srvErr.Message())
-					}
-					if srvErr.Message() != attachedInstancId {
-						t.Fatalf("Expected error message to contain previous attached instanceId %s, but get error message %s", attachedInstancId, srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.AlreadyExists)
-				}
+			name:             "Fail when volume is already attached to another node",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().AttachDisk(gomock.Eq(ctx), gomock.Eq(volumeId), gomock.Eq(expInstanceID)).Return("", (cloud.ErrVolumeInUse))
+			},
+			errorCode: codes.FailedPrecondition,
+		},
+		{
+			name:             "Aborted error when AttachDisk operation already in-flight",
+			volumeId:         "vol-test",
+			nodeId:           expInstanceID,
+			volumeCapability: stdVolCap,
+			mockAttach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+			},
+			errorCode: codes.Aborted,
+			setupFunc: func(controllerService *controllerService) {
+				controllerService.inFlight.Insert("vol-test")
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
+		t.Run(tc.name, func(t *testing.T) {
+			req := &csi.ControllerPublishVolumeRequest{
+				NodeId:           tc.nodeId,
+				VolumeCapability: tc.volumeCapability,
+				VolumeId:         tc.volumeId,
+			}
+			ctx := context.Background()
+
+			awsDriver, mockCtl, mockCloud := createControllerService(t)
+			defer mockCtl.Finish()
+
+			if tc.setupFunc != nil {
+				tc.setupFunc(&awsDriver)
+			}
+
+			if tc.mockAttach != nil {
+				tc.mockAttach(mockCloud, ctx, req.VolumeId, req.NodeId)
+			}
+
+			resp, err := awsDriver.ControllerPublishVolume(ctx, req)
+			if tc.errorCode != codes.OK {
+				assert.Equal(t, tc.errorCode, status.Code(err))
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, tc.expResp, resp)
+			}
+		})
 	}
 }
 
 func TestControllerUnpublishVolume(t *testing.T) {
 	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
+		name       string
+		volumeId   string
+		nodeId     string
+		errorCode  codes.Code
+		mockDetach func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string)
+		expResp    *csi.ControllerUnpublishVolumeResponse
+		setupFunc  func(driver *controllerService)
 	}{
 		{
-			name: "success normal",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerUnpublishVolumeRequest{
-					NodeId:   expInstanceID,
-					VolumeId: "vol-test",
-				}
-				expResp := &csi.ControllerUnpublishVolumeResponse{}
+			name:      "DetachDisk successfully with valid volume ID and node ID",
+			volumeId:  "vol-test",
+			nodeId:    expInstanceID,
+			errorCode: codes.OK,
+			mockDetach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().DetachDisk(gomock.Eq(ctx), volumeId, nodeId).Return(nil)
 
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().DetachDisk(gomock.Eq(ctx), req.VolumeId, req.NodeId).Return(nil)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				resp, err := awsDriver.ControllerUnpublishVolume(ctx, req)
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-
-				if !reflect.DeepEqual(resp, expResp) {
-					t.Fatalf("Expected resp to be %+v, got: %+v", expResp, resp)
-				}
+			},
+			expResp: &csi.ControllerUnpublishVolumeResponse{},
+		},
+		{
+			name:      "Return success when volume not found during DetachDisk operation",
+			volumeId:  "vol-not-found",
+			nodeId:    expInstanceID,
+			errorCode: codes.OK,
+			mockDetach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().DetachDisk(gomock.Eq(ctx), volumeId, nodeId).Return(cloud.ErrNotFound)
+			},
+			expResp: &csi.ControllerUnpublishVolumeResponse{},
+		},
+		{
+			name:      "Invalid argument error when no VolumeId provided",
+			volumeId:  "",
+			nodeId:    expInstanceID,
+			errorCode: codes.InvalidArgument,
+		},
+		{
+			name:      "Invalid argument error when no NodeId provided",
+			volumeId:  "vol-test",
+			nodeId:    "",
+			errorCode: codes.InvalidArgument,
+		},
+		{
+			name:      "Internal error when DetachDisk operation fails",
+			volumeId:  "vol-test",
+			nodeId:    expInstanceID,
+			errorCode: codes.Internal,
+			mockDetach: func(mockCloud *cloud.MockCloud, ctx context.Context, volumeId string, nodeId string) {
+				mockCloud.EXPECT().DetachDisk(gomock.Eq(ctx), volumeId, nodeId).Return(errors.New("test error"))
 			},
 		},
 		{
-			name: "fail no VolumeId",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerUnpublishVolumeRequest{}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerUnpublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.InvalidArgument {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.InvalidArgument)
-				}
-			},
-		},
-		{
-			name: "fail no NodeId",
-			testFunc: func(t *testing.T) {
-				req := &csi.ControllerUnpublishVolumeRequest{
-					VolumeId: "vol-test",
-				}
-
-				ctx := context.Background()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-
-				awsDriver := controllerService{
-					cloud:         mockCloud,
-					inFlight:      internal.NewInFlight(),
-					driverOptions: &DriverOptions{},
-				}
-
-				if _, err := awsDriver.ControllerUnpublishVolume(ctx, req); err != nil {
-					srvErr, ok := status.FromError(err)
-					if !ok {
-						t.Fatalf("Could not get error status code from error: %v", srvErr)
-					}
-					if srvErr.Code() != codes.InvalidArgument {
-						t.Fatalf("Expected error code %d, got %d message %s", codes.InvalidArgument, srvErr.Code(), srvErr.Message())
-					}
-				} else {
-					t.Fatalf("Expected error %v, got no error", codes.InvalidArgument)
-				}
+			name:      "Aborted error when operation already in-flight",
+			volumeId:  "vol-test",
+			nodeId:    expInstanceID,
+			errorCode: codes.Aborted,
+			setupFunc: func(driver *controllerService) {
+				driver.inFlight.Insert("vol-test")
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
+		t.Run(tc.name, func(t *testing.T) {
+			req := &csi.ControllerUnpublishVolumeRequest{
+				NodeId:   tc.nodeId,
+				VolumeId: tc.volumeId,
+			}
+
+			ctx := context.Background()
+
+			awsDriver, mockCtl, mockCloud := createControllerService(t)
+			defer mockCtl.Finish()
+
+			if tc.setupFunc != nil {
+				tc.setupFunc(&awsDriver)
+			}
+
+			if tc.mockDetach != nil {
+				tc.mockDetach(mockCloud, ctx, req.VolumeId, req.NodeId)
+			}
+
+			resp, err := awsDriver.ControllerUnpublishVolume(ctx, req)
+			if tc.errorCode != codes.OK {
+				assert.Equal(t, tc.errorCode, status.Code(err))
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				assert.Equal(t, tc.expResp, resp)
+			}
+		})
 	}
 }
 
@@ -3655,4 +3462,16 @@ func checkExpectedErrorCode(t *testing.T, err error, expectedCode codes.Code) {
 	if srvErr.Code() != expectedCode {
 		t.Fatalf("Expected Aborted but got: %s", srvErr.Code())
 	}
+}
+
+func createControllerService(t *testing.T) (controllerService, *gomock.Controller, *cloud.MockCloud) {
+	t.Helper()
+	mockCtl := gomock.NewController(t)
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	awsDriver := controllerService{
+		cloud:         mockCloud,
+		inFlight:      internal.NewInFlight(),
+		driverOptions: &DriverOptions{},
+	}
+	return awsDriver, mockCtl, mockCloud
 }


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
----
**`cloud.go`** changes:

This PR addresses incorrect handling of the Context in `WaitForAttachmentState` which implements a retry mechanism using exponential backoff to wait for an attachment to reach the expected state via the `DescribeVolumesWithContext` API.

The context is used to carry deadlines and cancellation signals across API boundaries. When polling for volume state, its possible for the context to be cancelled due to timeout etc. If this happens while we're waiting for the volume to reach the expected state, it is desirable to stop waiting and immediately return an error to the caller. This change allows us to better handle cases where the context is cancelled or reaches its deadline by stopping execution when no longer necessary.

----

**`controller.go`** changes:

Added in-flight checks to both `ControllerPublishVolume` and `ControllerUnpublishVolume`. The in-flight check acts as a synchronization mechanism by providing mutual exclusion to ensure idempotency.

----
Testing changes:

Added tests to validate code paths and logic when attaching / detaching volumes. Also did some refactoring to move towards table-driven tests which vastly improves readability and maintainability of these tests.

**What testing is done?** 
----
- Manual
- CI


**With this patch:**
```
I0602 17:16:29.032300       1 controller.go:370] "ControllerPublishVolume: attached" volumeID="vol-0163b0b755696dcdc" nodeID="i-07532540ce852721b" devicePath="/dev/xvdal"
I0602 17:16:47.545514       1 controller.go:362] "ControllerPublishVolume: attaching" volumeID="vol-0bf9e9d3205eb9fe7" nodeID="i-07532540ce852721b"
I0602 17:16:49.352063       1 controller.go:370] "ControllerPublishVolume: attached" volumeID="vol-0bf9e9d3205eb9fe7" nodeID="i-07532540ce852721b" devicePath="/dev/xvdap"
I0602 17:16:49.358931       1 controller.go:362] "ControllerPublishVolume: attaching" volumeID="vol-0bf9e9d3205eb9fe7" nodeID="i-07532540ce852721b"
I0602 17:16:49.519855       1 controller.go:370] "ControllerPublishVolume: attached" volumeID="vol-0bf9e9d3205eb9fe7" nodeID="i-07532540ce852721b" devicePath="/dev/xvdap"
 ```

**Without this patch:**

```
I0524 20:56:35.690733       1 inflight.go:74] "Node Service: volume operation finished" key="snapshot-299d9d27-a925-4954-93df-80ccd2105e85"
I0524 20:56:35.711511       1 cloud.go:713] "Waiting for volume state" volumeID="vol-05ee7370b8091e868" actual="detaching" desired="detached"
I0524 20:56:36.174965       1 inflight.go:74] "Node Service: volume operation finished" key="pvc-2a9b6b41-dc69-42ff-aa57-ec6bfcbd73e0"
I0524 20:56:36.176699       1 cloud.go:713] "Waiting for volume state" volumeID="vol-08a1528c35dfeb1ff" actual="detaching" desired="detached"
I0524 20:56:36.205657       1 cloud.go:654] "Ignoring error from describe volume, will retry" volumeID="vol-0aecdf207857b8263" err=<
	RequestCanceled: request context canceled
	caused by: context deadline exceeded
 >
I0524 20:57:31.4134426       1 cloud.go:654] "Ignoring error from describe volume, will retry" volumeID="vol-0aecdf207857b8263" err=<
	RequestCanceled: request context canceled
	caused by: context deadline exceeded
 >
...
 ```