### PR TITLE
Update `kubekins-e2e`

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -196,12 +196,11 @@ metadata:
 spec:
   containers:
     - name: kubetest2
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20220624-1a63fdd9f2-master
+      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master
       command: [ "/bin/sh", "-c" ]
       args:
         - |
           cp /etc/config/storageclass.yaml /workspace/storageclass.yaml
-          go install sigs.k8s.io/kubetest2/...@latest
           kubectl config set-cluster cluster --server=https://kubernetes.default --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           kubectl config set-context kubetest2 --cluster=cluster
           kubectl config set-credentials sa --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
@@ -211,7 +210,7 @@ spec:
             SNAPSHOTS="|snapshot fields"
           fi
           export FOCUS_REGEX="\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data$SNAPSHOTS)"
-          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl -L https://dl.k8s.io/release/stable-1.25.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
+          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl -L https://dl.k8s.io/release/stable-1.27.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -227,9 +227,6 @@ else
   if [[ $TEST_PATH == "./tests/e2e-kubernetes/..." ]]; then
     pushd ${PWD}/tests/e2e-kubernetes
     packageVersion=$(echo $(cut -d '.' -f 1,2 <<< $K8S_VERSION))
-    if [[ "${WINDOWS}" == true ]]; then
-      packageVersion="1.27"
-    fi
 
     set -x
     set +e


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Upgrade `gcr.io/k8s-staging-test-infra/kubekins-e2e` to fix CI failures:

```
# k8s.io/kube-openapi/pkg/cached
/go/pkg/mod/k8s.io/kube-openapi@v0.0.0-20230501164219-8b0f38b5fd1f/pkg/cached/cache.go:242:16: undefined: atomic.Pointer
note: module requires Go 1.19
```

**What testing is done?** 

```
$ docker run -it --entrypoint /bin/sh gcr.io/k8s-staging-test-infra/kubekins-e2e:v20230727-ea685f8747-master -c "go version"

go version go1.20.6 linux/amd64
```
