### PR TITLE
Use SSM to get latest stable AMI for EC2 nodes

### DIFF
--- a/hack/e2e/kops.sh
+++ b/hack/e2e/kops.sh
@@ -28,12 +28,13 @@ function kops_create_cluster() {
   ZONES=${3}
   NODE_COUNT=${4}
   INSTANCE_TYPE=${5}
-  K8S_VERSION=${6}
-  CLUSTER_FILE=${7}
-  KUBECONFIG=${8}
-  KOPS_PATCH_FILE=${9}
-  KOPS_PATCH_NODE_FILE=${10}
-  KOPS_STATE_FILE=${11}
+  AMI_ID=${6}
+  K8S_VERSION=${7}
+  CLUSTER_FILE=${8}
+  KUBECONFIG=${9}
+  KOPS_PATCH_FILE=${10}
+  KOPS_PATCH_NODE_FILE=${11}
+  KOPS_STATE_FILE=${12}
 
   if kops_cluster_exists "${CLUSTER_NAME}" "${BIN}" "${KOPS_STATE_FILE}"; then
     loudecho "Replacing cluster $CLUSTER_NAME with $CLUSTER_FILE"
@@ -44,6 +45,7 @@ function kops_create_cluster() {
       --zones "${ZONES}" \
       --node-count="${NODE_COUNT}" \
       --node-size="${INSTANCE_TYPE}" \
+      --image="${AMI_ID}" \
       --kubernetes-version="${K8S_VERSION}" \
       --dry-run \
       -o yaml \

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -55,6 +55,7 @@ KOPS_VERSION=${KOPS_VERSION:-1.27.0-beta.3}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
+AMI_ID=$(aws ssm get-parameters --names /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --region ${REGION} --query 'Parameters[0].Value' --output text)
 
 EKSCTL_VERSION=${EKSCTL_VERSION:-0.148.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
@@ -137,6 +138,7 @@ if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
     "$ZONES" \
     "$NODE_COUNT" \
     "$INSTANCE_TYPE" \
+    "$AMI_ID" \
     "$K8S_VERSION_KOPS" \
     "$CLUSTER_FILE" \
     "$KUBECONFIG" \


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Use AWS SSM to get the latest AL2023 AMI ID.

**What testing is done?** 
- CI
