### PR TITLE
[ebs-csi-controller] Allow passing template value for clusterName

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -26,7 +26,7 @@ spec:
         {{- end }}
       {{- if .Values.controller.podAnnotations }}
       annotations:
-        {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
+        {{- tpl ( .Values.controller.podAnnotations | toYaml ) . | nindent 8 }}
       {{- end }}
     spec:
       nodeSelector:
@@ -75,7 +75,7 @@ spec:
             {{- if .Values.controller.extraVolumeTags }}
               {{- include "aws-ebs-csi-driver.extra-volume-tags" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.controller.k8sTagClusterId }}
+            {{- with (tpl (default "" .Values.controller.k8sTagClusterId) . )  }}
             - --k8s-tag-cluster-id={{ . }}
             {{- end }}
             {{- if and (.Values.controller.enableMetrics) (not .Values.controller.httpEndpoint) }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** & **What is this PR about? / Why do we need it?**
This is a new feature. While using the `aws-ebs-csi-driver` as a dependency for another chart , I found it difficult to pass a global or a dynamic value for the clusterName related fields. This PR adds support for passing a template as value for `podAnnotations` and `k8sTagClusterId` fields.

**What testing is done?** 
I've tested it by passing both static value and dynamic ones as follow:
* for the current values (empty/unset) nothing has changed:
`values.yaml`
```
k8sTagClusterId:
podAnnotations: {}
```
` helm template --debug  .` output: no podAnnotations added and no argument

* for static values
`values.yaml`
```
k8sTagClusterId: "cluster"
podAnnotations:
   test.annotation: test
```
` helm template --debug  .`
```
...........................
    annotations:
        test.annotation: test
..........................
      containers:
        - name: ebs-plugin
          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.0
          imagePullPolicy: IfNotPresent
          args:
            - controller
            - --endpoint=$(CSI_ENDPOINT)
            - --k8s-tag-cluster-id=cluster
            - --logging-format=text
            - --user-agent-extra=helm
            - --v=2
```
* for template values
`values.yaml`
```
k8sTagClusterId: "{{- .Values.global.clusterName }}-k8s-eks"
podAnnotations:
   iam.amazonaws.com/role: arn:aws:iam::{{ .Values.global.accountId }}:role/{{ .Values.global.clusterName }}
   test.annotation: test
```
`helm template --set global.clusterName=cluster01-dev-va6 --set global.accountId=1234567 .`
```
...........................
      annotations:
        iam.amazonaws.com/role: arn:aws:iam::1234567:role/cluster01-dev-va6
        test.annotation: test
.....................
          args:
            - controller
            - --endpoint=$(CSI_ENDPOINT)
            - --k8s-tag-cluster-id=cluster01-dev-va6-k8s-eks
            - --logging-format=text
            - --user-agent-extra=helm
            - --v=2
```

