### PR TITLE
Feature: Multi-Attach for io2 block devices

### DIFF
--- a/docs/multi-attach.md
+++ b/docs/multi-attach.md
@@ -1,0 +1,81 @@
+# Multi-Attach
+
+The multi-attach capability allows you to attach a single EBS volume to multiple EC2 instances located within the same Availability Zone (AZ). This shared volume can be utilized by several pods running on distinct nodes.
+
+Multi-attach is enabled by specifying `ReadWriteMany` for the `PersistentVolumeClaim.spec.accessMode`.
+
+## Important
+
+- Application-level coordination (e.g., via I/O fencing) is required to use multi-attach safely. Failure to do so can result in data loss and silent data corruption. Refer to the AWS documentation on Multi-Attach for more information.
+- Currently, the EBS CSI driver only supports multi-attach for `IO2` volumes in `Block` mode.
+
+Refer to the official AWS documentation on [Multi-Attach](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html) for more information, best practices, and limitations of this capability.
+
+## Example
+
+1. Create a `StorageClass` referencing an `IO2` volume type:
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: io2
+  iops: "1000"
+```
+
+2. Create a `PersistentVolumeClaim` referencing the `ReadWriteMany` access and `Block` device modes:
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: block-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Block
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+```
+
+3. Create a `DaemonSet` referencing the `PersistentVolumeClaim` created in the previous step:
+```
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: app-daemon
+spec:
+  selector:
+    matchLabels:
+      name: app
+  template:
+    metadata:
+      labels:
+        name: app
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        command: ["/bin/sh", "-c"]
+        args: ["tail -f /dev/null"]
+        volumeDevices:
+        - name: data
+          devicePath: /dev/xvda
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: block-claim
+```
+
+4. Verify the `DaemonSet` is running:
+```
+$ kubectl get pods -A
+
+NAMESPACE     NAME                                   READY   STATUS    RESTARTS       AGE
+default       app-daemon-9hdgw                       1/1     Running   0              18s
+default       app-daemon-xm8zr                       1/1     Running   0              18s
+```

--- a/pkg/driver/internal/inflight.go
+++ b/pkg/driver/internal/inflight.go
@@ -35,7 +35,7 @@ const (
 	VolumeOperationAlreadyExistsErrorMsg = "An operation with the given Volume %s already exists"
 )
 
-// InFlight is a struct used to manage in flight requests per volumeId.
+// InFlight is a struct used to manage in flight requests for a unique identifier.
 type InFlight struct {
 	mux      *sync.Mutex
 	inFlight map[string]bool
@@ -49,7 +49,7 @@ func NewInFlight() *InFlight {
 	}
 }
 
-// Insert inserts the entry to the current list of inflight request key is volumeId for node and req hash for controller .
+// Insert inserts the entry to the current list of inflight, request key is a unique identifier.
 // Returns false when the key already exists.
 func (db *InFlight) Insert(key string) bool {
 	db.mux.Lock()

--- a/pkg/driver/internal/inflight_test.go
+++ b/pkg/driver/internal/inflight_test.go
@@ -22,6 +22,7 @@ import (
 
 type testRequest struct {
 	volumeId string
+	extra    string
 	expResp  bool
 	delete   bool
 }
@@ -73,15 +74,18 @@ func TestInFlight(t *testing.T) {
 			requests: []testRequest{
 				{
 					volumeId: "random-vol-name",
+					extra:    "random-node-id",
 					expResp:  true,
 				},
 				{
 					volumeId: "random-vol-name",
+					extra:    "random-node-id",
 					expResp:  false,
 					delete:   true,
 				},
 				{
 					volumeId: "random-vol-name",
+					extra:    "random-node-id",
 					expResp:  true,
 				},
 			},

--- a/tests/e2e/driver/driver.go
+++ b/tests/e2e/driver/driver.go
@@ -41,7 +41,7 @@ type DynamicPVTestDriver interface {
 // PreProvisionedVolumeTestDriver represents an interface for a CSI driver that supports pre-provisioned volume
 type PreProvisionedVolumeTestDriver interface {
 	// GetPersistentVolume returns a PersistentVolume with pre-provisioned volumeHandle
-	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume
+	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode) *v1.PersistentVolume
 }
 
 type VolumeSnapshotTestDriver interface {

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -68,7 +68,7 @@ func (d *ebsCSIDriver) GetVolumeSnapshotClass(namespace string) *volumesnapshotv
 	return getVolumeSnapshotClass(generateName, provisioner)
 }
 
-func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string) *v1.PersistentVolume {
+func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode) *v1.PersistentVolume {
 	provisioner := d.driverName
 	generateName := fmt.Sprintf("%s-%s-preprovsioned-pv-", namespace, provisioner)
 	// Default to Retain ReclaimPolicy for pre-provisioned volumes
@@ -76,6 +76,11 @@ func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size 
 	if reclaimPolicy != nil {
 		pvReclaimPolicy = *reclaimPolicy
 	}
+
+	if accessMode == "" {
+		accessMode = v1.ReadWriteOnce
+	}
+
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generateName,
@@ -86,7 +91,7 @@ func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size 
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			AccessModes: []v1.PersistentVolumeAccessMode{accessMode},
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): resource.MustParse(size),
 			},
@@ -98,6 +103,7 @@ func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size 
 					FSType:       fsType,
 				},
 			},
+			VolumeMode: &volumeMode,
 		},
 	}
 }

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -238,6 +238,187 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		test.Run(cs, ns)
 	})
 
+	It("should succeed multi-attach with dynamically provisioned IO2 block device", func() {
+		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		pods := []testsuites.PodDetails{
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMode: testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode:        v1.ReadWriteMany,
+						VolumeBindingMode: &volumeBindingMode,
+					},
+				},
+			},
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMode: testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode:        v1.ReadWriteMany,
+						VolumeBindingMode: &volumeBindingMode,
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedMultiAttachTest{
+			CSIDriver:  ebsDriver,
+			Pods:       pods,
+			VolumeMode: testsuites.Block,
+			VolumeType: awscloud.VolumeTypeIO2,
+			AccessMode: v1.ReadWriteMany,
+			RunningPod: true,
+		}
+		test.Run(cs, ns)
+	})
+
+	It("should fail to multi-attach dynamically provisioned IO2 block device - not enabled", func() {
+		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		pods := []testsuites.PodDetails{
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMode: testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode:        v1.ReadWriteOnce,
+						VolumeBindingMode: &volumeBindingMode,
+					},
+				},
+			},
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMode: testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode:        v1.ReadWriteOnce,
+						VolumeBindingMode: &volumeBindingMode,
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedMultiAttachTest{
+			CSIDriver:  ebsDriver,
+			Pods:       pods,
+			VolumeMode: testsuites.Block,
+			AccessMode: v1.ReadWriteOnce,
+			VolumeType: awscloud.VolumeTypeIO2,
+		}
+		test.Run(cs, ns)
+	})
+
+	It("should fail to multi-attach when VolumeMode is not Block", func() {
+		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		pods := []testsuites.PodDetails{
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						FSType:     ebscsidriver.FSTypeExt4,
+						VolumeMode: testsuites.FileSystem,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+						AccessMode:        v1.ReadWriteMany,
+						VolumeBindingMode: &volumeBindingMode,
+					},
+				},
+			},
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						FSType:     ebscsidriver.FSTypeExt4,
+						VolumeMode: testsuites.FileSystem,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+						AccessMode:        v1.ReadWriteMany,
+						VolumeBindingMode: &volumeBindingMode,
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedMultiAttachTest{
+			CSIDriver:  ebsDriver,
+			Pods:       pods,
+			VolumeMode: testsuites.FileSystem,
+			AccessMode: v1.ReadWriteMany,
+			VolumeType: awscloud.VolumeTypeIO2,
+			PendingPVC: true,
+		}
+		test.Run(cs, ns)
+	})
+
+	It("should fail to multi-attach non io2 VolumeType", func() {
+		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		pods := []testsuites.PodDetails{
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType:        awscloud.VolumeTypeGP3,
+						ClaimSize:         driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+						VolumeBindingMode: &volumeBindingMode,
+						VolumeMode:        testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode: v1.ReadWriteMany,
+					},
+				},
+			},
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType:        awscloud.VolumeTypeGP3,
+						ClaimSize:         driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+						VolumeBindingMode: &volumeBindingMode,
+						VolumeMode:        testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode: v1.ReadWriteMany,
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedMultiAttachTest{
+			CSIDriver:  ebsDriver,
+			Pods:       pods,
+			VolumeMode: testsuites.FileSystem,
+			AccessMode: v1.ReadWriteMany,
+			VolumeType: awscloud.VolumeTypeIO2,
+			PendingPVC: true,
+		}
+		test.Run(cs, ns)
+	})
+
 	It("should create a raw block volume and a filesystem volume on demand and bind to the same pod", func() {
 		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
 		pods := []testsuites.PodDetails{

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -118,14 +118,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 
 	AfterEach(func() {
 		if !skipManuallyDeletingVolume {
-			_, err := cloud.WaitForAttachmentState(context.Background(), volumeID, "detached", "", "", false)
-			if err != nil {
-				Fail(fmt.Sprintf("could not detach volume %q: %v", volumeID, err))
-			}
-			ok, err := cloud.DeleteDisk(context.Background(), volumeID)
-			if err != nil || !ok {
-				Fail(fmt.Sprintf("could not delete volume %q: %v", volumeID, err))
-			}
+			deleteDiskWithRetry(cloud, volumeID)
 		}
 	})
 
@@ -233,3 +226,116 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 		test.Run(cs, ns)
 	})
 })
+
+var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs                         clientset.Interface
+		ns                         *v1.Namespace
+		ebsDriver                  driver.PreProvisionedVolumeTestDriver
+		cloud                      awscloud.Cloud
+		volumeID                   string
+		skipManuallyDeletingVolume bool
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		ebsDriver = driver.InitEbsCSIDriver()
+
+		if os.Getenv(awsAvailabilityZonesEnv) == "" {
+			Skip(fmt.Sprintf("env %q not set", awsAvailabilityZonesEnv))
+		}
+		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
+		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
+		region := availabilityZone[0 : len(availabilityZone)-1]
+
+		diskOptions := &awscloud.DiskOptions{
+			CapacityBytes:      defaultDiskSizeBytes,
+			VolumeType:         awscloud.VolumeTypeIO2,
+			MultiAttachEnabled: true,
+			AvailabilityZone:   availabilityZone,
+			IOPS:               1000,
+			Tags:               map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
+		}
+		var err error
+		cloud, err = awscloud.NewCloud(region, false, "")
+		if err != nil {
+			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
+		}
+		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
+		disk, err := cloud.CreateDisk(context.Background(), fmt.Sprintf("pvc-%d", r1.Uint64()), diskOptions)
+		if err != nil {
+			Fail(fmt.Sprintf("could not provision a volume: %v", err))
+		}
+		volumeID = disk.VolumeID
+		By(fmt.Sprintf("Successfully provisioned EBS volume: %q\n", volumeID))
+	})
+
+	AfterEach(func() {
+		if !skipManuallyDeletingVolume {
+			deleteDiskWithRetry(cloud, volumeID)
+		}
+	})
+
+	It("should succeed multi-attach pre-provisioned IO2 block device", func() {
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		pods := []testsuites.PodDetails{
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMode: testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode:    v1.ReadWriteMany,
+						VolumeID:      volumeID,
+						ReclaimPolicy: &reclaimPolicy,
+					},
+				},
+			},
+			{
+				Volumes: []testsuites.VolumeDetails{
+					{
+						VolumeType: awscloud.VolumeTypeIO2,
+						ClaimSize:  driver.MinimumSizeForVolumeType(awscloud.VolumeTypeIO2),
+						VolumeMode: testsuites.Block,
+						VolumeDevice: testsuites.VolumeDeviceDetails{
+							NameGenerate: "test-block-volume-",
+							DevicePath:   "/dev/xvda",
+						},
+						AccessMode:    v1.ReadWriteMany,
+						VolumeID:      volumeID,
+						ReclaimPolicy: &reclaimPolicy,
+					},
+				},
+			},
+		}
+		test := testsuites.StaticallyProvisionedMultiAttachTest{
+			CSIDriver:  ebsDriver,
+			Pods:       pods,
+			VolumeMode: v1.PersistentVolumeBlock,
+			VolumeType: awscloud.VolumeTypeIO2,
+			VolumeID:   volumeID,
+			AccessMode: v1.ReadWriteMany,
+		}
+		test.Run(cs, ns)
+	})
+})
+
+func deleteDiskWithRetry(cloud awscloud.Cloud, volumeID string) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		ok, err := cloud.DeleteDisk(context.Background(), volumeID)
+		if err == nil && ok {
+			return
+		}
+		<-ticker.C
+	}
+}

--- a/tests/e2e/testsuites/dynamically_provisioned_multi_attach_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_multi_attach_tester.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+)
+
+type DynamicallyProvisionedMultiAttachTest struct {
+	CSIDriver  driver.DynamicPVTestDriver
+	Pods       []PodDetails
+	VolumeMode VolumeMode
+	AccessMode v1.PersistentVolumeAccessMode
+	VolumeType string
+	RunningPod bool
+	PendingPVC bool
+}
+
+func (t *DynamicallyProvisionedMultiAttachTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	// Setup StorageClass and PVC
+	tpvc, _ := t.Pods[0].Volumes[0].SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver)
+	defer tpvc.Cleanup()
+
+	for n, podDetail := range t.Pods {
+		tpod := NewTestPod(client, namespace, "tail -f /dev/null")
+
+		if podDetail.Volumes[0].VolumeMode == Block {
+			name := fmt.Sprintf("%s%d", podDetail.Volumes[0].VolumeDevice.NameGenerate, n+1)
+			devicePath := podDetail.Volumes[0].VolumeDevice.DevicePath
+			tpod.SetupRawBlockVolume(tpvc.persistentVolumeClaim, name, devicePath)
+		} else {
+			name := fmt.Sprintf("%s%d", podDetail.Volumes[0].VolumeMount.NameGenerate, n+1)
+			mountPath := fmt.Sprintf("%s%d", podDetail.Volumes[0].VolumeMount.MountPathGenerate, n+1)
+			readOnly := podDetail.Volumes[0].VolumeMount.ReadOnly
+			tpod.SetupVolume(tpvc.persistentVolumeClaim, name, mountPath, readOnly)
+		}
+
+		tpod.pod.ObjectMeta.Labels = map[string]string{"app": "my-service"}
+		tpod.pod.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "my-service"},
+				},
+			},
+		}
+
+		By("deploying the pod")
+		tpod.Create()
+		defer tpod.Cleanup()
+
+		if t.PendingPVC {
+			By("checking that the PVC is not bound")
+			pvcList := []*v1.PersistentVolumeClaim{tpvc.persistentVolumeClaim}
+			_, err := e2epv.WaitForPVClaimBoundPhase(context.Background(), client, pvcList, 30*time.Second)
+			Expect(err).To(HaveOccurred(), "Failed to wait for PVC to be in Pending state")
+			return
+		}
+		if t.RunningPod || n == 0 {
+			By("checking that the pod is running")
+			tpod.WaitForRunning()
+		} else {
+			By("checking that the pod is not running")
+			err := e2epod.WaitTimeoutForPodRunningInNamespace(context.Background(), client, tpod.pod.Name, namespace.Name, 30*time.Second)
+			Expect(err).To(HaveOccurred(), "Failed to wait for pod to be in a running state")
+		}
+	}
+}

--- a/tests/e2e/testsuites/pre_provisioned_multi_attach_tester.go
+++ b/tests/e2e/testsuites/pre_provisioned_multi_attach_tester.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type StaticallyProvisionedMultiAttachTest struct {
+	CSIDriver  driver.PreProvisionedVolumeTestDriver
+	Pods       []PodDetails
+	AccessMode v1.PersistentVolumeAccessMode
+	VolumeMode v1.PersistentVolumeMode
+	VolumeType string
+	RunningPod bool
+	PendingPVC bool
+	VolumeID   string
+}
+
+func (t *StaticallyProvisionedMultiAttachTest) Run(client clientset.Interface, namespace *v1.Namespace) {
+	tpvc, _ := t.Pods[0].Volumes[0].SetupPreProvisionedPersistentVolumeClaim(client, namespace, t.CSIDriver)
+
+	for n, podDetail := range t.Pods {
+		tpod := NewTestPod(client, namespace, "tail -f /dev/null")
+		name := fmt.Sprintf("%s%d", podDetail.Volumes[0].VolumeDevice.NameGenerate, n+1)
+		devicePath := podDetail.Volumes[0].VolumeDevice.DevicePath
+
+		tpod.SetupRawBlockVolume(tpvc.persistentVolumeClaim, name, devicePath)
+		tpod.pod.ObjectMeta.Labels = map[string]string{"app": "my-service"}
+		tpod.pod.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       "kubernetes.io/hostname",
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "my-service"},
+				},
+			},
+		}
+
+		By("deploying the pod")
+		tpod.Create()
+		defer tpod.Cleanup()
+
+		By("checking that the pods command exits with no error")
+		tpod.WaitForRunning()
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

- New feature
- Closes #449 

**What is this PR about? / Why do we need it?**

This PR implements the ability to enable [multi-attach](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volumes-multi.html) for `io2` block devices by specifying the `ReadWriteMany` access mode in `PersistentVolumeClaim.spec.accessModes`. A few important points to note:

- EBS Multi-Attach does not support standard file systems. Standard file systems such as `xfs`, `ext3`, `ext4`, and `NTFS` aren't designed to be simultaneously accessed by multiple EC2 instances.
- Simultaneous access to a standard file system can result in data corruption or data loss.
- Multi-Attach is only enabled for io2 block devices. 

See the documentation: https://github.com/torredil/aws-ebs-csi-driver/blob/d316ff830997cb38d17e38625cbaeea2e089068a/docs/multi-attach.md

**What testing is done?** 

- Unit tests: `make test`
- e2e tests:
```
$ ginkgo run --focus='multi-attach' --v&

Ran 3 of 42 Specs in 82.685 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 39 Skipped
```
- External.Storage suite
