### PR TITLE
Chart: add egress network policy for controller

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller-network-policy.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller-network-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "aws-ebs-csi-driver.name" . }}-controller
+  namespace: kube-system
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "aws-ebs-csi-driver.name" . }}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
**Is this a bug fix or adding a new feature?**
Bug fix
**What is this PR about? / Why do we need it?**
In a secure environment with strict network policy mode, all traffic is denied except traffic allowed by the network policies.

In order to be able to run the `aws-ebs-csi-driver ` in such an environment  it is necessary to specify the network policy for the controller otherwise it will end with the error:
```
I1102 15:12:02.790807       1 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"example-pvc", UID:"81413a15-1473-4778-94d4-6a2908249527", APIVersion:"v1", ResourceVersion:"37899", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' failed to provision volume with StorageClass "gp2": rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

**What testing is done?** 
