### PR TITLE
Update default API version for PodDisruptionBudget

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,8 +1,4 @@
-{{- if not (.Capabilities.APIVersions.Has "policy/v1") }}
-apiVersion: policy/v1beta1
-{{- else }}
 apiVersion: policy/v1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: ebs-csi-controller


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Close #1750 

Removes deprecated PodDisruptionBudget API version policy/v1beta1. 

**What testing is done?** 
Install default helm chart to test cluster, verifying the chart renders and uses policy/v1. 

```
❯ kubectl api-resources | grep -i "disruption"
poddisruptionbudgets              pdb          policy/v1                              true         PodDisruptionBudget
```
