### PR TITLE
Add compatibility workaround for A1 instance family

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,11 @@ ARG TARGETARCH
 ARG VERSION
 RUN OS=$TARGETOS ARCH=$TARGETARCH make $TARGETOS/$TARGETARCH
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al23 AS linux-amazon
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al23 AS linux-al2023
+COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
+ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
+
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al2 AS linux-al2
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ OUTPUT_TYPE?=docker
 
 OS?=linux
 ARCH?=amd64
-OSVERSION?=amazon
+OSVERSION?=al2023
 
 ALL_OS?=linux windows
 ALL_ARCH_linux?=amd64 arm64
-ALL_OSVERSION_linux?=amazon
+ALL_OSVERSION_linux?=al2023
 ALL_OS_ARCH_OSVERSION_linux=$(foreach arch, $(ALL_ARCH_linux), $(foreach osversion, ${ALL_OSVERSION_linux}, linux-$(arch)-${osversion}))
 
 ALL_ARCH_windows?=amd64
@@ -86,7 +86,7 @@ create-manifest: all-image-registry
 .PHONY: all-image-docker
 all-image-docker: $(addprefix sub-image-docker-,$(ALL_OS_ARCH_OSVERSION_linux))
 .PHONY: all-image-registry
-all-image-registry: $(addprefix sub-image-registry-,$(ALL_OS_ARCH_OSVERSION))
+all-image-registry: sub-image-registry-linux-arm64-al2 $(addprefix sub-image-registry-,$(ALL_OS_ARCH_OSVERSION))
 
 sub-image-%:
 	$(MAKE) OUTPUT_TYPE=$(call word-hyphen,$*,1) OS=$(call word-hyphen,$*,2) ARCH=$(call word-hyphen,$*,3) OSVERSION=$(call word-hyphen,$*,4) image

--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -1,5 +1,6 @@
 {{- define "node-windows" }}
 {{- if .Values.node.enableWindows }}
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -1,5 +1,6 @@
 {{- define "node" }}
 {{- if or (eq (default true .Values.node.enableLinux) true) }}
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/charts/aws-ebs-csi-driver/templates/node-windows.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node-windows.yaml
@@ -9,6 +9,5 @@
     "node" (deepCopy $.Values.node | mustMerge $values)
   )
 }}
----
 {{- include "node-windows" (deepCopy $ | mustMerge $args) -}}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -9,6 +9,38 @@
     "node" (deepCopy $.Values.node | mustMerge $values)
   )
 }}
----
+{{- include "node" (deepCopy $ | mustMerge $args) -}}
+{{- end }}
+{{- if .Values.a1CompatibilityDaemonSet }}
+{{$args := dict
+  "NodeName" "ebs-csi-node-a1compat"
+  "Values" (dict
+    "image" (dict
+      "tag" (printf "%s-a1compat" (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)))
+    )
+    "node" (dict
+      "affinity" (dict
+        "nodeAffinity" (dict
+          "requiredDuringSchedulingIgnoredDuringExecution" (dict
+            "nodeSelectorTerms" (list
+              (dict "matchExpressions" (list
+                (dict
+                  "key" "eks.amazonaws.com/compute-type"
+                  "operator" "NotIn"
+                  "values" (list "fargate")
+                )
+                (dict
+                  "key" "node.kubernetes.io/instance-type"
+                  "operator" "In"
+                  "values" (list "a1.medium" "a1.large" "a1.xlarge" "a1.2xlarge" "a1.4xlarge")
+                )
+              ))
+            )
+          )
+        )
+      )
+    )
+  )
+}}
 {{- include "node" (deepCopy $ | mustMerge $args) -}}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -325,6 +325,14 @@ node:
             operator: NotIn
             values:
             - fargate
+          - key: node.kubernetes.io/instance-type
+            operator: NotIn
+            values:
+            - a1.medium
+            - a1.large
+            - a1.xlarge
+            - a1.2xlarge
+            - a1.4xlarge
   nodeSelector: {}
   podAnnotations: {}
   podLabels: {}
@@ -390,6 +398,9 @@ additionalDaemonSets:
   #   nodeSelector:
   #     node.kubernetes.io/instance-type: c5.large
   #   volumeAttachLimit: 15
+
+# Enable compatibility for the A1 instance family via use of an AL2-based image in a separate DaemonSet
+# a1CompatibilityDaemonSet: true
 
 storageClasses: []
 # Add StorageClass resources like:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -30,6 +30,14 @@ spec:
                 operator: NotIn
                 values:
                 - fargate
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - a1.medium
+                - a1.large
+                - a1.xlarge
+                - a1.2xlarge
+                - a1.4xlarge
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: ebs-csi-node-sa

--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -27,8 +27,8 @@ function ecr_build_and_push() {
       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       make all-push
     else
-      IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=amazon make image
-      docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-amazon "${IMAGE_NAME}":"${IMAGE_TAG}"
+      IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=al2023 make image
+      docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-al2023 "${IMAGE_NAME}":"${IMAGE_TAG}"
       docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
     fi
   fi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Adds compatibility for running on instances with the a1 instance family

**What testing is done?** 

```
$ helm install aws-ebs-csi-driver . --set a1CompatibilityDaemonSet=true --set image.repository=368597081700.dkr.ecr.us-west-2.amazonaws.com/aws-ebs-csi-driver --set image.tag=fdb98666fa056862748ca337049f907d7b080e25
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Oct 25 15:15:29 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n default -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

NOTE: The [CSI Snapshotter](https://github.com/kubernetes-csi/external-snapshotter) controller and CRDs will no longer be installed as part of this chart and moving forward will be a prerequisite of using the snap shotting functionality.

$ kubectl get daemonsets.apps                   
NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
ebs-csi-node            0         0         0       0            0           kubernetes.io/os=linux   3m30s
ebs-csi-node-a1compat   1         1         1       1            1           kubernetes.io/os=linux   3m30s
```