### PR TITLE
chore: default to policy/v1

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,7 +1,7 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
-apiVersion: policy/v1
-{{- else }}
+{{- if not .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1beta1
+{{- else }}
+apiVersion: policy/v1
 {{- end }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,4 +1,4 @@
-{{- if not .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+{{- if not (.Capabilities.APIVersions.Has "policy/v1") }}
 apiVersion: policy/v1beta1
 {{- else }}
 apiVersion: policy/v1


### PR DESCRIPTION
policy/v1beta1 was removed almost a year ago in kubernetes 1.25. The default for the `PodDisruptionBudget` should be modernized to `policy/v1` and fallback to `v1beta1` if `policy/v1` is not supported in the cluster. The `.Capabilities` object does not validate cluster capabilities when generating templates so is an imperfect solution for ensuring we're using the right api version.

Signed-off-by: Noah Krause <krausenoah@gmail.com>

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
