### PR TITLE
[Automate-Release-1] Add image-source-of-truth.yaml and update-truth-sidecars scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,3 +268,7 @@ generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/role-leases.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/role-leases.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/rolebinding-leases.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/rolebinding-leases.yaml
+
+.PHONY: update-truth-sidecars
+update-truth-sidecars: hack/release-scripts/image-source-of-truth.yaml hack/release-scripts/update-truth-sidecars
+	hack/release-scripts/update-truth-sidecars

--- a/hack/release-scripts/image-source-of-truth.yaml
+++ b/hack/release-scripts/image-source-of-truth.yaml
@@ -1,0 +1,42 @@
+# This file acts as the source of truth for the driver and sidecar image tags and digests used by the rest of the repository.
+# It is to be updated through the use of scripts in `hack/release-scripts` or Makefile targets.
+driver:
+  name: "aws-ebs-csi-driver"
+  version: "v1.24.0"
+  gcrStagingImage: "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver"
+  manifestDigest: ""
+  gcrImage: "registry.k8s.io/provider-aws/aws-ebs-csi-driver"
+  ecrImage: "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver"
+sidecars: # sidecar names match upstream helm chart values.yaml
+  snapshotter:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter"
+    tag: ""
+    manifestDigest: ""
+  attacher:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher"
+    tag: ""
+    manifestDigest: ""
+  provisioner:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
+    tag: ""
+    manifestDigest: ""
+  resizer:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer"
+    tag: ""
+    manifestDigest: ""
+  livenessProbe:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
+    tag: ""
+    manifestDigest: ""
+  nodeDriverRegistrar:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
+    tag: ""
+    manifestDigest: ""
+  volumemodifier:
+    image: "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s"
+    tag: ""
+    manifestDigest: ""
+  snapshotController:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller"
+    tag: ""
+    manifestDigest: ""

--- a/hack/release-scripts/update-truth-sidecars
+++ b/hack/release-scripts/update-truth-sidecars
@@ -1,0 +1,68 @@
+#!/bin/bash
+# This script updates the image-source-of-truth.yaml with the latest tags and associated manifest digests for each sidecar image.
+
+# --- Environment Variables
+export ROOT_DIRECTORY TRUTH_FILEPATH
+ROOT_DIRECTORY=${ROOT_DIRECTORY:=$(git rev-parse --show-toplevel)}
+TRUTH_FILEPATH=${TRUTH_FILEPATH:="$ROOT_DIRECTORY/hack/release-scripts/image-source-of-truth.yaml"}
+
+tmp_filename="tmp_$RANDOM.txt"
+# --- Script Tools
+set -euo pipefail # Exit on any error
+
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git" "crane")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+error_handler() {
+  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
+  exit 1
+}
+
+trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
+
+# --- Script
+trap 'rm $tmp_filename' EXIT
+
+crane_get_latest_image_tag() {
+  image=$1
+
+  export TAG
+  TAG=$(crane ls "$image" | sed '/latest/d' | sort -V | tail -1)  # Get tag for $image with latest semvar
+}
+
+update_sidecars_source_of_truth () {
+  yq '.sidecars | keys | .[]' "$TRUTH_FILEPATH" > $tmp_filename
+
+  for sidecar in $(cat $tmp_filename)
+       do
+         log "Updating $sidecar in $TRUTH_FILEPATH"
+         image=$(yq ".sidecars.$sidecar.image" "$TRUTH_FILEPATH")
+
+         export TAG
+         crane_get_latest_image_tag "$image"
+         yq ".sidecars.$sidecar.tag = env(TAG)" -i "$TRUTH_FILEPATH"
+
+         export DIGEST
+         DIGEST=$(crane digest "$image:$TAG")
+         yq ".sidecars.$sidecar.manifestDigest = env(DIGEST)" -i "$TRUTH_FILEPATH"
+       done
+}
+
+main () {
+  check_dependencies
+  update_sidecars_source_of_truth
+}
+
+main


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Release automation

**What is this PR about? / Why do we need it?**
NOTE: This PR is the first in the series [Automate-Release]. 

The [Automate-Release] PRs add the directory `hack/release-scripts` to help automate release related activity.

This PR adds:
- `image_source_of_truth.yaml`: Is the source of truth of images, tags, and manifest digests used in the rest of the repository. Scripts in `hack/release-scripts` will update this file and propagating those updates to the rest of the repository. 
- `update-truth-sidecars`: Updates the image-source-of-truth.yaml with the latest tags and associated manifest digests for each sidecar image by using `crane`.
- A `update-truth-sidecars` target for our `Makefile`.

**What testing is done?** 
Running make `update-truth-sidecars` will produce the following diff:

```
diff --git a/hack/release-scripts/image-source-of-truth.yaml b/hack/release-scripts/image-source-of-truth.yaml
index 50ada827..f337afd4 100644
--- a/hack/release-scripts/image-source-of-truth.yaml
+++ b/hack/release-scripts/image-source-of-truth.yaml
@@ -10,33 +10,33 @@ driver:
 sidecars: # sidecar names match upstream helm chart values.yaml
   snapshotter:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter"
-    tag: ""
-    manifestDigest: ""
+    tag: "v6.3.0-eks-1-28-7"
+    manifestDigest: "sha256:61ebea9d396ad9ef0767bd697b50ed2615c9fd49c2625e64c102d916030f7369"
   attacher:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher"
-    tag: ""
-    manifestDigest: ""
+    tag: "v4.4.0-eks-1-28-7"
+    manifestDigest: "sha256:955fd72b5b77cffdf785c7c110de0a927906a8765c19160fdb5d7cd74cdc20a6"
   provisioner:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
-    tag: ""
-    manifestDigest: ""
+    tag: "v3.6.0-eks-1-28-7"
+    manifestDigest: "sha256:91158c7bf17832d03d7472f4ceb111564d61674ac1aea10c3699f0c55545782d"
   resizer:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer"
-    tag: ""
-    manifestDigest: ""
+    tag: "v1.9.0-eks-1-28-7"
+    manifestDigest: "sha256:991ffd5221c340168fbcd77148fd4098df469c2bc78aa84bed4eb323673f87ca"
   livenessProbe:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
-    tag: ""
-    manifestDigest: ""
+    tag: "v2.11.0-eks-1-28-7"
+    manifestDigest: "sha256:1ee7f20beaf76a57c5446dc41b0718172e8beb69da8ca2343804309e3a58a367"
   nodeDriverRegistrar:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
-    tag: ""
-    manifestDigest: ""
+    tag: "v2.9.0-eks-1-28-7"
+    manifestDigest: "sha256:a51e121d046e459a4315894be43b13ba7348038a67d3e9fb4e3d44cda3dbed1a"
   volumemodifier:
     image: "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s"
-    tag: ""
-    manifestDigest: ""
+    tag: "v0.1.3"
+    manifestDigest: "sha256:5452144bfc75cb986ccf266cc967773801c91d47ff3b51326904fa516765c914"
   snapshotController:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller"
-    tag: ""
-    manifestDigest: ""
+    tag: "v6.3.0-eks-1-28-7"
+    manifestDigest: "sha256:a6f0bf7d1f16991bbd85764b2e2791f7812d13b04ed8596904cd3a6a9fbb87b1"

```

