### PR TITLE
[Automate-Release-3] Add generate-release-pr to /hack/release-scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,3 +268,7 @@ generate-kustomize: bin/helm
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/serviceaccount-csi-node.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/serviceaccount-csi-node.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/role-leases.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/role-leases.yaml
 	cd charts/aws-ebs-csi-driver && ../../bin/helm template kustomize . -s templates/rolebinding-leases.yaml | sed -e "/namespace: /d" > ../../deploy/kubernetes/base/rolebinding-leases.yaml
+
+.PHONY: update-truth-sidecars
+update-truth-sidecars: hack/release-scripts/image-source-of-truth.yaml hack/release-scripts/update-truth-sidecars
+	hack/release-scripts/update-truth-sidecars

--- a/Makefile
+++ b/Makefile
@@ -271,4 +271,11 @@ generate-kustomize: bin/helm
 
 .PHONY: update-truth-sidecars
 update-truth-sidecars: hack/release-scripts/image-source-of-truth.yaml hack/release-scripts/update-truth-sidecars
-	hack/release-scripts/update-truth-sidecars
+	./hack/release-scripts/update-truth-sidecars
+
+.PHONY: generate-sidecar-tags
+generate-sidecar-tags: hack/release-scripts/image-source-of-truth.yaml charts/aws-ebs-csi-driver/values.yaml deploy/kubernetes/overlays/stable/gcr/kustomization.yaml hack/release-scripts/generate-sidecar-tags
+	./hack/release-scripts/generate-sidecar-tags
+
+.PHONY: update-sidecar-dependencies
+update-sidecar-dependencies: update-truth-sidecars generate-sidecar-tags generate-kustomize

--- a/hack/release-scripts/generate-release-pr
+++ b/hack/release-scripts/generate-release-pr
@@ -1,0 +1,125 @@
+#!/bin/bash
+# This script generates (most of) the file changes needed for a new aws-ebs-csi-driver release
+
+# --- Script Tools
+set -euo pipefail # Exit on any error
+
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git" "vi" "sed")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+
+  # Force macOS users to use gsed due to -i incompatibility
+  export SED="sed"
+  if [[ $(uname) = "Darwin" ]]; then
+    if ! command -v "gsed" &>/dev/null; then
+      log "gsed could not be found, please install it."
+            exit 1
+    fi
+    SED="gsed"
+  fi
+}
+
+error_handler() {
+  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
+  exit 1
+}
+
+trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
+
+# --- Script
+usage () {
+  echo "Usage: $0 [PREV_DRIVER_VERSION] [NEW_DRIVER_VERSION]"
+  echo "example: $0 v1.23.1 v1.24.0"
+  exit 1
+}
+
+setup_vars () {
+  export PREV_DRIVER_VERSION=$1
+  export NEW_DRIVER_VERSION=$2
+
+  # Paths
+  export ROOT_DIRECTORY TRUTH_PATH
+  ROOT_DIRECTORY=${ROOT_DIRECTORY:=$(git rev-parse --show-toplevel)}
+  TRUTH_PATH=${TRUTH_PATH:="$ROOT_DIRECTORY/hack/release-scripts/image-source-of-truth.yaml"}
+  export README_PATH="$ROOT_DIRECTORY/README.md"
+  export MAKEFILE_PATH="$ROOT_DIRECTORY/Makefile"
+  export INSTALL_MD_PATH="$ROOT_DIRECTORY/docs/install.md"
+  export CHART_PATH="$ROOT_DIRECTORY/charts/aws-ebs-csi-driver/Chart.yaml"
+}
+
+parse_args () {
+  # Confirm 2 parameters
+  [[ $# -ne 2 ]] && usage
+
+  # Confirm new driver version > prev driver version
+  log "Confirming $1 < $2"
+  sort -C -V <(echo "1.2
+  2.1") || usage
+
+  setup_vars "$@"
+}
+
+update_readme () {
+  log "Updating README.md"
+  # vi macro that adds new driver version 'Container Images' row to README.md
+  vi -s <(echo "gg/## Container Images
+  jjjjyy:%s/${PREV_DRIVER_VERSION}/${NEW_DRIVER_VERSION}/g
+  jjjjjjp:wq") "$README_PATH"
+}
+
+update_makefile () {
+  log "Updating Makefile"
+  $SED "s/VERSION?=$PREV_DRIVER_VERSION/VERSION?=$NEW_DRIVER_VERSION/g" -i "$MAKEFILE_PATH"
+}
+
+update_installmd () {
+  log "Updating docs/install.md"
+  prev_major_minor_version=$(echo "$PREV_DRIVER_VERSION" | sed 's/v\([0-9]*\.[0-9]*\).*/\1/')
+  new_major_minor_version=$(echo "$NEW_DRIVER_VERSION" | sed 's/v\([0-9]*\.[0-9]*\).*/\1/')
+  $SED "s/?ref=release-$prev_major_minor_version/?ref=release-$new_major_minor_version/g" -i "$INSTALL_MD_PATH"
+}
+
+update_chart_and_overlays () {
+  log "Updating helm chart and generates kustomize"
+  prev_minor_patch_version=$(echo "$PREV_DRIVER_VERSION" | sed 's/v[0-9]*\.//')
+  new_minor_patch_version=$(echo "$NEW_DRIVER_VERSION" | sed 's/v[0-9]*\.//')
+
+  $SED "s/$prev_minor_patch_version$/$new_minor_patch_version/g" -i "$CHART_PATH"
+
+  (cd "$ROOT_DIRECTORY"; make generate-kustomize) > "/dev/null"
+}
+
+update_upstream_repo () {
+  update_readme
+  update_makefile
+  update_installmd
+  update_chart_and_overlays
+}
+
+print_rest_of_release_steps () {
+  echo "SUCCESS!
+Before you submit the release PR, you must also:
+  1. Check that 'git diff' produces what you expected.
+  2. Update CHANGELOG.md
+  3. Update charts/aws-ebs-csi-driver/CHANGELOG.md"
+}
+
+main () {
+  check_dependencies
+  parse_args "$@"
+
+  update_upstream_repo
+  print_rest_of_release_steps
+}
+
+main "$@" # Must pass all args from script with $@

--- a/hack/release-scripts/generate-sidecar-tags
+++ b/hack/release-scripts/generate-sidecar-tags
@@ -1,0 +1,87 @@
+#!/bin/bash
+# This script generates the sidecar image tags in `deploy/kubernetes/overlays/stable/gcr/kustomization.yaml`and
+# `charts/aws-ebs-csi-driver/values.yaml` based off of the values in `hack/release-scripts/image-source-of-truth.yaml`
+
+# --- Environment Variables
+export ROOT_DIRECTORY TRUTH_FILEPATH HELM_VALUES_FILEPATH KUSTOMIZE_FILEPATH
+ROOT_DIRECTORY=${ROOT_DIRECTORY:=$(git rev-parse --show-toplevel)}
+TRUTH_FILEPATH=${TRUTH_FILEPATH:="$ROOT_DIRECTORY/hack/release-scripts/image-source-of-truth.yaml"}
+HELM_VALUES_FILEPATH=${HELM_VALUES_FILEPATH:="$ROOT_DIRECTORY/charts/aws-ebs-csi-driver/values.yaml"}
+KUSTOMIZE_FILEPATH=${KUSTOMIZE_FILEPATH:="$ROOT_DIRECTORY/deploy/kubernetes/overlays/stable/gcr/kustomization.yaml"}
+
+tmp_filename="tmp_$RANDOM.txt"
+
+# --- Script Tools
+set -euo pipefail # Exit on any error
+
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+error_handler() {
+  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
+  exit 1
+}
+
+trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
+
+# --- Script
+trap 'rm $tmp_filename' EXIT
+
+update_gcr_kustomize_sidecar_tag () {
+  sidecar_name=$1
+  line_above=$2
+
+  tag=$(yq ".sidecars.$sidecar_name.tag" "$TRUTH_FILEPATH" | awk -F- '{print $1}') # Cut off -eks-1... off of tag
+  log "Updating gcr kustomize $sidecar_name to $tag"
+  sed -i "" "\|$line_above|{n;s/.*/    newTag: $tag/;}" "$KUSTOMIZE_FILEPATH"
+}
+
+update_helm_chart_sidecar_tag () {
+  sidecar_name=$1
+
+  export TAG
+  TAG=$(yq ".sidecars.$sidecar_name.tag" "$TRUTH_FILEPATH")
+  log "Updating helm $sidecar_name sidecar to $TAG"
+  yq ".sidecars.$sidecar_name.image.tag = env(TAG)" -i "$HELM_VALUES_FILEPATH"
+}
+
+generate_gcr_kustomize () {
+    update_gcr_kustomize_sidecar_tag "provisioner" "newName: registry.k8s.io/sig-storage/csi-provisioner"
+    update_gcr_kustomize_sidecar_tag "attacher" "newName: registry.k8s.io/sig-storage/csi-attacher"
+    update_gcr_kustomize_sidecar_tag "livenessProbe" "newName: registry.k8s.io/sig-storage/livenessprobe"
+    update_gcr_kustomize_sidecar_tag "snapshotter" "newName: registry.k8s.io/sig-storage/csi-snapshotter"
+    update_gcr_kustomize_sidecar_tag "resizer" "newName: registry.k8s.io/sig-storage/csi-resizer"
+    update_gcr_kustomize_sidecar_tag "nodeDriverRegistrar" "newName: registry.k8s.io/sig-storage/csi-node-driver-registrar"
+
+    log "Success: All sidecar tags in $KUSTOMIZE_FILEPATH updated"
+}
+
+generate_helm_sidecars () {
+    yq '.sidecars | keys | .[]' "$TRUTH_FILEPATH" > $tmp_filename
+
+    for sidecar in $(cat $tmp_filename)
+         do
+           update_helm_chart_sidecar_tag "$sidecar"
+         done
+
+    log "Success: All sidecar tags in $HELM_VALUES_FILEPATH updated"
+}
+
+main () {
+  generate_gcr_kustomize
+  generate_helm_sidecars
+}
+
+main

--- a/hack/release-scripts/image-source-of-truth.yaml
+++ b/hack/release-scripts/image-source-of-truth.yaml
@@ -1,0 +1,42 @@
+# This file acts as the source of truth for the driver and sidecar image tags and digests used by the rest of the repository.
+# It is to be updated through the use of scripts in `hack/release-scripts` or Makefile targets.
+driver:
+  name: "aws-ebs-csi-driver"
+  version: "v1.24.0"
+  gcrStagingImage: "gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver"
+  manifestDigest: ""
+  gcrImage: "registry.k8s.io/provider-aws/aws-ebs-csi-driver"
+  ecrImage: "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver"
+sidecars: # sidecar names match upstream helm chart values.yaml
+  snapshotter:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter"
+    tag: ""
+    manifestDigest: ""
+  attacher:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher"
+    tag: ""
+    manifestDigest: ""
+  provisioner:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
+    tag: ""
+    manifestDigest: ""
+  resizer:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer"
+    tag: ""
+    manifestDigest: ""
+  livenessProbe:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
+    tag: ""
+    manifestDigest: ""
+  nodeDriverRegistrar:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
+    tag: ""
+    manifestDigest: ""
+  volumemodifier:
+    image: "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s"
+    tag: ""
+    manifestDigest: ""
+  snapshotController:
+    image: "public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/snapshot-controller"
+    tag: ""
+    manifestDigest: ""

--- a/hack/release-scripts/update-truth-sidecars
+++ b/hack/release-scripts/update-truth-sidecars
@@ -1,0 +1,68 @@
+#!/bin/bash
+# This script updates the image-source-of-truth.yaml with the latest tags and associated manifest digests for each sidecar image.
+
+# --- Environment Variables
+export ROOT_DIRECTORY TRUTH_FILEPATH
+ROOT_DIRECTORY=${ROOT_DIRECTORY:=$(git rev-parse --show-toplevel)}
+TRUTH_FILEPATH=${TRUTH_FILEPATH:="$ROOT_DIRECTORY/hack/release-scripts/image-source-of-truth.yaml"}
+
+tmp_filename="tmp_$RANDOM.txt"
+# --- Script Tools
+set -euo pipefail # Exit on any error
+
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git" "crane")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+error_handler() {
+  printf "Error occurred in script: %s, at line: %s. Command: %s. Error: %s\n" "$1" "$2" "$BASH_COMMAND" "$3" >&2
+  exit 1
+}
+
+trap 'error_handler ${LINENO} $? "$BASH_COMMAND"' ERR
+
+# --- Script
+trap 'rm $tmp_filename' EXIT
+
+crane_get_latest_image_tag() {
+  image=$1
+
+  export TAG
+  TAG=$(crane ls "$image" | sed '/latest/d' | sort -V | tail -1)  # Get tag for $image with latest semvar
+}
+
+update_sidecars_source_of_truth () {
+  yq '.sidecars | keys | .[]' "$TRUTH_FILEPATH" > $tmp_filename
+
+  for sidecar in $(cat $tmp_filename)
+       do
+         log "Updating $sidecar in $TRUTH_FILEPATH"
+         image=$(yq ".sidecars.$sidecar.image" "$TRUTH_FILEPATH")
+
+         export TAG
+         crane_get_latest_image_tag "$image"
+         yq ".sidecars.$sidecar.tag = env(TAG)" -i "$TRUTH_FILEPATH"
+
+         export DIGEST
+         DIGEST=$(crane digest "$image:$TAG")
+         yq ".sidecars.$sidecar.manifestDigest = env(DIGEST)" -i "$TRUTH_FILEPATH"
+       done
+}
+
+main () {
+  check_dependencies
+  update_sidecars_source_of_truth
+}
+
+main


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Release automation

**What is this PR about? / Why do we need it?**
NOTE: This is the third PR in the series [Automate-Release]. This PR will be rebased once previous PRs merge. 

See PR 1: #1791 
See PR 2: #1792 

The [Automate-Release] PRs add the directory hack/release-scripts to help automate release related activity.

This PR adds:
- `generate-release-pr` in hack/release-scripts: This script prepares (most of) a post-release PR, including updates to: 
  - `README.md`
  - `docs/install.md`
  - `Makefile`
  - `charts/aws-ebs-csi-driver/Chart.yaml`
  - Kustomize Overlays

**What testing is done?** 
Running `PUSHED_IMAGE_TAG_PREFIX="v20231013-" ./generate-release-pr v1.24.0` on the `release-1.23` branch will produce the following diff:

``` diff
diff --git a/Makefile b/Makefile
index 14381011..b32b030c 100644
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION?=v1.23.1
+VERSION?=v1.24.0
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)
diff --git a/README.md b/README.md
index c156d5f1..1c23ec64 100644
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| v1.23.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.1                      |
+| v1.24.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0                      |
 
 <details>
 <summary>Previous Images</summary>
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| v1.23.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.1                      |
 | v1.23.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.0                      |
 | v1.22.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.22.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.22.1                      |
 | v1.22.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.22.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.22.0                      |
diff --git a/charts/aws-ebs-csi-driver/Chart.yaml b/charts/aws-ebs-csi-driver/Chart.yaml
index 2dc59f77..09c56ab0 100644
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.23.1
+appVersion: 1.24.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.23.1
+version: 2.24.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:
diff --git a/deploy/kubernetes/base/controller.yaml b/deploy/kubernetes/base/controller.yaml
index 1537fb8d..8ebe5469 100644
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -61,7 +61,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.1
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode
diff --git a/deploy/kubernetes/base/node.yaml b/deploy/kubernetes/base/node.yaml
index 830f094e..7b1b12a0 100644
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -44,7 +44,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.1
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0
           imagePullPolicy: IfNotPresent
           args:
             - node
diff --git a/docs/install.md b/docs/install.md
index 7b7d734a..20afcc18 100644
--- a/docs/install.md
+++ b/docs/install.md
@@ -52,7 +52,7 @@ You may deploy the EBS CSI driver via Kustomize, Helm, or as an [Amazon EKS mana
 
 #### Kustomize
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.23"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.24"
 ```
 

