### PR TITLE
Change chart-releaser-action config to not set Helm Chart releases as default

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -25,3 +25,4 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           config: .github/cr.yaml
+          mark_as_latest: false


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"Bug fix"

**What is this PR about? / Why do we need it?**

By default, the chart releaser messes up the latest release on GitHub by marking the release used for the Helm chart as latest. This disables that behavior.

See parameter list here: https://github.com/helm/chart-releaser-action/blob/main/action.yml

**What testing is done?** 

N/A