### PR TITLE
Add arm64 e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,20 @@ test-e2e-external:
 	COLLECT_METRICS="true" \
 	./hack/e2e/run.sh
 
+.PHONY: test-e2e-external-arm64
+test-e2e-external-arm64:
+	AWS_REGION=us-west-2 \
+	AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
+	EBS_INSTALL_SNAPSHOT="true" \
+	TEST_PATH=./tests/e2e-kubernetes/... \
+	GINKGO_FOCUS="External.Storage" \
+	GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
+	INSTANCE_TYPE="m7g.medium" \
+	AMI_PARAMETER="/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64" \
+	IMAGE_ARCH="arm64" \
+	./hack/e2e/run.sh
+
 .PHONY: test-e2e-external-eks
 test-e2e-external-eks:
 	CLUSTER_TYPE=eksctl \

--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -10,6 +10,7 @@ function ecr_build_and_push() {
   AWS_ACCOUNT_ID=${2}
   IMAGE_NAME=${3}
   IMAGE_TAG=${4}
+  IMAGE_ARCH=${5}
   set +e
   if docker images --format "{{.Repository}}:{{.Tag}}" | grep "${IMAGE_NAME}:${IMAGE_TAG}"; then
     set -e
@@ -27,8 +28,8 @@ function ecr_build_and_push() {
       docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       make all-push
     else
-      IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=amd64 OSVERSION=al2023 make image
-      docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-amd64-al2023 "${IMAGE_NAME}":"${IMAGE_TAG}"
+      IMAGE=${IMAGE_NAME} TAG=${IMAGE_TAG} OS=linux ARCH=${IMAGE_ARCH} OSVERSION=al2023 make image
+      docker tag "${IMAGE_NAME}":"${IMAGE_TAG}"-linux-${IMAGE_ARCH}-al2023 "${IMAGE_NAME}":"${IMAGE_TAG}"
       docker push "${IMAGE_NAME}":"${IMAGE_TAG}"
     fi
   fi

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -46,6 +46,7 @@ INSTANCE_TYPE=${INSTANCE_TYPE:-c5.large}
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_NAME=${IMAGE_NAME:-${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${DRIVER_NAME}}
 IMAGE_TAG=${IMAGE_TAG:-${TEST_ID}}
+IMAGE_ARCH=${IMAGE_ARCH:-amd64}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
@@ -56,7 +57,8 @@ KOPS_VERSION=${KOPS_VERSION:-1.28.0}
 KOPS_STATE_FILE=${KOPS_STATE_FILE:-s3://k8s-kops-csi-shared-e2e}
 KOPS_PATCH_FILE=${KOPS_PATCH_FILE:-./hack/kops-patch.yaml}
 KOPS_PATCH_NODE_FILE=${KOPS_PATCH_NODE_FILE:-./hack/kops-patch-node.yaml}
-AMI_ID=$(aws ssm get-parameters --names /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64 --region ${REGION} --query 'Parameters[0].Value' --output text)
+AMI_PARAMETER=${AMI_PARAMETER:-/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}
+AMI_ID=$(aws ssm get-parameters --names ${AMI_PARAMETER} --region ${REGION} --query 'Parameters[0].Value' --output text)
 
 EKSCTL_VERSION=${EKSCTL_VERSION:-0.163.0}
 EKSCTL_PATCH_FILE=${EKSCTL_PATCH_FILE:-./hack/eksctl-patch.yaml}
@@ -137,7 +139,8 @@ fi
 ecr_build_and_push "${REGION}" \
   "${AWS_ACCOUNT_ID}" \
   "${IMAGE_NAME}" \
-  "${IMAGE_TAG}"
+  "${IMAGE_TAG}" \
+  "${IMAGE_ARCH}"
 
 if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   kops_create_cluster \


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature (for CI)

**What is this PR about? / Why do we need it?**

Adds `Makefile` target and associated changes to `hack/` to run e2e tests on ARM instances

**What testing is done?** 

Tested locally:

```
$ KOPS_STATE_FILE=s3://368597081700-kops-state make test-e2e-external-arm64
AWS_REGION=us-west-2 \
AWS_AVAILABILITY_ZONES=us-west-2a,us-west-2b,us-west-2c \
HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$CLUSTER_NAME' \
EBS_INSTALL_SNAPSHOT="true" \
TEST_PATH=./tests/e2e-kubernetes/... \
GINKGO_FOCUS="External.Storage" \
GINKGO_SKIP="\[Disruptive\]|\[Serial\]" \
INSTANCE_TYPE="m7g.medium" \
AMI_PARAMETER="/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64" \
IMAGE_ARCH="arm64" \
./hack/e2e/run.sh

...

Running Suite: Kubernetes e2e suite - /home/conncatl/aws-ebs-csi-driver/tests/e2e-kubernetes/_rundir/e2e-kubernetes
===================================================================================================================
Random Seed: 1698939377 - will randomize all specs

Will run 251 of 7672 specs
Running in parallel across 25 processes

...

Deleted cluster: "test-cluster-25926.k8s.local"
###
## OVERALL_TEST_PASSED: 0
#
###
## SUCCESS!
#
```
