### PR TITLE
Allow additional volume mounts on node pods

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -89,6 +89,9 @@ spec:
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
+          {{- with .Values.node.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: healthz
               containerPort: 9808
@@ -206,3 +209,6 @@ spec:
             type: Directory
         - name: probe-dir
           emptyDir: {}
+        {{- with .Values.node.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -264,8 +264,18 @@ controller:
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000
+  # Add additional volume mounts on the controller with controller.volumes and controller.volumeMounts
   volumes: []
+  # Add additional volumes to be mounted onto the controller:
+  # - name: custom-dir
+  #   hostPath:
+  #     path: /path/to/dir
+  #     type: Directory
   volumeMounts: []
+  # And add mount paths for those additional volumes:
+  # - name: custom-dir
+  #   mountPath: /mount/path
+  # ---
   # securityContext on the controller container (see sidecars for securityContext on sidecar containers)
   containerSecurityContext:
     readOnlyRootFilesystem: true
@@ -328,6 +338,18 @@ node:
     runAsUser: 0
     runAsGroup: 0
     fsGroup: 0
+  # Add additional volume mounts on the node pods with node.volumes and node.volumeMounts
+  volumes: []
+  # Add additional volumes to be mounted onto the node pods:
+  # - name: custom-dir
+  #   hostPath:
+  #     path: /path/to/dir
+  #     type: Directory
+  volumeMounts: []
+  # And add mount paths for those additional volumes:
+  # - name: custom-dir
+  #   mountPath: /mount/path
+  # ---
   # securityContext on the node container (see sidecars for securityContext on sidecar containers)
   containerSecurityContext:
     readOnlyRootFilesystem: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

Closes #1544 

This PR adds a helm parameter that allows additional volume mounts on the node pods (and adds documentation on how to add additional volume mounts on the controller).  

This would allow users to add their own mounts to the driver via the Helm parameters `node.volumes` and `node.volumeMounts` in [this PR's values.yaml](https://github.com/AndrewSirenko/aws-ebs-csi-driver/blob/3de7fded5908a4abc731227594e76255ce4b9cdc/charts/aws-ebs-csi-driver/values.yaml#L342-L351) without needing to patch the driver. 

**What testing is done?** 

Tested on live k8s cluster. 

1. Installed the ebs-csi-driver to a test cluster with two additional volume mounts for node pods. 
<img width="730" alt="values.yaml" src="https://github.com/kubernetes-sigs/aws-ebs-csi-driver/assets/68304519/c853b046-b3fb-45e4-9b2f-26b0b5f1b52c">

2. Describing one of the node pods "kubectl describe  pod ebs-csi-node-hstbp -n kube-system" the additional two volume mounts that were requested. 
<img width="713" alt="Additional Volumes Mounted" src="https://github.com/kubernetes-sigs/aws-ebs-csi-driver/assets/68304519/8538a78e-b1e9-48ff-b4c8-16d5a2f59be6">

