### PR TITLE
feat(helm): add labels to volumesnapshotclass

### DIFF
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.23.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.24.0
+version: 2.23.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.23.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.23.0
+version: 2.24.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/volumesnapshotclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/volumesnapshotclass.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- with .annotations }}
   annotations: {{- . | toYaml | trim | nindent 4 }}
   {{- end }}
+  {{- with .labels }}
+  labels: {{- . | toYaml | trim | nindent 4 }}
+  {{- end }}
 driver: ebs.csi.aws.com
 deletionPolicy: {{ .deletionPolicy }}
 {{- with .parameters }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -404,6 +404,9 @@ volumeSnapshotClasses: []
 #   # annotation metadata
 #   annotations:
 #     snapshot.storage.kubernetes.io/is-default-class: "true"
+#   # label metadata
+#   labels:
+#     my-label-is: supercool
 #   # deletionPolicy must be specified
 #   deletionPolicy: Delete
 #   parameters:


### PR DESCRIPTION
Hello,

This PR is adding the option to set labels to the volume snapshot classes created by the Helm chart.
For now this is only possible on the storage classes.

Thanks,
Fred