### PR TITLE
Chart: node-driver-registrar sidecar fixes

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -135,6 +135,9 @@ spec:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v={{ .Values.sidecars.nodeDriverRegistrar.logLevel }}
+            {{- range .Values.sidecars.nodeDriverRegistrar.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -146,22 +149,14 @@ spec:
             {{- with .Values.sidecars.nodeDriverRegistrar.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-            {{- range .Values.sidecars.nodeDriverRegistrar.additionalArgs }}
-            - {{ . }}
-            {{- end }}
           {{- with .Values.controller.envFrom }}
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:
-            exec:
-              command:
-                - /csi-node-driver-registrar
-                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-                - --mode=kubelet-registration-probe
-            initialDelaySeconds: 30
-            timeoutSeconds: 15
-            periodSeconds: 90
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -130,6 +130,15 @@ sidecars:
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
+    livenessProbe:
+      exec:
+        command:
+          - /csi-node-driver-registrar
+          - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+          - --mode=kubelet-registration-probe
+      initialDelaySeconds: 30
+      timeoutSeconds: 15
+      periodSeconds: 90
   volumemodifier:
     env: []
     image:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -133,12 +133,12 @@ sidecars:
     livenessProbe:
       exec:
         command:
-          - /csi-node-driver-registrar
-          - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-          - --mode=kubelet-registration-probe
+        - /csi-node-driver-registrar
+        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+        - --mode=kubelet-registration-probe
       initialDelaySeconds: 30
-      timeoutSeconds: 15
       periodSeconds: 90
+      timeoutSeconds: 15
   volumemodifier:
     env: []
     image:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -114,12 +114,12 @@ spec:
           livenessProbe:
             exec:
               command:
-                - /csi-node-driver-registrar
-                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-                - --mode=kubelet-registration-probe
+              - /csi-node-driver-registrar
+              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+              - --mode=kubelet-registration-probe
             initialDelaySeconds: 30
-            timeoutSeconds: 15
             periodSeconds: 90
+            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix and new feature
**What is this PR about? / Why do we need it?**
- Fixes #1813
  - `additionalArgs` was under env vars in helm template, moves to container args as intended
- Fixes #1814
  - Allows overriding the default livenessProbe

**What testing is done?** 
`helm template . -f values.yaml`
- `additionalArgs` now properly renders when provided
- Default livenessProbe is unchanged