### PR TITLE
Add doc of chart value additionalArgs

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -21,6 +21,7 @@ sidecars:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
       tag: "v3.5.0-eks-1-27-9"
     logLevel: 2
+    # Additional parameters provided by external-provisioner.
     additionalArgs: []
     resources: {}
     # Tune leader lease election for csi-provisioner.
@@ -53,6 +54,7 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     logLevel: 2
+    # Additional parameters provided by external-attacher.
     additionalArgs: []
     resources: {}
     securityContext:
@@ -67,6 +69,7 @@ sidecars:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
       tag: "v6.2.2-eks-1-27-9"
     logLevel: 2
+    # Additional parameters provided by csi-snapshotter.
     additionalArgs: []
     resources: {}
     securityContext:
@@ -77,6 +80,7 @@ sidecars:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
       tag: "v2.10.0-eks-1-27-9"
+    # Additional parameters provided by livenessprobe.
     additionalArgs: []
     resources: {}
     securityContext:
@@ -99,6 +103,7 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     logLevel: 2
+    # Additional parameters provided by external-resizer.
     additionalArgs: []
     resources: {}
     securityContext:
@@ -111,6 +116,7 @@ sidecars:
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
       tag: "v2.8.0-eks-1-27-9"
     logLevel: 2
+    # Additional parameters provided by node-driver-registrar.
     additionalArgs: []
     resources: {}
     securityContext:
@@ -131,6 +137,7 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     logLevel: 2
+    # Additional parameters provided by volume-modifier-for-k8s.
     additionalArgs: []
     resources: {}
     securityContext:
@@ -153,6 +160,7 @@ awsAccessSecret:
 controller:
   volumeModificationFeature:
     enabled: false
+  # Additional parameters provided by aws-ebs-csi-driver controller.
   additionalArgs: []
   sdkDebugLog: false
   loggingFormat: text

--- a/docs/install.md
+++ b/docs/install.md
@@ -72,6 +72,8 @@ helm upgrade --install aws-ebs-csi-driver \
 ```
 
 Review the [configuration values](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.yaml) for the Helm chart.
+For each container (including the controller, node, and sidecars), there is an `additionalArgs` that accepts arguments that are not explicitly specified, such as `--retry-interval-start`, `--retry-interval-max` and
+`--timeout` that provisioner and attacher provides, or `--kube-api-burst`, `--kube-api-qps` etc.
 
 #### Once the driver has been deployed, verify the pods are running:
 ```sh


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Add doc of `additionalArgs` and mention `--kube-api-burst` and `--kube-api-qps` that #1666 requested.

**What is this PR about? / Why do we need it?**

**What testing is done?** 
