### PR TITLE
Remove error_handler breaking CI

### DIFF
--- a/hack/e2e/metrics/metrics.sh
+++ b/hack/e2e/metrics/metrics.sh
@@ -28,12 +28,6 @@ metrics_collector() {
   upload_metrics
 }
 
-error_handler() {
-  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
-  exit 1
-}
-trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
-
 log() {
   printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
 }


### PR DESCRIPTION
`error_handler` breaks CI - removing it until we can find a better solution
See, for example, the end of the logs for https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/1703/pull-aws-ebs-csi-driver-test-e2e-external-eks-windows/1686370764527243264