### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,8 +14,9 @@ jobs:
     steps:
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
## Description

Resolve  #1635 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo "::set-output name=go-build::$(go env GOCACHE)"
  echo "::set-output name=go-mod::$(go env GOMODCACHE)"
```

**TO-BE**

```yml
run: |
  echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
  echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
shell: bash
```