### PR TITLE
added new test case for checking the same device letter

### DIFF
--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -103,9 +103,16 @@ func TestNewDeviceWithExistingDevice(t *testing.T) {
 		{
 			name:         "success: different volumes",
 			existingID:   "vol-1",
-			existingPath: deviceNames[0],
+			existingPath: deviceNames[0], // "/dev/xvdb"
 			volumeID:     "vol-2",
-			expectedPath: deviceNames[1],
+			expectedPath: deviceNames[1], // "/dev/xvdc"
+		},
+		{
+			name:         "success: existing device is /dev/sdb",
+			existingID:   "vol-7",
+			existingPath: "/dev/sdb",
+			volumeID:     "vol-8",
+			expectedPath: "/dev/xvdd",
 		},
 		{
 			name:         "success: same volumes",


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

bug fix

**What is this PR about? / Why do we need it?**

This addresses the issue where an EC2 instance has a current volume attached as "/dev/sdb" and the driver tries to attach a new device as "/dev/xvdb" not taking in consideration that "/dev/sdb" and "/dev/xvdb" are the same. 
Leading to the following error:
```
Could not attach volume "vol-id" to node "i-id": could not attach volume "vol-id" to node "i-id": 
InvalidParameterValue: Invalid value '/dev/xvdb' for unixDevice. Attachment point /dev/xvdb is already in use

status code: 400, request id: "id"
```
**What testing is done?** 
Added a new test case in "testCases" where in the original code fails to return the correct device letter.

```
go test -v -timeout 30s -run ^TestNewDeviceWithExistingDevice$ .                                                                                 
=== RUN   TestNewDeviceWithExistingDevice
=== RUN   TestNewDeviceWithExistingDevice/success:_different_volumes
=== RUN   TestNewDeviceWithExistingDevice/success:_existing_device_is_/dev/sdb
    manager_test.go:150: Expected path /dev/xvdd got /dev/xvdb
=== RUN   TestNewDeviceWithExistingDevice/success:_same_volumes
=== RUN   TestNewDeviceWithExistingDevice/success:_same_volumes_with_/dev/sdX_path
=== RUN   TestNewDeviceWithExistingDevice/success:_same_volumes_with_weird_path
--- FAIL: TestNewDeviceWithExistingDevice (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_different_volumes (0.00s)
    --- FAIL: TestNewDeviceWithExistingDevice/success:_existing_device_is_/dev/sdb (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_same_volumes (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_same_volumes_with_/dev/sdX_path (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_same_volumes_with_weird_path (0.00s)
FAIL
FAIL	github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/devicemanager	0.397s
FAIL
```

After adapting the code take in consideration the above issue, the test passes.

```
go test -v -timeout 30s -run ^TestNewDeviceWithExistingDevice$ .                                                                                 
=== RUN   TestNewDeviceWithExistingDevice
=== RUN   TestNewDeviceWithExistingDevice/success:_different_volumes
=== RUN   TestNewDeviceWithExistingDevice/success:_existing_device_is_/dev/sdb
=== RUN   TestNewDeviceWithExistingDevice/success:_same_volumes
=== RUN   TestNewDeviceWithExistingDevice/success:_same_volumes_with_/dev/sdX_path
=== RUN   TestNewDeviceWithExistingDevice/success:_same_volumes_with_weird_path
--- PASS: TestNewDeviceWithExistingDevice (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_different_volumes (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_existing_device_is_/dev/sdb (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_same_volumes (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_same_volumes_with_/dev/sdX_path (0.00s)
    --- PASS: TestNewDeviceWithExistingDevice/success:_same_volumes_with_weird_path (0.00s)
PASS
ok  	github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/devicemanager	0.338s
```
