### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -20,7 +20,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/output-code-coverage.yaml
+++ b/.github/workflows/output-code-coverage.yaml
@@ -32,7 +32,7 @@ jobs:
             }
 
       - name: 'Determine source PR'
-        uses: potiuk/get-workflow-origin@08219db9dbbbec802d571eaf0e14ece0bc005f72
+        uses: potiuk/get-workflow-origin@e2dae063368361e4cd1f510e8785cd73bca9352e
         id: source-run-info
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"Bug fix" for CI

**What is this PR about? / Why do we need it?**

- Fixes code coverage job by changing to tag `1_5` which actually works (tag `1_6`, which the current hash is for, is broken)
- Bumps chart-releaser-action to latest tagged version

**What testing is done?** 

N/A