### PR TITLE
Temporarily workaround Windows e2e failures with larger instance type and slimmer AMI

### DIFF
--- a/hack/e2e/eksctl.sh
+++ b/hack/e2e/eksctl.sh
@@ -67,7 +67,8 @@ function eksctl_create_cluster() {
       --managed=true \
       --ssh-access=false \
       --cluster="${CLUSTER_NAME}" \
-      --node-ami-family=WindowsServer2022FullContainer \
+      --node-ami-family=WindowsServer2022CoreContainer \
+      --instance-types=m5.2xlarge \
       -n ng-windows \
       -m 3 \
       -M 3 \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"Bug fix"

**What is this PR about? / Why do we need it?**

Windows e2e is broken since the June AMI, this temporarily works around that breakage so the Windows e2e tests will be a reliable signal again.

**What testing is done?** 

CI
