### PR TITLE
CI: Fix 'error: externally-managed-environment'

### DIFF
--- a/hack/e2e/chart-testing.sh
+++ b/hack/e2e/chart-testing.sh
@@ -10,6 +10,5 @@ function ct_install() {
     curl --silent --location "${CHART_TESTING_DOWNLOAD_URL}" | tar xz -C "${INSTALL_PATH}"
     chmod +x "${INSTALL_PATH}"/ct
   fi
-
-  python3 -m pip install yamllint yamale
+  apt-get update && apt-get install -y yamllint
 }


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

See [PEP 668 – Marking Python base environments as “externally managed”](https://peps.python.org/pep-0668/) and https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/1706/pull-aws-ebs-csi-driver-test-helm-chart/1711789551590051840/build-log.txt for context.

**What testing is done?** 

CI
