### PR TITLE
Display verbose output for test-helm-chart CI job

### DIFF
--- a/tests/ct-config.yaml
+++ b/tests/ct-config.yaml
@@ -12,3 +12,4 @@ release-label: release
 kubectl-timeout: 3000s
 skip-clean-up: false
 print-logs: true
+debug: true


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

This PR enables verbose output in test-helm-chart CI job to help debug issues.

**What testing is done?** 
- CI
