### PR TITLE
Manage DaemonSets enablement

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -1,4 +1,5 @@
 {{- define "node" }}
+{{- if or (eq (default true .Values.node.enableLinux) true) }}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -221,4 +222,5 @@ spec:
         {{- with .Values.node.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -336,6 +336,8 @@ node:
     name: ebs-csi-node-sa
     annotations: {}
     automountServiceAccountToken: true
+  # Enable the linux daemonset creation
+  enableLinux: true
   enableWindows: false
   # The "maximum number of attachable volumes" per node
   volumeAttachLimit:


### PR DESCRIPTION
This is a new feature needed to enable/disable the daemonset. Having different kubelet locations on clusters, there's the need to add daemonsets per each kubelet location.
 
