### PR TITLE
Add Helm compatibility for --reuse-values upgrades

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -64,7 +64,7 @@ Convert the `--extra-tags` command line arg from a map.
 */}}
 {{- define "aws-ebs-csi-driver.extra-volume-tags" -}}
 {{- $result := dict "pairs" (list) -}}
-{{- range $key, $value := .Values.controller.extraVolumeTags -}}
+{{- range $key, $value := (.Values.controller).extraVolumeTags -}}
 {{- $noop := printf "%s=%v" $key $value | append $result.pairs | set $result "pairs" -}}
 {{- end -}}
 {{- if gt (len $result.pairs) 0 -}}
@@ -77,9 +77,9 @@ Handle http proxy env vars
 */}}
 {{- define "aws-ebs-csi-driver.http-proxy" -}}
 - name: HTTP_PROXY
-  value: {{ .Values.proxy.http_proxy | quote }}
+  value: {{ (.Values.proxy).http_proxy | quote }}
 - name: HTTPS_PROXY
-  value: {{ .Values.proxy.http_proxy | quote }}
+  value: {{ (.Values.proxy).http_proxy | quote }}
 - name: NO_PROXY
-  value: {{ .Values.proxy.no_proxy | quote }}
+  value: {{ (.Values.proxy).no_proxy | quote }}
 {{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -1,5 +1,6 @@
 {{- define "node" }}
-{{- if or (eq (default true .Values.node.enableLinux) true) }}
+{{- if or (eq (default true (.Values.node).enableLinux) true) }}
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -12,61 +13,83 @@ spec:
     matchLabels:
       app: {{ .NodeName }}
       {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
+  {{- with (.Values.node).updateStrategy }}
   updateStrategy:
-    {{- toYaml .Values.node.updateStrategy | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "10%"
+  {{- end }}
   template:
     metadata:
       labels:
         app: {{ .NodeName }}
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
-        {{- if .Values.node.podLabels }}
-        {{- toYaml .Values.node.podLabels | nindent 8 }}
+        {{- with (.Values.node).podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.node.podAnnotations }}
+      {{- with (.Values.node).podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with .Values.node.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
+      {{- with (.Values.node).affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
-        {{- with .Values.node.nodeSelector }}
+        {{- with (.Values.node).nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      serviceAccountName: {{ .Values.node.serviceAccount.name }}
-      priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
+      serviceAccountName: {{ default "ebs-csi-node-sa" ((.Values.node).serviceAccount).name }}
+      priorityClassName: {{ default "system-node-critical" (.Values.node).priorityClassName }}
       tolerations:
-        {{- if .Values.node.tolerateAllTaints }}
+        {{- if default true (.Values.node).tolerateAllTaints }}
         - operator: Exists
         {{- else }}
-        {{- with .Values.node.tolerations }}
+        {{- with (.Values.node).tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         - key: "ebs.csi.aws.com/agent-not-ready"
           operator: "Exists"
         {{- end }}
-      hostNetwork: {{ .Values.node.hostNetwork }}
-      {{- with .Values.node.securityContext }}
+      hostNetwork: {{ default "false" (.Values.node).hostNetwork }}
+      {{- with (.Values.node).securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+      {{- else }}
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver" (.Values.image).repository) (toString (default (printf "v%s" .Chart.AppVersion) (.Values.image).tag)) }}
+          imagePullPolicy: {{ default "IfNotPresent" (.Values.image).pullPolicy }}
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
-            {{- with .Values.node.volumeAttachLimit }}
+            {{- with (.Values.node).volumeAttachLimit }}
             - --volume-attach-limit={{ . }}
             {{- end }}
-            {{- with .Values.node.loggingFormat }}
-            - --logging-format={{ . }}
-            {{- end }}
-            - --v={{ .Values.node.logLevel }}
-            {{- if .Values.node.otelTracing }}
+            - --logging-format={{ default "text" (.Values.node).loggingFormat }}
+            - --v={{ default "2" (.Values.node).logLevel }}
+            {{- if (.Values.node).otelTracing }}
             - --enable-otel-tracing=true
             {{- end}}
           env:
@@ -76,31 +99,31 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.node.otelTracing }}
+            {{- with (.Values.node).otelTracing }}
             - name: OTEL_SERVICE_NAME
               value: {{ .otelServiceName }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otelExporterEndpoint }}
             {{- end }}
-            {{- with .Values.node.env }}
+            {{- with (.Values.node).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.node).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: kubelet-dir
-              mountPath: {{ .Values.node.kubeletPath }}
+              mountPath: {{ default "/var/lib/kubelet" (.Values.node).kubeletPath }}
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
-          {{- with .Values.node.volumeMounts }}
+          {{- with (.Values.node).volumeMounts }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
@@ -115,40 +138,51 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
-          {{- with .Values.node.resources }}
+          {{- with (.Values.node).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.node.containerSecurityContext }}
+          {{- with (.Values.node).containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            privileged: true
           {{- end }}
           lifecycle:
             preStop:
               exec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
         - name: node-driver-registrar
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.nodeDriverRegistrar.image.repository .Values.sidecars.nodeDriverRegistrar.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.nodeDriverRegistrar.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar" (((.Values.sidecars).nodeDriverRegistrar).image).repository) (default "v2.9.0-eks-1-28-6" (((.Values.sidecars).nodeDriverRegistrar).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) (((.Values.sidecars).nodeDriverRegistrar).image).pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v={{ .Values.sidecars.nodeDriverRegistrar.logLevel }}
+            - --v={{ default "2" ((.Values.sidecars).nodeDriverRegistrar).logLevel }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ printf "%s/plugins/ebs.csi.aws.com/csi.sock" (trimSuffix "/" .Values.node.kubeletPath) }}
-            {{- if .Values.proxy.http_proxy }}
+              value: {{ printf "%s/plugins/ebs.csi.aws.com/csi.sock" (trimSuffix "/" (default "/var/lib/kubelet" (.Values.node).kubeletPath)) }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.sidecars.nodeDriverRegistrar.env }}
+            {{- with ((.Values.sidecars).nodeDriverRegistrar).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-            {{- range .Values.sidecars.nodeDriverRegistrar.additionalArgs }}
+            {{- range ((.Values.sidecars).nodeDriverRegistrar).additionalArgs }}
             - {{ . }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.node).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
@@ -167,56 +201,78 @@ spec:
             - name: registration-dir
               mountPath: /registration
             - name: probe-dir
-              mountPath: {{ printf "%s/plugins/ebs.csi.aws.com/" (trimSuffix "/" .Values.node.kubeletPath) }}
-          {{- with default .Values.node.resources .Values.sidecars.nodeDriverRegistrar.resources }}
+              mountPath: {{ printf "%s/plugins/ebs.csi.aws.com/" (trimSuffix "/" (default "/var/lib/kubelet" (.Values.node).kubeletPath)) }}
+          {{- with default (.Values.node).resources ((.Values.sidecars).nodeDriverRegistrar).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.nodeDriverRegistrar.securityContext }}
+          {{- with ((.Values.sidecars).nodeDriverRegistrar).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.livenessProbe.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe" (((.Values.sidecars).livenessProbe).image).repository) (default "v2.10.0-eks-1-28-6" (((.Values.sidecars).livenessProbe).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) (((.Values.sidecars).livenessProbe).image).pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
-            {{- range .Values.sidecars.livenessProbe.additionalArgs }}
+            {{- range ((.Values.sidecars).livenessProbe).additionalArgs }}
             - {{ . }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.node).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
-          {{- with default .Values.node.resources .Values.sidecars.livenessProbe.resources }}
+          {{- with default (.Values.node).resources ((.Values.sidecars).livenessProbe).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.livenessProbe.securityContext }}
+          {{- with ((.Values.sidecars).livenessProbe).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
-      {{- if .Values.imagePullSecrets }}
+      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.imagePullSecrets }}
+      {{- range . }}
         - name: {{ . }}
       {{- end }}
       {{- end }}
       volumes:
         - name: kubelet-dir
           hostPath:
-            path: {{ .Values.node.kubeletPath }}
+            path: {{ (default "/var/lib/kubelet" (.Values.node).kubeletPath) }}
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: {{ printf "%s/plugins/ebs.csi.aws.com/" (trimSuffix "/" .Values.node.kubeletPath) }}
+            path: {{ printf "%s/plugins/ebs.csi.aws.com/" (trimSuffix "/" (default "/var/lib/kubelet" (.Values.node).kubeletPath)) }}
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: {{ printf "%s/plugins_registry/" (trimSuffix "/" .Values.node.kubeletPath) }}
+            path: {{ printf "%s/plugins_registry/" (trimSuffix "/" (default "/var/lib/kubelet" (.Values.node).kubeletPath)) }}
             type: Directory
         - name: device-dir
           hostPath:
@@ -224,7 +280,7 @@ spec:
             type: Directory
         - name: probe-dir
           emptyDir: {}
-        {{- with .Values.node.volumes }}
+        {{- with (.Values.node).volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
@@ -21,6 +21,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments/status" ]
     verbs: [ "patch" ]
-  {{- with .Values.sidecars.attacher.additionalClusterRoleRules }}
+  {{- with ((.Values.sidecars).attacher).additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
@@ -33,6 +33,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
-  {{- with .Values.sidecars.provisioner.additionalClusterRoleRules }}
+  {{- with ((.Values.sidecars).provisioner).additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
@@ -29,6 +29,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs: [ "get", "list", "watch" ]
-  {{- with .Values.sidecars.resizer.additionalClusterRoleRules }}
+  {{- with ((.Values.sidecars).resizer).additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -25,6 +25,6 @@ rules:
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]
-  {{- with .Values.sidecars.snapshotter.additionalClusterRoleRules }}
+  {{- with ((.Values.sidecars).snapshotter).additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.controller.serviceAccount.name }}
+    name: {{ (default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name) }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-csi-node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-csi-node.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.node.serviceAccount.name }}
+    name: {{ (default "ebs-csi-node-sa" ((.Values.node).serviceAccount).name) }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.controller.serviceAccount.name }}
+    name: {{ (default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name) }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.controller.serviceAccount.name }}
+    name: {{ (default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name) }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.controller.serviceAccount.name }}
+    name: {{ (default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name) }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -7,10 +7,15 @@ metadata:
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.controller.replicaCount }}
-  {{- with .Values.controller.updateStrategy }}
+  replicas: {{ (default 2 (.Values.controller).replicaCount) }}
+  {{- with (.Values.controller).updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
+  {{- else }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   {{- end }}
   selector:
     matchLabels:
@@ -21,83 +26,110 @@ spec:
       labels:
         app: ebs-csi-controller
         {{- include "aws-ebs-csi-driver.labels" . | nindent 8 }}
-        {{- if .Values.controller.podLabels }}
-        {{- toYaml .Values.controller.podLabels | nindent 8 }}
+        {{- if (.Values.controller).podLabels }}
+        {{- toYaml (.Values.controller).podLabels | nindent 8 }}
         {{- end }}
-      {{- if .Values.controller.podAnnotations }}
+      {{- if (.Values.controller).podAnnotations }}
       annotations:
-        {{- tpl ( .Values.controller.podAnnotations | toYaml ) . | nindent 8 }}
+        {{- tpl ( (.Values.controller).podAnnotations | toYaml ) . | nindent 8 }}
       {{- end }}
     spec:
       nodeSelector:
         kubernetes.io/os: linux
-        {{- with .Values.controller.nodeSelector }}
+        {{- with (.Values.controller).nodeSelector }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
-      priorityClassName: {{ .Values.controller.priorityClassName }}
-      {{- with default .Values.controller.affinity }}
+      serviceAccountName: {{ default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name }}
+      priorityClassName: {{ default "system-cluster-critical" (.Values.controller).priorityClassName }}
+      {{- with (.Values.controller).affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+      {{- else }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - ebs-csi-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       {{- end }}
+      {{- with (.Values.controller).tolerations }}
       tolerations:
-        {{- with .Values.controller.tolerations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- if .Values.controller.topologySpreadConstraints }}
+      {{- else }}
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+          tolerationSeconds: 300
+      {{- end }}
+      {{- if (.Values.controller).topologySpreadConstraints }}
       {{- $tscLabelSelector := dict "labelSelector" ( dict "matchLabels" ( dict "app" "ebs-csi-controller" ) ) }}
       {{- $constraints := list }}
-      {{- range .Values.controller.topologySpreadConstraints }}
+      {{- range (.Values.controller).topologySpreadConstraints }}
         {{- $constraints = mustAppend $constraints (mergeOverwrite . $tscLabelSelector) }}
       {{- end }}
       topologySpreadConstraints:
         {{- $constraints | toYaml | nindent 8 }}
       {{- end }}
-      {{- with .Values.controller.securityContext }}
+      {{- with (.Values.controller).securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+      {{- else }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       {{- end }}
-      {{- with .Values.controller.initContainers }}
+      {{- with (.Values.controller).initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver" (.Values.image).repository) (toString (default (printf "v%s" .Chart.AppVersion) (.Values.image).tag)) }}
+          imagePullPolicy: {{ default "IfNotPresent" (.Values.image).pullPolicy }}
           args:
-            {{- if ne .Release.Name "kustomize" }}
             - controller
-            {{- else }}
-            # - {all,controller,node} # specify the driver mode
-            {{- end }}
             - --endpoint=$(CSI_ENDPOINT)
-            {{- if .Values.controller.extraVolumeTags }}
+            {{- if (.Values.controller).extraVolumeTags }}
               {{- include "aws-ebs-csi-driver.extra-volume-tags" . | nindent 12 }}
             {{- end }}
-            {{- with (tpl (default "" .Values.controller.k8sTagClusterId) . )  }}
+            {{- with (tpl (default "" (.Values.controller).k8sTagClusterId) . )  }}
             - --k8s-tag-cluster-id={{ . }}
             {{- end }}
-            {{- if and (.Values.controller.enableMetrics) (not .Values.controller.httpEndpoint) }}
+            {{- if and ((.Values.controller).enableMetrics) (not (.Values.controller).httpEndpoint) }}
             - --http-endpoint=0.0.0.0:3301
             {{- end}}
-            {{- with .Values.controller.httpEndpoint }}
+            {{- with (.Values.controller).httpEndpoint }}
             - --http-endpoint={{ . }}
             {{- end }}
-            {{- if .Values.controller.sdkDebugLog }}
+            {{- if (.Values.controller).sdkDebugLog }}
             - --aws-sdk-debug-log=true
             {{- end}}
-            {{- with .Values.controller.loggingFormat }}
-            - --logging-format={{ . }}
-            {{- end }}
-            {{- with .Values.controller.userAgentExtra }}
-            - --user-agent-extra={{ . }}
-            {{- end }}
-            {{- if .Values.controller.otelTracing }}
+            - --logging-format={{ default "text" (.Values.controller).loggingFormat }}
+            - --user-agent-extra={{ default "helm" (.Values.controller).userAgentExtra }}
+            {{- if (.Values.controller).otelTracing }}
             - --enable-otel-tracing=true
             {{- end}}
-            - --v={{ .Values.controller.logLevel }}
-            {{- range .Values.controller.additionalArgs }}
+            - --v={{ default "2" (.Values.controller).logLevel }}
+            {{- range (.Values.controller).additionalArgs }}
             - {{ . }}
             {{- end }}
           env:
@@ -107,57 +139,55 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            {{- with .Values.awsAccessSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .name }}
-                  key: {{ .keyId }}
+                  name: {{ default "aws-secret" (.Values.awsAccessSecret).name }}
+                  key: {{ default "key_id" (.Values.awsAccessSecret).keyId }}
                   optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .name }}
-                  key: {{ .accessKey }}
+                  name: {{ default "aws-secret" (.Values.awsAccessSecret).name }}
+                  key: {{ default "key_id" (.Values.awsAccessSecret).accessKey }}
                   optional: true
-            {{- end }}
             - name: AWS_EC2_ENDPOINT
               valueFrom:
                 configMapKeyRef:
                   name: aws-meta
                   key: endpoint
                   optional: true
-            {{- with .Values.controller.region }}
+            {{- with (.Values.controller).region }}
             - name: AWS_REGION
               value: {{ . }}
             {{- end }}
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.controller.env }}
+            {{- with (.Values.controller).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-            {{- with .Values.controller.otelTracing }}
+            {{- with (.Values.controller).otelTracing }}
             - name: OTEL_SERVICE_NAME
               value: {{ .otelServiceName }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otelExporterEndpoint }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with .Values.controller.volumeMounts }}
+          {{- with (.Values.controller).volumeMounts }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
             - name: healthz
               containerPort: 9808
               protocol: TCP
-            {{- if .Values.controller.enableMetrics }}
+            {{- if (.Values.controller).enableMetrics }}
             - name: metrics
               containerPort: 3301
               protocol: TCP
@@ -178,167 +208,211 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
-          {{- with .Values.controller.resources }}
+          {{- with (.Values.controller).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.controller.containerSecurityContext }}
+          {{- with (.Values.controller).containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
         - name: csi-provisioner
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.provisioner.image.repository .Values.sidecars.provisioner.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.provisioner.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner" (((.Values.sidecars).provisioner).image).repository) (default "v3.5.0-eks-1-28-6" (((.Values.sidecars).provisioner).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) ((.Values.sidecars).provisioner).image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v={{ .Values.sidecars.provisioner.logLevel }}
+            - --v={{ default "2" ((.Values.sidecars).provisioner).logLevel }}
             - --feature-gates=Topology=true
-            {{- if .Values.controller.extraCreateMetadata }}
+            {{- if default true (.Values.controller).extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}
-            - --leader-election={{ .Values.sidecars.provisioner.leaderElection.enabled | required "leader election state for csi-provisioner is required, must be set to true || false." }}
-            {{- if .Values.sidecars.provisioner.leaderElection.enabled }}
-            {{- if .Values.sidecars.provisioner.leaderElection.leaseDuration }}
-            - --leader-election-lease-duration={{ .Values.sidecars.provisioner.leaderElection.leaseDuration }}
+            - --leader-election={{ default true (((.Values.sidecars).provisioner).leaderElection).enabled }}
+            {{- if default true (((.Values.sidecars).provisioner).leaderElection).enabled }}
+            {{- with (((.Values.sidecars).provisioner).leaderElection).leaseDuration }}
+            - --leader-election-lease-duration={{ ((.Values.sidecars).provisioner).leaderElection.leaseDuration }}
             {{- end }}
-            {{- if .Values.sidecars.provisioner.leaderElection.renewDeadline}}
-            - --leader-election-renew-deadline={{ .Values.sidecars.provisioner.leaderElection.renewDeadline }}
+            {{- with (((.Values.sidecars).provisioner).leaderElection).renewDeadline}}
+            - --leader-election-renew-deadline={{ ((.Values.sidecars).provisioner).leaderElection.renewDeadline }}
             {{- end }}
-            {{- if .Values.sidecars.provisioner.leaderElection.retryPeriod }}
-            - --leader-election-retry-period={{ .Values.sidecars.provisioner.leaderElection.retryPeriod }}
+            {{- with (((.Values.sidecars).provisioner).leaderElection).retryPeriod }}
+            - --leader-election-retry-period={{ ((.Values.sidecars).provisioner).leaderElection.retryPeriod }}
             {{- end }}
             {{- end }}
-            - --default-fstype={{ .Values.controller.defaultFsType }}
-            {{- range .Values.sidecars.provisioner.additionalArgs }}
+            - --default-fstype={{ default "ext4" (.Values.controller).defaultFsType }}
+            {{- range ((.Values.sidecars).provisioner).additionalArgs }}
             - {{ . }}
             {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.sidecars.provisioner.env }}
+            {{- with ((.Values.sidecars).provisioner).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with default .Values.controller.resources .Values.sidecars.provisioner.resources }}
+          {{- with default (.Values.controller).resources ((.Values.sidecars).provisioner).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.provisioner.securityContext }}
+          {{- with ((.Values.sidecars).provisioner).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
         - name: csi-attacher
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.attacher.image.repository .Values.sidecars.attacher.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.attacher.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher" (((.Values.sidecars).attacher).image).repository) (default "v4.4.0-eks-1-28-6" (((.Values.sidecars).attacher).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) ((.Values.sidecars).attacher).image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v={{ .Values.sidecars.attacher.logLevel }}
-            - --leader-election={{ .Values.sidecars.attacher.leaderElection.enabled | required "leader election state for csi-attacher is required, must be set to true || false." }}
-            {{- if .Values.sidecars.attacher.leaderElection.enabled }}
-            {{- if .Values.sidecars.attacher.leaderElection.leaseDuration }}
-            - --leader-election-lease-duration={{ .Values.sidecars.attacher.leaderElection.leaseDuration }}
+            - --v={{ default "2" ((.Values.sidecars).attacher).logLevel }}
+            - --leader-election={{ default true (((.Values.sidecars).attacher).leaderElection).enabled }}
+            {{- if default true (((.Values.sidecars).attacher).leaderElection).enabled }}
+            {{- with (((.Values.sidecars).attacher).leaderElection).leaseDuration }}
+            - --leader-election-lease-duration={{ ((.Values.sidecars).attacher).leaderElection.leaseDuration }}
             {{- end }}
-            {{- if .Values.sidecars.attacher.leaderElection.renewDeadline}}
-            - --leader-election-renew-deadline={{ .Values.sidecars.attacher.leaderElection.renewDeadline }}
+            {{- with (((.Values.sidecars).attacher).leaderElection).renewDeadline}}
+            - --leader-election-renew-deadline={{ ((.Values.sidecars).attacher).leaderElection.renewDeadline }}
             {{- end }}
-            {{- if .Values.sidecars.attacher.leaderElection.retryPeriod }}
-            - --leader-election-retry-period={{ .Values.sidecars.attacher.leaderElection.retryPeriod }}
+            {{- with (((.Values.sidecars).attacher).leaderElection).retryPeriod }}
+            - --leader-election-retry-period={{ ((.Values.sidecars).attacher).leaderElection.retryPeriod }}
             {{- end }}
             {{- end }}
-            {{- range .Values.sidecars.attacher.additionalArgs }}
+            {{- range ((.Values.sidecars).attacher).additionalArgs }}
             - {{ . }}
             {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.sidecars.attacher.env }}
+            {{- with ((.Values.sidecars).attacher).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with default .Values.controller.resources .Values.sidecars.attacher.resources }}
+          {{- with default (.Values.controller).resources ((.Values.sidecars).attacher).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.attacher.securityContext }}
+          {{- with ((.Values.sidecars).attacher).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
-        {{- if or .Values.sidecars.snapshotter.forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
+        {{- if or ((.Values.sidecars).snapshotter).forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
         - name: csi-snapshotter
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.snapshotter.image.repository .Values.sidecars.snapshotter.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.snapshotter.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter" (((.Values.sidecars).snapshotter).image).repository) (default "v6.3.0-eks-1-28-6" (((.Values.sidecars).snapshotter).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) ((.Values.sidecars).snapshotter).image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
-            {{- if .Values.controller.extraCreateMetadata }}
+            {{- if default true (.Values.controller).extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}
-            {{- range .Values.sidecars.snapshotter.additionalArgs }}
+            {{- range ((.Values.sidecars).snapshotter).additionalArgs }}
             - {{ . }}
             {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.sidecars.snapshotter.env }}
+            {{- with ((.Values.sidecars).snapshotter).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with default .Values.controller.resources .Values.sidecars.snapshotter.resources }}
+          {{- with default (.Values.controller).resources ((.Values.sidecars).snapshotter).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.snapshotter.securityContext }}
+          {{- with ((.Values.sidecars).snapshotter).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
         {{- end }}
-        {{- if (.Values.controller.volumeModificationFeature).enabled }}
+        {{- if ((.Values.controller).volumeModificationFeature).enabled }}
         - name: volumemodifier
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.volumemodifier.image.repository .Values.sidecars.volumemodifier.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.volumemodifier.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s" (((.Values.sidecars).volumemodifier).image).repository) (default "v0.1.3" (((.Values.sidecars).volumemodifier).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) ((.Values.sidecars).volumemodifier).image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v={{ .Values.sidecars.volumemodifier.logLevel }}
-            - --leader-election={{ .Values.sidecars.volumemodifier.leaderElection.enabled | required "leader election state for csi-volumemodifier is required, must be set to true || false." }}
-            {{- if .Values.sidecars.volumemodifier.leaderElection.enabled }}
-            {{- if .Values.sidecars.volumemodifier.leaderElection.leaseDuration }}
-            - --leader-election-lease-duration={{ .Values.sidecars.volumemodifier.leaderElection.leaseDuration }}
+            - --v={{ default "2" ((.Values.sidecars).volumemodifier).logLevel }}
+            - --leader-election={{ default true (((.Values.sidecars).volumemodifier).leaderElection).enabled }}
+            {{- if default true (((.Values.sidecars).volumemodifier).leaderElection).enabled }}
+            {{- with (((.Values.sidecars).volumemodifier).leaderElection).leaseDuration }}
+            - --leader-election-lease-duration={{ ((.Values.sidecars).volumemodifier).leaderElection.leaseDuration }}
             {{- end }}
-            {{- if .Values.sidecars.volumemodifier.leaderElection.renewDeadline}}
-            - --leader-election-renew-deadline={{ .Values.sidecars.volumemodifier.leaderElection.renewDeadline }}
+            {{- with (((.Values.sidecars).volumemodifier).leaderElection).renewDeadline}}
+            - --leader-election-renew-deadline={{ ((.Values.sidecars).volumemodifier).leaderElection.renewDeadline }}
             {{- end }}
-            {{- if .Values.sidecars.volumemodifier.leaderElection.retryPeriod }}
-            - --leader-election-retry-period={{ .Values.sidecars.volumemodifier.leaderElection.retryPeriod }}
+            {{- with (((.Values.sidecars).volumemodifier).leaderElection).retryPeriod }}
+            - --leader-election-retry-period={{ ((.Values.sidecars).volumemodifier).leaderElection.retryPeriod }}
             {{- end }}
             {{- end }}
-            {{- range .Values.sidecars.volumemodifier.additionalArgs }}
+            {{- range ((.Values.sidecars).volumemodifier).additionalArgs }}
             - {{ . }}
             {{- end }}
           env:
@@ -352,96 +426,129 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.sidecars.volumemodifier.env }}
+            {{- with ((.Values.sidecars).volumemodifier).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with default .Values.controller.resources .Values.sidecars.volumemodifier.resources }}
+          {{- with default (.Values.controller).resources ((.Values.sidecars).volumemodifier).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.volumemodifier.securityContext }}
+          {{- with ((.Values.sidecars).volumemodifier).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
         {{- end }}
         - name: csi-resizer
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.resizer.image.repository .Values.sidecars.resizer.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.resizer.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer" (((.Values.sidecars).resizer).image).repository) (default "v1.9.0-eks-1-28-6" (((.Values.sidecars).resizer).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) ((.Values.sidecars).resizer).image.pullPolicy }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v={{ .Values.sidecars.resizer.logLevel }}
+            - --v={{ default "2" ((.Values.sidecars).resizer).logLevel }}
             - --handle-volume-inuse-error=false
-            {{- with .Values.sidecars.resizer.leaderElection }}
-            - --leader-election={{ .enabled | default true }}
-            {{- if .leaseDuration }}
-            - --leader-election-lease-duration={{ .leaseDuration }}
+            - --leader-election={{ default true (((.Values.sidecars).resizer).leaderElection).enabled }}
+            {{- if default true (((.Values.sidecars).resizer).leaderElection).enabled }}
+            {{- with (((.Values.sidecars).resizer).leaderElection).leaseDuration }}
+            - --leader-election-lease-duration={{ ((.Values.sidecars).resizer).leaderElection.leaseDuration }}
             {{- end }}
-            {{- if .renewDeadline }}
-            - --leader-election-renew-deadline={{ .renewDeadline }}
+            {{- with (((.Values.sidecars).resizer).leaderElection).renewDeadline}}
+            - --leader-election-renew-deadline={{ ((.Values.sidecars).resizer).leaderElection.renewDeadline }}
             {{- end }}
-            {{- if .retryPeriod }}
-            - --leader-election-retry-period={{ .retryPeriod }}
+            {{- with (((.Values.sidecars).resizer).leaderElection).retryPeriod }}
+            - --leader-election-retry-period={{ ((.Values.sidecars).resizer).leaderElection.retryPeriod }}
             {{- end }}
             {{- end }}
-            {{- range .Values.sidecars.resizer.additionalArgs }}
+            {{- range ((.Values.sidecars).resizer).additionalArgs }}
             - {{ . }}
             {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            {{- if .Values.proxy.http_proxy }}
+            {{- if (.Values.proxy).http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.sidecars.resizer.env }}
+            {{- with ((.Values.sidecars).resizer).env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-          {{- with default .Values.controller.resources .Values.sidecars.resizer.resources }}
+          {{- with default (.Values.controller).resources ((.Values.sidecars).resizer).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.resizer.securityContext }}
+          {{- with ((.Values.sidecars).resizer).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
         - name: liveness-probe
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.livenessProbe.image.repository .Values.sidecars.livenessProbe.image.tag }}
-          imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.livenessProbe.image.pullPolicy }}
+          image: {{ printf "%s%s:%s" (default "" (.Values.image).containerRegistry) (default "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe" (((.Values.sidecars).livenessProbe).image).repository) (default "v2.10.0-eks-1-28-6" (((.Values.sidecars).livenessProbe).image).tag) }}
+          imagePullPolicy: {{ default (default "IfNotPresent" (.Values.image).pullPolicy) ((.Values.sidecars).livenessProbe).image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
-            {{- range .Values.sidecars.livenessProbe.additionalArgs }}
+            {{- range ((.Values.sidecars).livenessProbe).additionalArgs }}
             - {{ . }}
             {{- end }}
-          {{- with .Values.controller.envFrom }}
+          {{- with (.Values.controller).envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-          {{- with default .Values.controller.resources .Values.sidecars.livenessProbe.resources }}
+          {{- with default (.Values.controller).resources ((.Values.sidecars).livenessProbe).resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 40Mi
+            limits:
+              memory: 256Mi
           {{- end }}
-          {{- with .Values.sidecars.livenessProbe.securityContext }}
+          {{- with ((.Values.sidecars).livenessProbe).securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -452,6 +559,6 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
-        {{- with .Values.controller.volumes }}
+        {{- with (.Values.controller).volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: ebs.csi.aws.com

--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enableMetrics -}}
+{{- if (.Values.controller).enableMetrics -}}
 ---
 apiVersion: v1
 kind: Service
@@ -16,7 +16,7 @@ spec:
       targetPort: 3301
   type: ClusterIP
 ---
-{{- if or .Values.controller.serviceMonitor.forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if or ((.Values.controller).serviceMonitor).forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -24,8 +24,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: ebs-csi-controller
-    {{- if .Values.controller.serviceMonitor.labels }}
-    {{- toYaml .Values.controller.serviceMonitor.labels | nindent 4 }}
+    {{- with ((.Values.controller).serviceMonitor).labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    release: prometheus
     {{- end }}
 spec:
   selector:

--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -9,6 +9,5 @@
     "node" (deepCopy $.Values.node | mustMerge $values)
   )
 }}
----
 {{- include "node-windows" (deepCopy $ | mustMerge $args) -}}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -9,6 +9,5 @@
     "node" (deepCopy $.Values.node | mustMerge $values)
   )
 }}
----
 {{- include "node" (deepCopy $ | mustMerge $args) -}}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app: ebs-csi-controller
       {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
-  {{- if le (.Values.controller.replicaCount | int) 2 }}
+  {{- if le ((default 2 (.Values.controller).replicaCount) | int) 2 }}
   maxUnavailable: 1
   {{- else }}
   minAvailable: 2

--- a/charts/aws-ebs-csi-driver/templates/rolebinding-leases.yaml
+++ b/charts/aws-ebs-csi-driver/templates/rolebinding-leases.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.controller.serviceAccount.name }}
+  name: {{ (default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name) }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -1,21 +1,14 @@
-{{- if .Values.controller.serviceAccount.create -}}
+{{- if default true ((.Values.controller).serviceAccount).create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.controller.serviceAccount.name }}
+  name: {{ (default "ebs-csi-controller-sa" ((.Values.controller).serviceAccount).name) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
-  {{- with .Values.controller.serviceAccount.annotations }}
+  {{- with ((.Values.controller).serviceAccount).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if eq .Release.Name "kustomize" }}
-  #Enable if EKS IAM roles for service accounts (IRSA) is used. See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
-  #annotations:
-  #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
-  {{- end }}
-{{- if .Values.controller.serviceAccount.automountServiceAccountToken }}
-automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
-{{- end }}
+automountServiceAccountToken: {{ default "true" ((.Values.controller).serviceAccount).automountServiceAccountToken }}
 {{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-node.yaml
@@ -1,16 +1,14 @@
-{{- if .Values.node.serviceAccount.create -}}
+{{- if default true ((.Values.node).serviceAccount).create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.node.serviceAccount.name }}
+  name: {{ (default "ebs-csi-node-sa" ((.Values.node).serviceAccount).name) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
-  {{- with .Values.node.serviceAccount.annotations }}
+  {{- with ((.Values.node).serviceAccount).annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if .Values.node.serviceAccount.automountServiceAccountToken }}
-automountServiceAccountToken: {{ .Values.node.serviceAccount.automountServiceAccountToken }}
-{{- end }}
+automountServiceAccountToken: {{ default "true" ((.Values.node).serviceAccount).automountServiceAccountToken }}
 {{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/volumesnapshotclass.yaml
+++ b/charts/aws-ebs-csi-driver/templates/volumesnapshotclass.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.sidecars.snapshotter.forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
+{{- if or ((.Values.sidecars).snapshotter).forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
 {{- range .Values.volumeSnapshotClasses }}
 ---
 kind: VolumeSnapshotClass

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -64,7 +64,7 @@ spec:
           image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0
           imagePullPolicy: IfNotPresent
           args:
-            # - {all,controller,node} # specify the driver mode
+            - controller
             - --endpoint=$(CSI_ENDPOINT)
             - --logging-format=text
             - --user-agent-extra=kustomize

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -6,7 +6,4 @@ metadata:
   name: ebs-csi-controller-sa
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
-  #Enable if EKS IAM roles for service accounts (IRSA) is used. See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
-  #annotations:
-  #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
 automountServiceAccountToken: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Adds support for upgrading with `--reuse-values` with Helm from any prior version

**What is this PR about? / Why do we need it?**

The team decided we want to support upgrades when using `--reuse-values`. This PR adds support for that from any prior version. Unfortunately, already released versions cannot be fixed, but this will fix any upgrades to the next or any later version.

**What testing is done?** 

Testing on master (doesn't work):
```bash
# Oldest release of the EBS CSI Driver chart, thus the worst case scenario for --reuse-values
$ git checkout aws-ebs-csi-driver-0.6.2

# Note: depending on your Kubernetes version, you may need to make some changes to the Chart to bump removed API versions
$ helm install aws-ebs-csi-driver .
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Oct 18 18:29:05 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"
    
# Switch to latest release
$ git checkout release-1.23

# Note: useOldCSIDriver=true is required to prevent immutable change (although it won't matter here because the upgrade is broken anyways)
# It breaks!
$ helm upgrade --reuse-values --set useOldCSIDriver=true aws-ebs-csi-driver .
Error: UPGRADE FAILED: template: aws-ebs-csi-driver/templates/volumesnapshotclass.yaml:1:17: executing "aws-ebs-csi-driver/templates/volumesnapshotclass.yaml" at <.Values.sidecars.snapshotter.forceEnable>: nil pointer evaluating interface {}.forceEnable
```

Testing with PR (works):
```bash
# Oldest release of the EBS CSI Driver chart, thus the worst case scenario for --reuse-values
$ git checkout aws-ebs-csi-driver-0.6.2

# Note: depending on your Kubernetes version, you may need to make some changes to the Chart to bump removed API versions
$ helm install aws-ebs-csi-driver .
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Oct 18 18:31:53 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

# Switch to PR
$ git checkout helm-reuse-values-support

# Note: useOldCSIDriver=true is required to prevent immutable change
# It works!
$ helm upgrade --reuse-values --set useOldCSIDriver=true aws-ebs-csi-driver .          
Release "aws-ebs-csi-driver" has been upgraded. Happy Helming!
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Oct 18 18:33:57 2023
NAMESPACE: default
STATUS: deployed
REVISION: 3
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n default -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

NOTE: The [CSI Snapshotter](https://github.com/kubernetes-csi/external-snapshotter) controller and CRDs will no longer be installed as part of this chart and moving forward will be a prerequisite of using the snap shotting functionality.

# All pods are running etc
$ kubectl -n kube-system get pods                              
NAME                                            READY   STATUS    RESTARTS      AGE
aws-cloud-controller-manager-dt766              1/1     Running   0             41m
aws-node-termination-handler-68d9cbd5dc-xfzcx   1/1     Running   0             41m
coredns-78c4944598-8zs9h                        1/1     Running   0             40m
coredns-78c4944598-bbhqv                        1/1     Running   0             41m
coredns-autoscaler-fcf87bf56-h5j9h              1/1     Running   0             41m
dns-controller-c848f4d4d-kvxx4                  1/1     Running   0             41m
etcd-manager-events-i-00dc16e2d485fab66         1/1     Running   0             42m
etcd-manager-main-i-00dc16e2d485fab66           1/1     Running   0             42m
kops-controller-vmfll                           1/1     Running   0             41m
kube-apiserver-i-00dc16e2d485fab66              2/2     Running   2 (43m ago)   41m
kube-controller-manager-i-00dc16e2d485fab66     1/1     Running   4 (42m ago)   42m
kube-proxy-i-008703fa7cb2d77b7                  1/1     Running   0             39m
kube-proxy-i-00dc16e2d485fab66                  1/1     Running   0             41m
kube-scheduler-i-00dc16e2d485fab66              1/1     Running   0             41m
```