### PR TITLE
Request coalescing for resizing and modifying volume

### DIFF
--- a/docs/modify-volume.md
+++ b/docs/modify-volume.md
@@ -20,7 +20,6 @@ Users can specify the following PVC annotations:
 ## Considerations
 
 - Keep in mind the [6 hour cooldown period](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVolume.html) for EBS ModifyVolume. Multiple ModifyVolume calls for the same volume within a 6 hour period will fail. 
-- It is not yet possible to update both the annotations and capacity of the PVC at the same time. This results in multiple RPC calls to the driver, and only one of them will succeed (due to the cooldown period). A future release of the driver will lift this restriction.
 - Ensure that the desired volume properties are permissible. The driver does minimum client side validation. 
 
 ## Example

--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -8,11 +8,10 @@ import (
 
 type Cloud interface {
 	CreateDisk(ctx context.Context, volumeName string, diskOptions *DiskOptions) (disk *Disk, err error)
-	ModifyDisk(ctx context.Context, volumeName string, modifyDiskOptions *ModifyDiskOptions) error
 	DeleteDisk(ctx context.Context, volumeID string) (success bool, err error)
 	AttachDisk(ctx context.Context, volumeID string, nodeID string) (devicePath string, err error)
 	DetachDisk(ctx context.Context, volumeID string, nodeID string) (err error)
-	ResizeDisk(ctx context.Context, volumeID string, reqSize int64) (newSize int64, err error)
+	ResizeOrModifyDisk(ctx context.Context, volumeID string, newSizeBytes int64, options *ModifyDiskOptions) (newSize int64, err error)
 	WaitForAttachmentState(ctx context.Context, volumeID, expectedState string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*ec2.VolumeAttachment, error)
 	GetDiskByName(ctx context.Context, name string, capacityBytes int64) (disk *Disk, err error)
 	GetDiskByID(ctx context.Context, volumeID string) (disk *Disk, err error)

--- a/pkg/cloud/mock_cloud.go
+++ b/pkg/cloud/mock_cloud.go
@@ -243,33 +243,19 @@ func (mr *MockCloudMockRecorder) ListSnapshots(ctx, volumeID, maxResults, nextTo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSnapshots", reflect.TypeOf((*MockCloud)(nil).ListSnapshots), ctx, volumeID, maxResults, nextToken)
 }
 
-// ModifyDisk mocks base method.
-func (m *MockCloud) ModifyDisk(ctx context.Context, volumeName string, modifyDiskOptions *ModifyDiskOptions) error {
+// ResizeOrModifyDisk mocks base method.
+func (m *MockCloud) ResizeOrModifyDisk(ctx context.Context, volumeID string, newSizeBytes int64, options *ModifyDiskOptions) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModifyDisk", ctx, volumeName, modifyDiskOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ModifyDisk indicates an expected call of ModifyDisk.
-func (mr *MockCloudMockRecorder) ModifyDisk(ctx, volumeName, modifyDiskOptions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDisk", reflect.TypeOf((*MockCloud)(nil).ModifyDisk), ctx, volumeName, modifyDiskOptions)
-}
-
-// ResizeDisk mocks base method.
-func (m *MockCloud) ResizeDisk(ctx context.Context, volumeID string, reqSize int64) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResizeDisk", ctx, volumeID, reqSize)
+	ret := m.ctrl.Call(m, "ResizeOrModifyDisk", ctx, volumeID, newSizeBytes, options)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ResizeDisk indicates an expected call of ResizeDisk.
-func (mr *MockCloudMockRecorder) ResizeDisk(ctx, volumeID, reqSize interface{}) *gomock.Call {
+// ResizeOrModifyDisk indicates an expected call of ResizeOrModifyDisk.
+func (mr *MockCloudMockRecorder) ResizeOrModifyDisk(ctx, volumeID, newSizeBytes, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeDisk", reflect.TypeOf((*MockCloud)(nil).ResizeDisk), ctx, volumeID, reqSize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeOrModifyDisk", reflect.TypeOf((*MockCloud)(nil).ResizeOrModifyDisk), ctx, volumeID, newSizeBytes, options)
 }
 
 // WaitForAttachmentState mocks base method.

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -61,9 +61,10 @@ const isManagedByDriver = "true"
 
 // controllerService represents the controller service of CSI driver
 type controllerService struct {
-	cloud         cloud.Cloud
-	inFlight      *internal.InFlight
-	driverOptions *DriverOptions
+	cloud               cloud.Cloud
+	inFlight            *internal.InFlight
+	driverOptions       *DriverOptions
+	modifyVolumeManager *modifyVolumeManager
 
 	rpc.UnimplementedModifyServer
 }
@@ -97,9 +98,10 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 	}
 
 	return controllerService{
-		cloud:         cloudSrv,
-		inFlight:      internal.NewInFlight(),
-		driverOptions: driverOptions,
+		cloud:               cloudSrv,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       driverOptions,
+		modifyVolumeManager: newModifyVolumeManager(),
 	}
 }
 
@@ -508,9 +510,26 @@ func (d *controllerService) ControllerExpandVolume(ctx context.Context, req *csi
 		return nil, status.Error(codes.InvalidArgument, "After round-up, volume size exceeds the limit specified")
 	}
 
-	actualSizeGiB, err := d.cloud.ResizeDisk(ctx, volumeID, newSize)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not resize volume %q: %v", volumeID, err)
+	responseChan := make(chan modifyVolumeResponse)
+	modifyVolumeRequest := modifyVolumeRequest{
+		newSize:      newSize,
+		responseChan: responseChan,
+	}
+
+	// Intentionally not pass in context as we deal with context locally in this method
+	d.addModifyVolumeRequest(volumeID, &modifyVolumeRequest) //nolint:contextcheck
+
+	var actualSizeGiB int64
+
+	select {
+	case response := <-responseChan:
+		if response.err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not resize volume %q: %v", volumeID, response.err)
+		} else {
+			actualSizeGiB = response.volumeSize
+		}
+	case <-ctx.Done():
+		return nil, status.Errorf(codes.Internal, "Could not resize volume %q: context cancelled", volumeID)
 	}
 
 	nodeExpansionRequired := true

--- a/pkg/driver/controller_modify_volume.go
+++ b/pkg/driver/controller_modify_volume.go
@@ -2,7 +2,10 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/awslabs/volume-modifier-for-k8s/pkg/rpc"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
@@ -17,7 +20,158 @@ const (
 	ModificationKeyIOPS = "iops"
 
 	ModificationKeyThroughput = "throughput"
+
+	modifyVolumeRequestHandlerTimeout = 2 * time.Second
 )
+
+type modifyVolumeRequest struct {
+	newSize           int64
+	modifyDiskOptions cloud.ModifyDiskOptions
+	// Channel for sending the response to the request caller
+	responseChan chan modifyVolumeResponse
+}
+
+type modifyVolumeResponse struct {
+	volumeSize int64
+	err        error
+}
+
+type modifyVolumeRequestHandler struct {
+	volumeID string
+	// Merged request from the requests that have been accepted for the volume
+	mergedRequest *modifyVolumeRequest
+	// Channel for sending requests to the goroutine for the volume
+	requestChan chan *modifyVolumeRequest
+}
+
+type modifyVolumeManager struct {
+	// Map of volume ID to modifyVolumeRequestHandler
+	requestHandlerMap sync.Map
+}
+
+func newModifyVolumeManager() *modifyVolumeManager {
+	return &modifyVolumeManager{
+		requestHandlerMap: sync.Map{},
+	}
+}
+
+func newModifyVolumeRequestHandler(volumeID string, request *modifyVolumeRequest) modifyVolumeRequestHandler {
+	requestChan := make(chan *modifyVolumeRequest)
+	return modifyVolumeRequestHandler{
+		requestChan:   requestChan,
+		mergedRequest: request,
+		volumeID:      volumeID,
+	}
+}
+
+// This function validates the new request against the merged request for the volume.
+// If the new request has a volume property that's already included in the merged request and its value is different from that in the merged request,
+// this function will return an error and the new request will be rejected.
+func (h *modifyVolumeRequestHandler) validateModifyVolumeRequest(r *modifyVolumeRequest) error {
+	if r.newSize != 0 && h.mergedRequest.newSize != 0 && r.newSize != h.mergedRequest.newSize {
+		return fmt.Errorf("Different size was requested by a previous request. Current: %d, Requested: %d", h.mergedRequest.newSize, r.newSize)
+	}
+	if r.modifyDiskOptions.IOPS != 0 && h.mergedRequest.modifyDiskOptions.IOPS != 0 && r.modifyDiskOptions.IOPS != h.mergedRequest.modifyDiskOptions.IOPS {
+		return fmt.Errorf("Different IOPS was requested by a previous request. Current: %d, Requested: %d", h.mergedRequest.modifyDiskOptions.IOPS, r.modifyDiskOptions.IOPS)
+	}
+	if r.modifyDiskOptions.Throughput != 0 && h.mergedRequest.modifyDiskOptions.Throughput != 0 && r.modifyDiskOptions.Throughput != h.mergedRequest.modifyDiskOptions.Throughput {
+		return fmt.Errorf("Different throughput was requested by a previous request. Current: %d, Requested: %d", h.mergedRequest.modifyDiskOptions.Throughput, r.modifyDiskOptions.Throughput)
+	}
+	if r.modifyDiskOptions.VolumeType != "" && h.mergedRequest.modifyDiskOptions.VolumeType != "" && r.modifyDiskOptions.VolumeType != h.mergedRequest.modifyDiskOptions.VolumeType {
+		return fmt.Errorf("Different volume type was requested by a previous request. Current: %s, Requested: %s", h.mergedRequest.modifyDiskOptions.VolumeType, r.modifyDiskOptions.VolumeType)
+	}
+	return nil
+}
+
+func (h *modifyVolumeRequestHandler) mergeModifyVolumeRequest(r *modifyVolumeRequest) {
+	if r.newSize != 0 {
+		h.mergedRequest.newSize = r.newSize
+	}
+	if r.modifyDiskOptions.IOPS != 0 {
+		h.mergedRequest.modifyDiskOptions.IOPS = r.modifyDiskOptions.IOPS
+	}
+	if r.modifyDiskOptions.Throughput != 0 {
+		h.mergedRequest.modifyDiskOptions.Throughput = r.modifyDiskOptions.Throughput
+	}
+	if r.modifyDiskOptions.VolumeType != "" {
+		h.mergedRequest.modifyDiskOptions.VolumeType = r.modifyDiskOptions.VolumeType
+	}
+}
+
+// processModifyVolumeRequests method starts its execution with a timer that has modifyVolumeRequestHandlerTimeout as its timeout value.
+// When the Timer times out, it calls the ec2 API to perform the volume modification. processModifyVolumeRequests method sends back the response of
+// the ec2 API call to the CSI Driver main thread via response channels.
+// This method receives requests from CSI driver main thread via the request channel. When a new request is received from the request channel, we first
+// validate the new request. If the new request is acceptable, it will be merged with the existing request for the volume.
+func (d *controllerService) processModifyVolumeRequests(h *modifyVolumeRequestHandler, responseChans []chan modifyVolumeResponse) {
+	klog.V(4).InfoS("Start processing ModifyVolumeRequest for ", "volume ID", h.volumeID)
+	process := func(req *modifyVolumeRequest) {
+		if err := h.validateModifyVolumeRequest(req); err != nil {
+			req.responseChan <- modifyVolumeResponse{err: err}
+		} else {
+			h.mergeModifyVolumeRequest(req)
+			responseChans = append(responseChans, req.responseChan)
+		}
+	}
+
+	for {
+		select {
+		case req := <-h.requestChan:
+			process(req)
+		case <-time.After(modifyVolumeRequestHandlerTimeout):
+			d.modifyVolumeManager.requestHandlerMap.Delete(h.volumeID)
+			// At this point, no new requests can come in on the request channel because it has been removed from the map
+			// However, the request channel may still have requests waiting on it
+			// Thus, process any requests still waiting in the channel
+			for loop := true; loop; {
+				select {
+				case req := <-h.requestChan:
+					process(req)
+				default:
+					loop = false
+				}
+			}
+			actualSizeGiB, err := d.executeModifyVolumeRequest(h.volumeID, h.mergedRequest)
+			for _, c := range responseChans {
+				select {
+				case c <- modifyVolumeResponse{volumeSize: actualSizeGiB, err: err}:
+				default:
+					klog.V(6).InfoS("Ignoring response channel because it has no receiver", "volumeID", h.volumeID)
+				}
+			}
+			return
+		}
+	}
+}
+
+// When a new request comes in, we look up requestHandlerMap using the volume ID of the request.
+// If there's no ModifyVolumeRequestHandler for the volume, meaning that there’s no inflight requests for the volume, we will start a goroutine
+// for the volume calling processModifyVolumeRequests method, and ModifyVolumeRequestHandler for the volume will be added to requestHandlerMap.
+// If there’s ModifyVolumeRequestHandler for the volume, meaning that there is inflight request(s) for the volume, we will send the new request
+// to the goroutine for the volume via the receiving channel.
+// Note that each volume with inflight requests has their own goroutine which follows timeout schedule of their own.
+func (d *controllerService) addModifyVolumeRequest(volumeID string, r *modifyVolumeRequest) {
+	requestHandler := newModifyVolumeRequestHandler(volumeID, r)
+	handler, loaded := d.modifyVolumeManager.requestHandlerMap.LoadOrStore(volumeID, requestHandler)
+	if loaded {
+		h := handler.(modifyVolumeRequestHandler)
+		h.requestChan <- r
+	} else {
+		responseChans := []chan modifyVolumeResponse{r.responseChan}
+		go d.processModifyVolumeRequests(&requestHandler, responseChans)
+	}
+}
+
+func (d *controllerService) executeModifyVolumeRequest(volumeID string, req *modifyVolumeRequest) (int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	actualSizeGiB, err := d.cloud.ResizeOrModifyDisk(ctx, volumeID, req.newSize, &req.modifyDiskOptions)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "Could not modify volume %q: %v", volumeID, err)
+	} else {
+		return actualSizeGiB, nil
+	}
+}
 
 func (d *controllerService) GetCSIDriverModificationCapability(
 	_ context.Context,
@@ -30,8 +184,8 @@ func (d *controllerService) ModifyVolumeProperties(
 	ctx context.Context,
 	req *rpc.ModifyVolumePropertiesRequest,
 ) (*rpc.ModifyVolumePropertiesResponse, error) {
-	klog.V(4).InfoS("ModifyVolumeAttributes called", "req", req)
-	if err := validateModifyVolumeAttributesRequest(req); err != nil {
+	klog.V(4).InfoS("ModifyVolumeProperties called", "req", req)
+	if err := validateModifyVolumePropertiesRequest(req); err != nil {
 		return nil, err
 	}
 
@@ -55,13 +209,29 @@ func (d *controllerService) ModifyVolumeProperties(
 			modifyOptions.VolumeType = value
 		}
 	}
-	if err := d.cloud.ModifyDisk(ctx, name, &modifyOptions); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not modify volume %q: %v", name, err)
+
+	responseChan := make(chan modifyVolumeResponse)
+	request := modifyVolumeRequest{
+		modifyDiskOptions: modifyOptions,
+		responseChan:      responseChan,
 	}
+
+	// Intentionally not pass in context as we deal with context locally in this method
+	d.addModifyVolumeRequest(name, &request) //nolint:contextcheck
+
+	select {
+	case response := <-responseChan:
+		if response.err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not modify volume %q: %v", name, response.err)
+		}
+	case <-ctx.Done():
+		return nil, status.Errorf(codes.Internal, "Could not modify volume %q: context cancelled", name)
+	}
+
 	return &rpc.ModifyVolumePropertiesResponse{}, nil
 }
 
-func validateModifyVolumeAttributesRequest(req *rpc.ModifyVolumePropertiesRequest) error {
+func validateModifyVolumePropertiesRequest(req *rpc.ModifyVolumePropertiesRequest) error {
 	name := req.GetName()
 	if name == "" {
 		return status.Error(codes.InvalidArgument, "Volume name not provided")

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -3418,12 +3418,13 @@ func TestControllerExpandVolume(t *testing.T) {
 			}
 
 			mockCloud := cloud.NewMockCloud(mockCtl)
-			mockCloud.EXPECT().ResizeDisk(gomock.Eq(ctx), gomock.Eq(tc.req.VolumeId), gomock.Any()).Return(retSizeGiB, nil).AnyTimes()
+			mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(tc.req.VolumeId), gomock.Any(), gomock.Any()).Return(retSizeGiB, nil).AnyTimes()
 
 			awsDriver := controllerService{
-				cloud:         mockCloud,
-				inFlight:      internal.NewInFlight(),
-				driverOptions: &DriverOptions{},
+				cloud:               mockCloud,
+				inFlight:            internal.NewInFlight(),
+				driverOptions:       &DriverOptions{},
+				modifyVolumeManager: newModifyVolumeManager(),
 			}
 
 			resp, err := awsDriver.ControllerExpandVolume(ctx, tc.req)

--- a/pkg/driver/request_coalescing_test.go
+++ b/pkg/driver/request_coalescing_test.go
@@ -1,0 +1,500 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	// "errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/awslabs/volume-modifier-for-k8s/pkg/rpc"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+	"k8s.io/klog/v2"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+)
+
+// TestBasicRequestCoalescingSuccess tests the success case of coalescing 2 requests from ControllerExpandVolume and ModifyVolumeProperties respectively.
+func TestBasicRequestCoalescingSuccess(t *testing.T) {
+	const NewVolumeType = "gp3"
+	const NewSize = 5 * util.GiB
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk called", "volumeID", volumeID, "newSize", newSize, "options", options)
+		if newSize != NewSize {
+			t.Errorf("newSize incorrect")
+		} else if options.VolumeType != NewVolumeType {
+			t.Errorf("VolumeType incorrect")
+		}
+
+		return newSize, nil
+	})
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+			VolumeId: volumeID,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: NewSize,
+			},
+		})
+
+		if err != nil {
+			t.Error("ControllerExpandVolume returned error")
+		}
+		wg.Done()
+	})
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType,
+			},
+		})
+
+		if err != nil {
+			t.Error("ModifyVolumeProperties returned error")
+		}
+		wg.Done()
+	})
+
+	wg.Wait()
+}
+
+// TestRequestFail tests failing requests from ResizeOrModifyDisk failure.
+func TestRequestFail(t *testing.T) {
+	const NewVolumeType = "gp3"
+	const NewSize = 5 * util.GiB
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk called", "volumeID", volumeID, "newSize", newSize, "options", options)
+		return 0, fmt.Errorf("ResizeOrModifyDisk failed")
+	})
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+			VolumeId: volumeID,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: NewSize,
+			},
+		})
+
+		if err == nil {
+			t.Error("ControllerExpandVolume should fail")
+		}
+		wg.Done()
+	})
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType,
+			},
+		})
+
+		if err == nil {
+			t.Error("ModifyVolumeProperties should fail")
+		}
+		wg.Done()
+	})
+
+	wg.Wait()
+}
+
+// TestPartialFail tests making these 3 requests roughly in parallel:
+// 1) Change size
+// 2) Change volume type to NewVolumeType1
+// 3) Change volume type to NewVolumeType2
+// The expected result is the resizing request succeeds and one of the volume-type requests fails.
+func TestPartialFail(t *testing.T) {
+	const NewVolumeType1 = "gp3"
+	const NewVolumeType2 = "io2"
+	const NewSize = 5 * util.GiB
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	volumeTypeChosen := ""
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk called", "volumeID", volumeID, "newSize", newSize, "options", options)
+		if newSize != NewSize {
+			t.Errorf("newSize incorrect")
+		} else if options.VolumeType == "" {
+			t.Errorf("no volume type")
+		}
+
+		volumeTypeChosen = options.VolumeType
+		return newSize, nil
+	})
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	volumeType1Err, volumeType2Error := false, false
+
+	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+			VolumeId: volumeID,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: NewSize,
+			},
+		})
+
+		if err != nil {
+			t.Error("ControllerExpandVolume returned error")
+		}
+		wg.Done()
+	})
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType1, // gp3
+			},
+		})
+		volumeType1Err = err != nil
+		wg.Done()
+	})
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType2, // io2
+			},
+		})
+		if err != nil {
+			klog.InfoS("Got err io2")
+		}
+		volumeType2Error = err != nil
+		wg.Done()
+	})
+
+	wg.Wait()
+
+	if volumeTypeChosen == NewVolumeType1 {
+		if volumeType1Err {
+			t.Error("Controller chose", NewVolumeType1, "but errored request")
+		}
+		if !volumeType2Error {
+			t.Error("Controller chose", NewVolumeType1, "but returned success to", NewVolumeType2, "request")
+		}
+	} else if volumeTypeChosen == NewVolumeType2 {
+		if volumeType2Error {
+			t.Error("Controller chose", NewVolumeType2, "but errored request")
+		}
+		if !volumeType1Err {
+			t.Error("Controller chose", NewVolumeType2, "but returned success to", NewVolumeType1, "request")
+		}
+	} else {
+		t.Error("No volume type chosen")
+	}
+}
+
+// TestSequential tests sending 2 requests sequentially.
+func TestSequentialRequests(t *testing.T) {
+	const NewVolumeType = "gp3"
+	const NewSize = 5 * util.GiB
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk", "volumeID", volumeID, "newSize", newSize, "options", options)
+		return newSize, nil
+	}).Times(2)
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+			VolumeId: volumeID,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: NewSize,
+			},
+		})
+
+		if err != nil {
+			t.Error("ControllerExpandVolume returned error")
+		}
+		wg.Done()
+	})
+
+	// We expect ModifyVolume to be called by the end of this sleep
+	time.Sleep(5 * time.Second)
+
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType,
+			},
+		})
+
+		if err != nil {
+			t.Error("ModifyVolumeProperties returned error")
+		}
+		wg.Done()
+	})
+
+	wg.Wait()
+}
+
+// TestDuplicateRequest tests sending multiple same requests roughly in parallel.
+func TestDuplicateRequest(t *testing.T) {
+	const NewSize = 5 * util.GiB
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk called", "volumeID", volumeID, "newSize", newSize, "options", options)
+		return newSize, nil
+	})
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	num := 5
+	wg.Add(num * 2)
+
+	for j := 0; j < num; j++ {
+		go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+			_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+				VolumeId: volumeID,
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: NewSize,
+				},
+			})
+			if err != nil {
+				t.Error("Duplicate ControllerExpandVolume request should succeed")
+			}
+			wg.Done()
+		})
+		go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+			_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+				Name: volumeID,
+				Parameters: map[string]string{
+					ModificationKeyVolumeType: "io2",
+				},
+			})
+			if err != nil {
+				t.Error("Duplicate ModifyVolumeProperties request should succeed")
+			}
+			wg.Done()
+		})
+	}
+
+	wg.Wait()
+}
+
+// TestContextTimeout tests request failing due to context cancellation and the behavior of the following request.
+func TestContextTimeout(t *testing.T) {
+	const NewVolumeType = "gp3"
+	const NewSize = 5 * util.GiB
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk called", "volumeID", volumeID, "newSize", newSize, "options", options)
+		time.Sleep(3 * time.Second)
+
+		// Controller could decide to coalesce the timed out request, or to drop it
+		if newSize != 0 && newSize != NewSize {
+			t.Errorf("newSize incorrect")
+		} else if options.VolumeType != NewVolumeType {
+			t.Errorf("volumeType incorrect")
+		}
+
+		return newSize, nil
+	})
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+		_, err := awsDriver.ControllerExpandVolume(ctx, &csi.ControllerExpandVolumeRequest{
+			VolumeId: volumeID,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: NewSize,
+			},
+		})
+		if err == nil {
+			t.Error("ControllerExpandVolume should return err because context is cancelled")
+		}
+		wg.Done()
+	})
+
+	// Cancel the context (simulate a "sidecar timeout")
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType,
+			},
+		})
+
+		if err != nil {
+			t.Error("ModifyVolumeProperties returned error")
+		}
+		wg.Done()
+	})
+
+	wg.Wait()
+}
+
+// TestResponseReturnTiming tests the caller of request coalescing blocking until receiving response from cloud.ResizeOrModifyDisk
+func TestResponseReturnTiming(t *testing.T) {
+	const NewVolumeType = "gp3"
+	const NewSize = 5 * util.GiB
+	var ec2ModifyVolumeFinished = false
+	volumeID := t.Name()
+
+	mockCtl := gomock.NewController(t)
+	defer mockCtl.Finish()
+
+	mockCloud := cloud.NewMockCloud(mockCtl)
+	mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(volumeID), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, volumeID string, newSize int64, options *cloud.ModifyDiskOptions) (int64, error) {
+		klog.InfoS("ResizeOrModifyDisk called", "volumeID", volumeID, "newSize", newSize, "options", options)
+
+		// Sleep to simulate ec2.ModifyVolume taking a long time
+		time.Sleep(5 * time.Second)
+		ec2ModifyVolumeFinished = true
+
+		return newSize, nil
+	})
+
+	awsDriver := controllerService{
+		cloud:               mockCloud,
+		inFlight:            internal.NewInFlight(),
+		driverOptions:       &DriverOptions{},
+		modifyVolumeManager: newModifyVolumeManager(),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
+		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+			VolumeId: volumeID,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: NewSize,
+			},
+		})
+
+		if !ec2ModifyVolumeFinished {
+			t.Error("ControllerExpandVolume returned success BEFORE ResizeOrModifyDisk returns")
+		}
+		if err != nil {
+			t.Error("ControllerExpandVolume returned error")
+		}
+		wg.Done()
+	})
+	go wrapTimeout(t, "ModifyVolumeProperties timed out", func() {
+		_, err := awsDriver.ModifyVolumeProperties(context.Background(), &rpc.ModifyVolumePropertiesRequest{
+			Name: volumeID,
+			Parameters: map[string]string{
+				ModificationKeyVolumeType: NewVolumeType,
+			},
+		})
+
+		if !ec2ModifyVolumeFinished {
+			t.Error("ModifyVolumeProperties returned success BEFORE ResizeOrModifyDisk returns")
+		}
+		if err != nil {
+			t.Error("ModifyVolumeProperties returned error")
+		}
+
+		wg.Done()
+	})
+
+	wg.Wait()
+}
+
+func wrapTimeout(t *testing.T, failMessage string, execFunc func()) {
+	timeout := time.After(15 * time.Second)
+	done := make(chan bool)
+	go func() {
+		execFunc()
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Error(failMessage)
+	case <-done:
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
One [restriction](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/modify-volume.md) of the volume modification support provided by EBS CSI Driver is that if a user updates both annotations and capacity of a PVC at the same time, it will result in 2 RPC calls from ``external-resizer`` and [``volume-modifier``](https://github.com/awslabs/volume-modifier-for-k8s) sidecars  to the CSI Driver, and only one of the them will succeed due to the 6-hour cool down period for EBS ModifyVolume.

This PR solves that problem by implementing the Request Coalescing feature in EBS CSI Driver that merges RPC requests from ``externa-resizer`` and ``volume-modifier`` sidecars.

**What testing is done?** 
New unit tests && ``make test`` and ``make verify`` pass.
Built and Deployed a CSI Driver image with the changes in this PR.
1. Created a PVC
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 4Gi
```
2. Verified the PVC via ``kubectl describe pvc ebs-claim``
```
Name:          ebs-claim
Namespace:     default
StorageClass:  ebs-sc
Status:        Bound
Volume:        pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
               volume.kubernetes.io/selected-node: ip-192-168-38-32.ec2.internal
               volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      4Gi
```
3. Updated the PVC with new size, volume type, throughput, iops via ``kubectl edit``.
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
        ebs.csi.aws.com/volumeType: "io2"
        ebs.csi.aws.com/iops: "1000"
        ebs.csi.aws.com/throughput: "1000"

spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
```

4. Verified the PVC and PV was updated with the new size, volume type, iops and throughput.
```

Name:          ebs-claim
Namespace:     default
StorageClass:  ebs-sc
Status:        Bound
Volume:       pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
Labels:        <none>
Annotations:   ebs.csi.aws.com/iops: 1000
               ebs.csi.aws.com/throughput: 1000
               ebs.csi.aws.com/volumeType: io2
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
               volume.kubernetes.io/selected-node: ip-192-168-38-32.ec2.internal
               volume.kubernetes.io/storage-provisioner: ebs.csi.aws.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      5Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       app
Events:
  Type     Reason                        Age                From                                                                                      Message
  ----     ------                        ----               ----                                                                                      -------
  Normal   VolumeModificationStarted     60s                  volume-modifier-for-k8s-ebs.csi.aws.com                                                   External modifier is modifying volume pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
  Warning  ExternalExpanding             60s                  volume_expand                                                                             Ignoring the PVC: didn't find a plugin capable of expanding the volume; waiting for an external controller to process this PVC.
  Normal   Resizing                      60s                  external-resizer ebs.csi.aws.com                                                          External resizer is resizing volume pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
  Normal   VolumeModificationSuccessful  55s                  volume-modifier-for-k8s-ebs.csi.aws.com                                                   External modifier has successfully modified volume pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
  Normal   FileSystemResizeRequired      55s                  external-resizer ebs.csi.aws.com                                                          Require file system resize of volume on node
  Normal   FileSystemResizeSuccessful    26s                  kubelet                                                                                   MountVolume.NodeExpandVolume succeeded for volume "pvc-fe46b239-1e50-4e7e-9d99-b041d964c048" ip-192-168-38-32.ec2.internal

kubectl describe pv   
Name:              pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
Labels:            <none>
Annotations:       ebs.csi.aws.com/iops: 1000
                   ebs.csi.aws.com/throughput: 1000
                   ebs.csi.aws.com/volumeType: io2
                   pv.kubernetes.io/provisioned-by: ebs.csi.aws.com
                   volume.kubernetes.io/provisioner-deletion-secret-name: 
                   volume.kubernetes.io/provisioner-deletion-secret-namespace: 
Finalizers:        [kubernetes.io/pv-protection external-attacher/ebs-csi-aws-com]
StorageClass:      resize-sc
Status:            Bound
Claim:             default/ebs-claim
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          5Gi
```
5. Inspected logs.
csi controller logs:
```
I0810 17:13:22.132209       1 controller_modify_volume.go:172] "ModifyVolumeProperties called" req="name:\"vol-0b280a33be37a7458\" parameters:{key:\"iops\" value:\"1000\"} parameters:{key:\"throughput\" value:\"1000\"} parameters:{key:\"volumeType\" value:\"io2\"}"
I0810 17:13:22.132413       1 controller_modify_volume.go:107] "Start processing ModifyVolumeRequest for " volume ID="vol-0b280a33be37a7458"
I0810 17:13:22.143910       1 controller.go:442] "ControllerGetCapabilities: called" args={}
I0810 17:13:22.144537       1 controller.go:496] "ControllerExpandVolume: called" args={"volume_id":"vol-0b280a33be37a7458","capacity_range":{"required_bytes":5368709120},"volume_capability":{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}}}
I0810 17:13:24.144910       1 cloud.go:476] "Received Resize and/or Modify Disk request" volumeID="vol-0b280a33be37a7458" newSizeBytes=5368709120 options={"VolumeType":"io2","IOPS":1000,"Throughput":1000}
```
resizer sidecar logs:
```
I0810 17:13:22.143733       1 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"ebs-claim", UID:"fe46b239-1e50-4e7e-9d99-b041d964c048", APIVersion:"v1", ResourceVersion:"14114656", FieldPath:""}): type: 'Normal' reason: 'Resizing' External resizer is resizing volume pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
I0810 17:13:27.449721       1 controller.go:483] Resize volume succeeded for volume "pvc-fe46b239-1e50-4e7e-9d99-b041d964c048", start to update PV's capacity
```
volume-modifier sidecar logs:
```
I0810 17:13:22.131085       1 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"ebs-claim", UID:"fe46b239-1e50-4e7e-9d99-b041d964c048", APIVersion:"v1", ResourceVersion:"14114654", FieldPath:""}): type: 'Normal' reason: 'VolumeModificationStarted' External modifier is modifying volume pvc-fe46b239-1e50-4e7e-9d99-b041d964c048
I0810 17:13:22.131614       1 csi_modifier.go:62] "Calling modify volume for volume" volumeID="vol-0b280a33be37a7458"
I0810 17:13:27.449787       1 csi_client.go:67] "Volume modification completed" volumeID="vol-0b280a33be37a7458"
```