### PR TITLE
Update sidecar timeout values

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -190,6 +190,9 @@ spec:
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.provisioner.image.repository .Values.sidecars.provisioner.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.provisioner.image.pullPolicy }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.provisioner.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.provisioner.logLevel }}
             - --feature-gates=Topology=true
@@ -245,6 +248,9 @@ spec:
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.attacher.image.repository .Values.sidecars.attacher.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.attacher.image.pullPolicy }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.attacher.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.attacher.logLevel }}
             - --leader-election={{ .Values.sidecars.attacher.leaderElection.enabled | required "leader election state for csi-attacher is required, must be set to true || false." }}
@@ -339,6 +345,9 @@ spec:
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.volumemodifier.image.repository .Values.sidecars.volumemodifier.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.volumemodifier.image.pullPolicy }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.volumemodifier.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.volumemodifier.logLevel }}
             - --leader-election={{ .Values.sidecars.volumemodifier.leaderElection.enabled | required "leader election state for csi-volumemodifier is required, must be set to true || false." }}
@@ -393,6 +402,9 @@ spec:
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.sidecars.resizer.image.repository .Values.sidecars.resizer.image.tag }}
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.resizer.image.pullPolicy }}
           args:
+            {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.resizer.additionalArgs)) }}
+            - --timeout=60s
+            {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.resizer.logLevel }}
             - --handle-volume-inuse-error=false

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -130,6 +130,7 @@ spec:
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.6.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
+            - --timeout=60s
             - --csi-address=$(ADDRESS)
             - --v=2
             - --feature-gates=Topology=true
@@ -158,6 +159,7 @@ spec:
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.4.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
+            - --timeout=60s
             - --csi-address=$(ADDRESS)
             - --v=2
             - --leader-election=true
@@ -208,6 +210,7 @@ spec:
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.9.0-eks-1-28-7
           imagePullPolicy: IfNotPresent
           args:
+            - --timeout=60s
             - --csi-address=$(ADDRESS)
             - --v=2
             - --handle-volume-inuse-error=false


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
- This PR changes the default timeout value (15s) for the attacher sidecar, responsible for exercising `ControllerPublishVolume` / `ControllerUnpublishVolume`. The default value of 15s used today is not a sensible default, as a result the following error is observed frequently:

```
E1101 14:21:54.345145       1 driver.go:124] "GRPC error" err="rpc error: code = Internal desc = Could not detach volume \"vol-07ec886465a316b9b\" from node \"i-0e137107f5012fb1f\": context deadline exceeded"
```

In the vast majority of cases the volume is successfully detached just mere seconds after the attacher times out.

closes #1671

For context:
```
--timeout <duration>: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of ControllerPublish and ControllerUnpublish calls. See [CSI error and timeout handling](https://github.com/kubernetes-csi/external-attacher#csi-error-and-timeout-handling) for details. 15 seconds is used by default.
```

**What testing is done?** 
- Manual testing
- CI