### PR TITLE
Add release scripts for upgrading sidecar dependencies and collating image digests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ Vagrantfile
 # IntelliJ
 .idea/
 
-#MacOS system files
+# MacOS system files
 *.DS_Store
 
 # Vendor dir
@@ -30,3 +30,6 @@ vendor/
 
 # .image-* files used by Makefile
 .image-*
+
+# Files used by Makefile when upgrading sidecars
+hack/release-scripts/image-digests.yaml

--- a/Makefile
+++ b/Makefile
@@ -282,3 +282,14 @@ generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/role-leases.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/role-leases.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/rolebinding-leases.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/rolebinding-leases.yaml
+
+.PHONY: update-truth-sidecars
+update-truth-sidecars: hack/release-scripts/get-latest-sidecar-images
+	./hack/release-scripts/get-latest-sidecar-images
+
+.PHONY: generate-sidecar-tags
+generate-sidecar-tags: update-truth-sidecars charts/aws-ebs-csi-driver/values.yaml deploy/kubernetes/overlays/stable/gcr/kustomization.yaml hack/release-scripts/generate-sidecar-tags
+	./hack/release-scripts/generate-sidecar-tags
+
+.PHONY: update-sidecar-dependencies
+update-sidecar-dependencies: update-truth-sidecars generate-sidecar-tags generate-kustomize

--- a/hack/release-scripts/generate-sidecar-tags
+++ b/hack/release-scripts/generate-sidecar-tags
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---
+# This script generates the sidecar image tags in `deploy/kubernetes/overlays/stable/gcr/kustomization.yaml`and
+# `charts/aws-ebs-csi-driver/values.yaml` based off of the values in the generated
+# `hack/release-scripts/image-digests.yaml` file from running the get-latest-sidecar-images script.
+
+set -euo pipefail # Exit on any error
+
+# --- Environment Variables
+export SCRIPT_PATH ROOT_DIRECTORY TRUTH_FILEPATH HELM_VALUES_FILEPATH KUSTOMIZE_FILEPATH
+SCRIPT_PATH=$(dirname $(realpath "$0"))
+ROOT_DIRECTORY="$SCRIPT_PATH/../.."
+IMAGE_DIGESTS_FILEPATH=${IMAGE_DIGESTS_FILEPATH:="$ROOT_DIRECTORY/hack/release-scripts/image-digests.yaml"}
+HELM_VALUES_FILEPATH=${HELM_VALUES_FILEPATH:="$ROOT_DIRECTORY/charts/aws-ebs-csi-driver/values.yaml"}
+KUSTOMIZE_FILEPATH=${KUSTOMIZE_FILEPATH:="$ROOT_DIRECTORY/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml"}
+
+tmp_filename=$(mktemp)
+
+# --- Script Tools
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git" "sed")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+
+  # Force macOS users to use gsed due to -i incompatibility
+  export SED="sed"
+  if [[ $(uname) = "Darwin" ]]; then
+    if ! command -v "gsed" &>/dev/null; then
+      log "gsed could not be found, please install it."
+        exit 1
+    fi
+    SED="gsed"
+  fi
+}
+
+error_handler() {
+  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
+  exit 1
+}
+
+trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
+
+# --- Script
+trap 'rm $tmp_filename' EXIT
+
+update_gcr_kustomize_sidecar_tag () {
+  sidecar_name=$1
+  line_above=$2
+
+  tag=$(yq ".sidecars.$sidecar_name.tag" "$IMAGE_DIGESTS_FILEPATH" | awk -F- '{print $1}') # Cut off -eks-1... off of tag
+  log "Updating gcr kustomize $sidecar_name to $tag"
+  $SED -i "\|$line_above|{n;s/.*/    newTag: $tag/;}" "$KUSTOMIZE_FILEPATH"
+}
+
+update_helm_chart_sidecar_tag () {
+  sidecar_name=$1
+
+  export TAG
+  TAG=$(yq ".sidecars.$sidecar_name.tag" "$IMAGE_DIGESTS_FILEPATH")
+  log "Updating helm $sidecar_name sidecar to $TAG"
+  yq ".sidecars.$sidecar_name.image.tag = env(TAG)" -i "$HELM_VALUES_FILEPATH"
+}
+
+generate_gcr_kustomize () {
+  update_gcr_kustomize_sidecar_tag "provisioner" "newName: registry.k8s.io/sig-storage/csi-provisioner"
+  update_gcr_kustomize_sidecar_tag "attacher" "newName: registry.k8s.io/sig-storage/csi-attacher"
+  update_gcr_kustomize_sidecar_tag "livenessProbe" "newName: registry.k8s.io/sig-storage/livenessprobe"
+  update_gcr_kustomize_sidecar_tag "snapshotter" "newName: registry.k8s.io/sig-storage/csi-snapshotter"
+  update_gcr_kustomize_sidecar_tag "resizer" "newName: registry.k8s.io/sig-storage/csi-resizer"
+  update_gcr_kustomize_sidecar_tag "nodeDriverRegistrar" "newName: registry.k8s.io/sig-storage/csi-node-driver-registrar"
+
+  log "Success: All sidecar tags in $KUSTOMIZE_FILEPATH updated"
+}
+
+generate_helm_sidecars () {
+  yq '.sidecars | keys | .[]' "$IMAGE_DIGESTS_FILEPATH" > "$tmp_filename"
+
+  for sidecar in $(cat "$tmp_filename")
+     do
+       update_helm_chart_sidecar_tag "$sidecar"
+     done
+
+  log "Success: All sidecar tags in $HELM_VALUES_FILEPATH updated"
+}
+
+main () {
+  check_dependencies
+  generate_gcr_kustomize
+  generate_helm_sidecars
+}
+
+main

--- a/hack/release-scripts/get-latest-sidecar-images
+++ b/hack/release-scripts/get-latest-sidecar-images
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---
+# Script generates a file with the latest tags and associated manifest digests for each sidecar image at OUTPUT_FILEPATH
+
+set -euo pipefail # Exit on any error
+
+# --- Environment Variables
+export SCRIPT_PATH ROOT_DIRECTORY IMAGE_DIGESTS_TEMPLATE_FILEPATH OUTPUT_FILEPATH
+SCRIPT_PATH=$(dirname $(realpath "$0"))
+ROOT_DIRECTORY="$SCRIPT_PATH/../.."
+OUTPUT_FILEPATH=${OUTPUT_FILEPATH:="$ROOT_DIRECTORY/hack/release-scripts/image-digests.yaml"}
+
+tmp_filename=$(mktemp)
+
+# --- Script Tools
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git" "crane")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+error_handler() {
+  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
+  exit 1
+}
+
+trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
+
+# --- Script
+trap 'rm $tmp_filename' EXIT
+
+generate_image_digests_file () {
+  touch "$OUTPUT_FILEPATH"
+
+  yq '.sidecars.snapshotter.image = "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter"' -i "$OUTPUT_FILEPATH"
+  yq '.sidecars.attacher.image = "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher"' -i "$OUTPUT_FILEPATH"
+  yq '.sidecars.provisioner.image = "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"' -i "$OUTPUT_FILEPATH"
+  yq '.sidecars.resizer.image = "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer"' -i "$OUTPUT_FILEPATH"
+  yq '.sidecars.livenessProbe.image = "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"' -i "$OUTPUT_FILEPATH"
+  yq '.sidecars.nodeDriverRegistrar.image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"' -i "$OUTPUT_FILEPATH"
+  yq '.sidecars.volumemodifier.image = "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s"' -i "$OUTPUT_FILEPATH"
+}
+
+crane_get_latest_image_tag() {
+  image=$1
+
+  export TAG
+  TAG=$(crane ls "$image" | sed '/latest/d' | sort -V | tail -1)  # Get tag for $image with latest semvar
+}
+
+update_sidecars_source_of_truth () {
+  yq '.sidecars | keys | .[]' "$OUTPUT_FILEPATH" > "$tmp_filename"
+
+  for sidecar in $(cat "$tmp_filename")
+     do
+       log "Updating $sidecar in $OUTPUT_FILEPATH"
+       image=$(yq ".sidecars.$sidecar.image" "$OUTPUT_FILEPATH")
+
+       export TAG
+       crane_get_latest_image_tag "$image"
+       yq ".sidecars.$sidecar.tag = env(TAG)" -i "$OUTPUT_FILEPATH"
+
+       export DIGEST
+       DIGEST=$(crane digest "$image:$TAG")
+       yq ".sidecars.$sidecar.manifestDigest = env(DIGEST)" -i "$OUTPUT_FILEPATH"
+     done
+}
+
+main () {
+  check_dependencies
+  generate_image_digests_file
+  update_sidecars_source_of_truth
+}
+
+main


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Release automation

**What is this PR about? / Why do we need it?**
This PR adds:
- `image-digests-template.yaml`: A helper file for collating images, tags, and manifest digests used in the rest of the repository. Scripts in `hack/release-scripts` will generate an `image-digests.yaml` file from this template and propagating those updates to the rest of the repository. 
- `get-latest-sidecar-images`: Generates a `image-digests.yaml` file with the latest tags and associated manifest digests for each sidecar image by using `crane`.
- `generate-sidecar-tags` in hack/release-scripts: Generates the sidecar image tags in `deploy/kubernetes/overlays/stable/gcr/kustomization.yaml` and `charts/aws-ebs-csi-driver/values.yaml` based off of the values in `hack/release-scripts/image-digests.yaml`
- `update-sidecar-dependencies` Makefile target: Fetches latest sidecar tags and syncs helm/kustomize files via the following Makefile targets
  - `update-truth-sidecars`
  - `generate-sidecar-tags`
  - `generate-kustomize`


See previous discussion here: [[Automate-Release-1] Add image-source-of-truth.yaml and update-truth-sidecars scripts #1791](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1791)

**What testing is done?** 
Running `make update-sidecar-dependencies` will and produce the following diff:

``` diff
diff --git a/charts/aws-ebs-csi-driver/values.yaml b/charts/aws-ebs-csi-driver/values.yaml
index 27280e7e..cbc240ee 100644
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -7,11 +7,9 @@ image:
   # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
   tag: ""
   pullPolicy: IfNotPresent
-
 # -- Custom labels to add into metadata
-customLabels:
-  {}
-  # k8s-app: aws-ebs-csi-driver
+customLabels: {}
+# k8s-app: aws-ebs-csi-driver
 
 sidecars:
   provisioner:
@@ -19,7 +17,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
-      tag: "v3.5.0-eks-1-28-6"
+      tag: "v3.6.0-eks-1-28-7"
     logLevel: 2
     # Additional parameters provided by external-provisioner.
     additionalArgs: []
@@ -44,7 +42,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
-      tag: "v4.4.0-eks-1-28-6"
+      tag: "v4.4.0-eks-1-28-7"
     # Tune leader lease election for csi-attacher.
     # Leader election is on by default.
     leaderElection:
@@ -71,7 +69,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
-      tag: "v6.3.0-eks-1-28-6"
+      tag: "v6.3.0-eks-1-28-7"
     logLevel: 2
     # Additional parameters provided by csi-snapshotter.
     additionalArgs: []
@@ -85,7 +83,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
-      tag: "v2.10.0-eks-1-28-6"
+      tag: "v2.11.0-eks-1-28-7"
     # Additional parameters provided by livenessprobe.
     additionalArgs: []
     resources: {}
@@ -97,7 +95,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer
-      tag: "v1.9.0-eks-1-28-6"
+      tag: "v1.9.0-eks-1-28-7"
     # Tune leader lease election for csi-resizer.
     # Leader election is on by default.
     leaderElection:
@@ -122,7 +120,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar
-      tag: "v2.9.0-eks-1-28-6"
+      tag: "v2.9.0-eks-1-28-7"
     logLevel: 2
     # Additional parameters provided by node-driver-registrar.
     additionalArgs: []
@@ -151,20 +149,19 @@ sidecars:
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
-
+  snapshotController:
+    image:
+      tag: v6.3.0-eks-1-28-7
 proxy:
   http_proxy:
   no_proxy:
-
 imagePullSecrets: []
 nameOverride:
 fullnameOverride:
-
 awsAccessSecret:
   name: aws-secret
   keyId: key_id
   accessKey: access_key
-
 controller:
   volumeModificationFeature:
     enabled: false
@@ -175,24 +172,24 @@ controller:
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 1
-        preference:
-          matchExpressions:
-          - key: eks.amazonaws.com/compute-type
-            operator: NotIn
-            values:
-            - fargate
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
-      - podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-              - ebs-csi-controller
-          topologyKey: kubernetes.io/hostname
-        weight: 100
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - ebs-csi-controller
+            topologyKey: kubernetes.io/hostname
+          weight: 100
   # The default filesystem type of the volume to provision when fstype is unspecified in the StorageClass.
   # If the default is not set and fstype is unset in the StorageClass, then no fstype will be set
   defaultFsType: ext4
@@ -251,7 +248,7 @@ controller:
     limits:
       memory: 256Mi
   serviceAccount:
-  # A service account will be created for you if set to true. Set to false if you want to use your own.
+    # A service account will be created for you if set to true. Set to false if you want to use your own.
     create: true
     name: ebs-csi-controller-sa
     annotations: {}
@@ -308,7 +305,6 @@ controller:
   otelTracing: {}
   #  otelServiceName: ebs-csi-controller
   #  otelExporterEndpoint: "http://localhost:4317"
-
 node:
   env: []
   envFrom: []
@@ -320,19 +316,19 @@ node:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
-        - matchExpressions:
-          - key: eks.amazonaws.com/compute-type
-            operator: NotIn
-            values:
-            - fargate
+          - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
   nodeSelector: {}
   podAnnotations: {}
   podLabels: {}
   tolerateAllTaints: true
   tolerations:
-  - operator: Exists
-    effect: NoExecute
-    tolerationSeconds: 300
+    - operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 300
   resources:
     requests:
       cpu: 10m
@@ -381,16 +377,14 @@ node:
   otelTracing: {}
   #  otelServiceName: ebs-csi-node
   #  otelExporterEndpoint: "http://localhost:4317"
-
 additionalDaemonSets:
-  # Additional node DaemonSets, using the node config structure
-  # See docs/additional-daemonsets.md for more information
-  #
-  # example:
-  #   nodeSelector:
-  #     node.kubernetes.io/instance-type: c5.large
-  #   volumeAttachLimit: 15
-
+# Additional node DaemonSets, using the node config structure
+# See docs/additional-daemonsets.md for more information
+#
+# example:
+#   nodeSelector:
+#     node.kubernetes.io/instance-type: c5.large
+#   volumeAttachLimit: 15
 storageClasses: []
 # Add StorageClass resources like:
 # - name: ebs-sc
diff --git a/deploy/kubernetes/base/controller.yaml b/deploy/kubernetes/base/controller.yaml
index 8ebe5469..a749ea9e 100644
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -127,7 +127,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.5.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.6.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -152,7 +152,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.4.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.4.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -174,7 +174,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-snapshotter
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v6.3.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v6.3.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -196,7 +196,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.9.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.9.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -219,7 +219,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.11.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
diff --git a/deploy/kubernetes/base/node.yaml b/deploy/kubernetes/base/node.yaml
index 7b1b12a0..195499b7 100644
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -92,7 +92,7 @@ spec:
               exec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
         - name: node-driver-registrar
-          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.9.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.9.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -129,7 +129,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.10.0-eks-1-28-6
+          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.11.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
diff --git a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
index 38c674c4..2de3e3de 100644
--- a/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml
@@ -7,13 +7,13 @@ images:
     newName: registry.k8s.io/provider-aws/aws-ebs-csi-driver
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner
     newName: registry.k8s.io/sig-storage/csi-provisioner
-    newTag: v3.5.0
+    newTag: v3.6.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher
     newName: registry.k8s.io/sig-storage/csi-attacher
     newTag: v4.4.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe
     newName: registry.k8s.io/sig-storage/livenessprobe
-    newTag: v2.10.0
+    newTag: v2.11.0
   - name: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter
     newName: registry.k8s.io/sig-storage/csi-snapshotter
     newTag: v6.3.0
diff --git a/hack/release-scripts/image-source-of-truth.yaml b/hack/release-scripts/image-source-of-truth.yaml
index 9ba68e18..a6814b0b 100644
--- a/hack/release-scripts/image-source-of-truth.yaml
+++ b/hack/release-scripts/image-source-of-truth.yaml
@@ -10,33 +10,33 @@ driver:
 sidecars: # sidecar names match upstream helm chart values.yaml
   snapshotter:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter"
-    tag: ""
-    manifestDigest: ""
+    tag: "v6.3.0-eks-1-28-7"
+    manifestDigest: "sha256:61ebea9d396ad9ef0767bd697b50ed2615c9fd49c2625e64c102d916030f7369"
   attacher:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher"
-    tag: ""
-    manifestDigest: ""
+    tag: "v4.4.0-eks-1-28-7"
+    manifestDigest: "sha256:955fd72b5b77cffdf785c7c110de0a927906a8765c19160fdb5d7cd74cdc20a6"
   provisioner:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
-    tag: ""
-    manifestDigest: ""
+    tag: "v3.6.0-eks-1-28-7"
+    manifestDigest: "sha256:91158c7bf17832d03d7472f4ceb111564d61674ac1aea10c3699f0c55545782d"
   resizer:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer"
-    tag: ""
-    manifestDigest: ""
+    tag: "v1.9.0-eks-1-28-7"
+    manifestDigest: "sha256:991ffd5221c340168fbcd77148fd4098df469c2bc78aa84bed4eb323673f87ca"
   livenessProbe:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
-    tag: ""
-    manifestDigest: ""
+    tag: "v2.11.0-eks-1-28-7"
+    manifestDigest: "sha256:1ee7f20beaf76a57c5446dc41b0718172e8beb69da8ca2343804309e3a58a367"
   nodeDriverRegistrar:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
-    tag: ""
-    manifestDigest: ""
+    tag: "v2.9.0-eks-1-28-7"
+    manifestDigest: "sha256:a51e121d046e459a4315894be43b13ba7348038a67d3e9fb4e3d44cda3dbed1a"
   volumemodifier:
     image: "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s"
-    tag: ""
-    manifestDigest: ""
+    tag: "v0.1.3"
+    manifestDigest: "sha256:5452144bfc75cb986ccf266cc967773801c91d47ff3b51326904fa516765c914"
   snapshotController:
     image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller"
-    tag: ""
-    manifestDigest: ""
+    tag: "v6.3.0-eks-1-28-7"
+    manifestDigest: "sha256:a6f0bf7d1f16991bbd85764b2e2791f7812d13b04ed8596904cd3a6a9fbb87b1"

```

Running `make verify` successfully passes afterwards


