### PR TITLE
Add additionalArgs parameter for sidecars

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -198,6 +198,9 @@ spec:
             {{- end }}
             {{- end }}
             - --default-fstype={{ .Values.controller.defaultFsType }}
+            {{- range .Values.sidecars.provisioner.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -240,6 +243,9 @@ spec:
             - --leader-election-retry-period={{ .Values.sidecars.attacher.leaderElection.retryPeriod }}
             {{- end }}
             {{- end }}
+            {{- range .Values.sidecars.attacher.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -274,6 +280,9 @@ spec:
             {{- if .Values.controller.extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}
+            {{- range .Values.sidecars.snapshotter.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -317,6 +326,9 @@ spec:
             {{- if .Values.sidecars.volumemodifier.leaderElection.retryPeriod }}
             - --leader-election-retry-period={{ .Values.sidecars.volumemodifier.leaderElection.retryPeriod }}
             {{- end }}
+            {{- end }}
+            {{- range .Values.sidecars.volumemodifier.additionalArgs }}
+            - {{ . }}
             {{- end }}
           env:
             - name: ADDRESS
@@ -362,6 +374,9 @@ spec:
             - --leader-election-retry-period={{ .retryPeriod }}
             {{- end }}
             {{- end }}
+            {{- range .Values.sidecars.resizer.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -391,6 +406,9 @@ spec:
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.livenessProbe.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
+            {{- range .Values.sidecars.livenessProbe.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           envFrom:
             {{- with .Values.controller.envFrom }}
             {{- . | toYaml | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -127,6 +127,9 @@ spec:
             {{- with .Values.sidecars.nodeDriverRegistrar.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+            {{- range .Values.sidecars.nodeDriverRegistrar.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           envFrom:
             {{- with .Values.controller.envFrom }}
             {{- . | toYaml | nindent 12 }}
@@ -163,6 +166,9 @@ spec:
           envFrom:
             {{- with .Values.controller.envFrom }}
             {{- . | toYaml | nindent 12 }}
+            {{- end }}
+            {{- range .Values.sidecars.livenessProbe.additionalArgs }}
+            - {{ . }}
             {{- end }}
           volumeMounts:
             - name: plugin-dir

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -21,6 +21,7 @@ sidecars:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
       tag: "v3.5.0-eks-1-27-3"
     logLevel: 2
+    additionalArgs: []
     resources: {}
     # Tune leader lease election for csi-provisioner.
     # Leader election is on by default.
@@ -52,6 +53,7 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     logLevel: 2
+    additionalArgs: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -65,6 +67,7 @@ sidecars:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
       tag: "v6.2.1-eks-1-27-3"
     logLevel: 2
+    additionalArgs: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -74,6 +77,7 @@ sidecars:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
       tag: "v2.10.0-eks-1-27-3"
+    additionalArgs: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -95,6 +99,7 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     logLevel: 2
+    additionalArgs: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -106,6 +111,7 @@ sidecars:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
       tag: "v2.8.0-eks-1-27-3"
     logLevel: 2
+    additionalArgs: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -125,6 +131,7 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     logLevel: 2
+    additionalArgs: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature (for helm chart)

**What is this PR about? / Why do we need it?**

Adds an `additionalArgs` parameter to sidecars, for parameters such as `--retry-interval-max` or `--kube-api-qps`.

Supersedes #1585
Fixes #1579 

**What testing is done?** 

Manually rendered, CI