### PR TITLE
Add volume attachment limits for c7a instance family

### DIFF
--- a/pkg/cloud/volume_limits.go
+++ b/pkg/cloud/volume_limits.go
@@ -17,7 +17,7 @@ const (
 func init() {
 	// This list of Nitro instance types have a dedicated Amazon EBS volume limit of up to 128 attachments, depending on instance size.
 	// The limit is not shared with other device attachments: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html#nitro-system-limits
-	instanceFamilies := []string{"m7i", "m7a", "c7i", "r7a", "r7iz"}
+	instanceFamilies := []string{"m7i", "m7a", "c7i", "c7a", "r7a", "r7iz"}
 	commonInstanceSizes := []string{"medium", "large", "xlarge", "2xlarge", "4xlarge", "8xlarge", "12xlarge"}
 
 	for _, family := range instanceFamilies {


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Add volume attachment limits for `c7a` instance family, see https://aws.amazon.com/about-aws/whats-new/2023/10/compute-optimized-amazon-ec2-c7a-instances/.

**What testing is done?** 

`make test`
