### PR TITLE
fix: Add parameters for tuning revisionHistoryLimit and emptyDir volumes

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ .NodeName }}
@@ -199,6 +200,6 @@ spec:
             path: \\.\pipe\csi-proxy-filesystem-v1
             type: ""
         - name: probe-dir
-          emptyDir: {}
+          {{- toYaml .Values.node.probeDirVolume | nindent 10 }}
 {{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -9,7 +9,9 @@ metadata:
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
+  {{- if or (kindIs "float64" .Values.node.revisionHistoryLimit) (kindIs "int64" .Values.node.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .NodeName }}
@@ -200,6 +202,10 @@ spec:
             path: \\.\pipe\csi-proxy-filesystem-v1
             type: ""
         - name: probe-dir
+          {{- if .Values.node.probeDirVolume }}
           {{- toYaml .Values.node.probeDirVolume | nindent 10 }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ .NodeName }}
@@ -219,7 +220,7 @@ spec:
             path: /dev
             type: Directory
         - name: probe-dir
-          emptyDir: {}
+          {{- toYaml .Values.node.probeDirVolume | nindent 10 }}
         {{- with .Values.node.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -9,7 +9,9 @@ metadata:
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
+  {{- if or (kindIs "float64" .Values.node.revisionHistoryLimit) (kindIs "int64" .Values.node.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .NodeName }}
@@ -220,7 +222,11 @@ spec:
             path: /dev
             type: Directory
         - name: probe-dir
+          {{- if .Values.node.probeDirVolume }}
           {{- toYaml .Values.node.probeDirVolume | nindent 10 }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- with .Values.node.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
+  {{- end }}
   {{- with .Values.controller.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -487,7 +489,11 @@ spec:
       {{- end }}
       volumes:
         - name: socket-dir
+          {{- if .Values.controller.socketDirVolume }}
           {{- toYaml .Values.controller.socketDirVolume | nindent 10 }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- with .Values.controller.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
   {{- with .Values.controller.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -486,7 +487,7 @@ spec:
       {{- end }}
       volumes:
         - name: socket-dir
-          emptyDir: {}
+          {{- toYaml .Values.controller.socketDirVolume | nindent 10 }}
         {{- with .Values.controller.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -246,6 +246,9 @@ controller:
   # region: us-east-1
   region:
   replicaCount: 2
+  revisionHistoryLimit: 10
+  socketDirVolume:
+    emptyDir: {}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -359,6 +362,9 @@ node:
       memory: 40Mi
     limits:
       memory: 256Mi
+  revisionHistoryLimit: 10
+  probeDirVolume:
+    emptyDir: {}
   serviceAccount:
     create: true
     name: ebs-csi-node-sa

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/name: aws-ebs-csi-driver
 spec:
   replicas: 2
+  revisionHistoryLimit: 10
   strategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
 spec:
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: ebs-csi-node


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Helm chart feature.

**What is this PR about? / Why do we need it?**

This PR adds chart parameters to tune the `revisionHistoryLimit` on the Deployment & DaemonSet and also to tune the `emptyDir` volumes used for sockets and probes, (set `sizeLimit`, `medium`, etc.).

Default values match the implicit Kubernetes default (in the case of `revisionHistoryLimit`) or match the original hardcoded value.

**What testing is done?** 

Generated manifests only show the addition of the (now explicit) default `revisionHistoryLimit`, volumes remain unchanged.