### PR TITLE
feat(helm): add to additionalClusterRoleRules to sidecar chart templates

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
@@ -21,3 +21,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments/status" ]
     verbs: [ "patch" ]
+  {{- with .Values.sidecars.attacher.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
@@ -33,3 +33,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
+  {{- with .Values.sidecars.provisioner.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
@@ -29,3 +29,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs: [ "get", "list", "watch" ]
+  {{- with .Values.sidecars.resizer.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -25,3 +25,6 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]
+  {{- with .Values.sidecars.snapshotter.additionalClusterRoleRules }}
+    {{- . | toYaml | nindent 2 }}
+  {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -23,6 +23,8 @@ sidecars:
     logLevel: 2
     # Additional parameters provided by external-provisioner.
     additionalArgs: []
+    # Grant additional permissions to external-provisioner
+    additionalClusterRoleRules:
     resources: {}
     # Tune leader lease election for csi-provisioner.
     # Leader election is on by default.
@@ -56,6 +58,8 @@ sidecars:
     logLevel: 2
     # Additional parameters provided by external-attacher.
     additionalArgs: []
+    # Grant additional permissions to external-attacher
+    additionalClusterRoleRules: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -71,6 +75,8 @@ sidecars:
     logLevel: 2
     # Additional parameters provided by csi-snapshotter.
     additionalArgs: []
+    # Grant additional permissions to csi-snapshotter
+    additionalClusterRoleRules: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true
@@ -105,6 +111,8 @@ sidecars:
     logLevel: 2
     # Additional parameters provided by external-resizer.
     additionalArgs: []
+    # Grant additional permissions to external-resizer
+    additionalClusterRoleRules: []
     resources: {}
     securityContext:
       readOnlyRootFilesystem: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feature

**What is this PR about? / Why do we need it?**
Allows users to more easily pass in sidecar cluster role rules when installing driver via helm chart. Closes #1746 

**What testing is done?** 
helm install with an additional cluster role rule 