### PR TITLE
Add E2E tests for modifying volumes via annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ test-sanity:
 test-e2e-single-az:
 	AWS_REGION=us-west-2 \
 	AWS_AVAILABILITY_ZONES=us-west-2a \
-	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME' \
+	HELM_EXTRA_FLAGS='--set=controller.k8sTagClusterId=$$CLUSTER_NAME,controller.volumeModificationFeature.enabled=true' \
 	EBS_INSTALL_SNAPSHOT="true" \
 	TEST_PATH=./tests/e2e/... \
 	GINKGO_FOCUS="\[ebs-csi-e2e\] \[single-az\]" \

--- a/tests/e2e/modify_volume.go
+++ b/tests/e2e/modify_volume.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/testsuites"
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var (
+	defaultModifyVolumeTestGp3CreateVolumeParameters = map[string]string{
+		ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+		ebscsidriver.FSTypeKey:     ebscsidriver.FSTypeExt4,
+	}
+)
+
+var (
+	modifyVolumeTests = map[string]testsuites.ModifyVolumeTest{
+		"with a new iops annotation": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationIops: "4000",
+			},
+			ShouldResizeVolume:                    false,
+			ShouldTestInvalidModificationRecovery: false,
+		},
+		"with a new io2 volumeType annotation": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationVolumeType: awscloud.VolumeTypeIO2,
+				testsuites.AnnotationIops:       testsuites.DefaultIopsIoVolumes, // As of aws-ebs-csi-driver v1.25.0, parameter iops must be re-specified when modifying volumeType io2 volumes.
+			},
+			ShouldResizeVolume:                    false,
+			ShouldTestInvalidModificationRecovery: false,
+		},
+		"with a new throughput annotation": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationThroughput: "150",
+			},
+			ShouldResizeVolume:                    false,
+			ShouldTestInvalidModificationRecovery: false,
+		},
+		"with new throughput and iops annotations": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationIops:       "4000",
+				testsuites.AnnotationThroughput: "150",
+			},
+			ShouldResizeVolume:                    false,
+			ShouldTestInvalidModificationRecovery: false,
+		},
+		"with a larger size and new throughput and iops annotations": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationIops:       "4000",
+				testsuites.AnnotationThroughput: "150",
+			},
+			ShouldResizeVolume:                    true,
+			ShouldTestInvalidModificationRecovery: false,
+		},
+		"with a larger size and new throughput and iops annotations after providing an invalid annotation": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationIops:       "4000",
+				testsuites.AnnotationThroughput: "150",
+			},
+			ShouldResizeVolume:                    true,
+			ShouldTestInvalidModificationRecovery: true,
+		},
+		"from io2 to gp3 with larger size and new iops and throughput annotations": {
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeIO2,
+				ebscsidriver.FSTypeKey:     ebscsidriver.FSTypeExt4,
+				ebscsidriver.IopsKey:       testsuites.DefaultIopsIoVolumes,
+			},
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationVolumeType: awscloud.VolumeTypeGP3,
+				testsuites.AnnotationIops:       "4000",
+				testsuites.AnnotationThroughput: "150",
+			},
+			ShouldResizeVolume:                    true,
+			ShouldTestInvalidModificationRecovery: false,
+		},
+	}
+)
+
+var _ = Describe("[ebs-csi-e2e] [single-az] [modify-volume] Modifying a PVC", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		ebsDriver driver.PVTestDriver
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		ebsDriver = driver.InitEbsCSIDriver()
+	})
+
+	for testName, modifyVolumeTest := range modifyVolumeTests {
+		modifyVolumeTest := modifyVolumeTest
+		Context(testName, func() {
+			It("will modify associated PV and EBS Volume", func() {
+				modifyVolumeTest.Run(cs, ns, ebsDriver)
+			})
+		})
+	}
+})

--- a/tests/e2e/testsuites/e2e_utils.go
+++ b/tests/e2e/testsuites/e2e_utils.go
@@ -14,17 +14,119 @@ limitations under the License.
 
 package testsuites
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"time"
+)
 
 const (
 	DefaultVolumeName = "test-volume-1"
 	DefaultMountPath  = "/mnt/default-mount"
 
 	DefaultIopsIoVolumes = "100"
+
+	DefaultSizeIncreaseGi = 1
+
+	DefaultModificationTimeout   = 3 * time.Minute
+	DefaultResizeTimout          = 1 * time.Minute
+	DefaultK8sApiPollingInterval = 5 * time.Second
+
+	AnnotationIops       = "ebs.csi.aws.com/iops"
+	AnnotationThroughput = "ebs.csi.aws.com/throughput"
+	AnnotationVolumeType = "ebs.csi.aws.com/volumeType"
 )
 
+// PodCmdWriteToVolume returns pod command that would write to mounted volume
 func PodCmdWriteToVolume(volumeMountPath string) string {
 	return fmt.Sprintf("echo 'hello world' >> %s/data && grep 'hello world' %s/data && sync", volumeMountPath, volumeMountPath)
+}
+
+// PodCmdContinuousWrite returns pod command that would continuously write to mounted volume
+func PodCmdContinuousWrite(volumeMountPath string) string {
+	return fmt.Sprintf("while true; do echo \"$(date -u)\" >> /%s/out.txt; sleep 5; done", volumeMountPath)
+}
+
+// IncreasePvcObjectStorage increases `storage` of a K8s PVC object by specified Gigabytes
+func IncreasePvcObjectStorage(pvc *v1.PersistentVolumeClaim, sizeIncreaseGi int64) resource.Quantity {
+	pvcSize := pvc.Spec.Resources.Requests["storage"]
+	delta := resource.Quantity{}
+	delta.Set(util.GiBToBytes(sizeIncreaseGi))
+	pvcSize.Add(delta)
+	pvc.Spec.Resources.Requests["storage"] = pvcSize
+	return pvcSize
+}
+
+// WaitForPvToResize waiting for pvc size to be resized to desired size
+func WaitForPvToResize(c clientset.Interface, ns *v1.Namespace, pvName string, desiredSize resource.Quantity, timeout time.Duration, interval time.Duration) error {
+	framework.Logf("waiting up to %v for pv resize in namespace %q to be complete", timeout, ns.Name)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
+		newPv, _ := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+		newPvSize := newPv.Spec.Capacity["storage"]
+		if desiredSize.Equal(newPvSize) {
+			framework.Logf("pv size is updated to %v", newPvSize.String())
+			return nil
+		}
+	}
+	return fmt.Errorf("gave up after waiting %v for pv %q to complete resizing", timeout, pvName)
+}
+
+// ResizeTestPvc increases size of given `TestPersistentVolumeClaim` by specified Gigabytes
+func ResizeTestPvc(client clientset.Interface, namespace *v1.Namespace, testPvc *TestPersistentVolumeClaim, sizeIncreaseGi int64) (updatedSize resource.Quantity) {
+	framework.Logf("getting pvc name: %v", testPvc.persistentVolumeClaim.Name)
+	pvc, _ := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), testPvc.persistentVolumeClaim.Name, metav1.GetOptions{})
+
+	IncreasePvcObjectStorage(pvc, sizeIncreaseGi)
+
+	framework.Logf("updating the pvc object")
+	updatedPvc, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+	if err != nil {
+		framework.ExpectNoError(err, fmt.Sprintf("fail to resize pvc(%s): %v", pvc.Name, err))
+	}
+	updatedSize = updatedPvc.Spec.Resources.Requests["storage"]
+
+	framework.Logf("checking the resizing PV result")
+	err = WaitForPvToResize(client, namespace, updatedPvc.Spec.VolumeName, updatedSize, DefaultResizeTimout, DefaultK8sApiPollingInterval)
+	framework.ExpectNoError(err)
+	return updatedSize
+}
+
+// AnnotatePvc annotates supplied k8s pvc object with supplied annotations
+func AnnotatePvc(pvc *v1.PersistentVolumeClaim, annotations map[string]string) {
+	for annotation, value := range annotations {
+		pvc.Annotations[annotation] = value
+	}
+}
+
+// CheckPvAnnotations checks whether supplied k8s pv object contains supplied annotations
+func CheckPvAnnotations(pv *v1.PersistentVolume, annotations map[string]string) bool {
+	for annotation, value := range annotations {
+		if pv.Annotations[annotation] != value {
+			return false
+		}
+	}
+	return true
+}
+
+// WaitForPvToModify waiting for PV to be modified
+func WaitForPvToModify(c clientset.Interface, ns *v1.Namespace, pvName string, expectedAnnotations map[string]string, timeout time.Duration, interval time.Duration) error {
+	framework.Logf("waiting up to %v for pv in namespace %q to be modified", timeout, ns.Name)
+
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
+		modifyingPv, _ := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+
+		if CheckPvAnnotations(modifyingPv, expectedAnnotations) {
+			framework.Logf("pv annotations are updated to %v", modifyingPv.Annotations)
+			return nil
+		}
+	}
+	return fmt.Errorf("gave up after waiting %v for pv %q to complete modifying", timeout, pvName)
 }
 
 func CreateVolumeDetails(createVolumeParameters map[string]string, volumeSize string) *VolumeDetails {

--- a/tests/e2e/testsuites/format_options_tester.go
+++ b/tests/e2e/testsuites/format_options_tester.go
@@ -28,10 +28,6 @@ type FormatOptionTest struct {
 	CreateVolumeParameters map[string]string
 }
 
-const (
-	volumeSizeIncreaseAmtGi = 1
-)
-
 func (t *FormatOptionTest) Run(client clientset.Interface, namespace *v1.Namespace, ebsDriver driver.PVTestDriver) {
 	By("setting up pvc with custom format option")
 	volumeDetails := CreateVolumeDetails(t.CreateVolumeParameters, driver.MinimumSizeForVolumeType(t.CreateVolumeParameters[ebscsidriver.VolumeTypeKey]))
@@ -44,7 +40,7 @@ func (t *FormatOptionTest) Run(client clientset.Interface, namespace *v1.Namespa
 	formatOptionMountPod.WaitForSuccess()
 
 	By("testing that pvc is able to be resized")
-	ResizeTestPvc(client, namespace, testPvc, volumeSizeIncreaseAmtGi)
+	ResizeTestPvc(client, namespace, testPvc, DefaultSizeIncreaseGi)
 
 	By("validating resized pvc by deploying new pod")
 	resizeTestPod := createPodWithVolume(client, namespace, PodCmdWriteToVolume(DefaultMountPath), testPvc, volumeDetails)

--- a/tests/e2e/testsuites/modify_volume_tester.go
+++ b/tests/e2e/testsuites/modify_volume_tester.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// ModifyVolumeTest will provision pod with attached volume, and test that modifying its pvc will modify the associated pv.
+type ModifyVolumeTest struct {
+	CreateVolumeParameters                map[string]string
+	ModifyVolumeAnnotations               map[string]string
+	ShouldResizeVolume                    bool
+	ShouldTestInvalidModificationRecovery bool
+}
+
+var (
+	invalidAnnotations = map[string]string{
+		AnnotationIops: "1",
+	}
+	volumeSize = "10Gi" // Different from driver.MinimumSizeForVolumeType to simplify iops, throughput, volumeType modification
+)
+
+func (modifyVolumeTest *ModifyVolumeTest) Run(c clientset.Interface, ns *v1.Namespace, ebsDriver driver.PVTestDriver) {
+	By("setting up pvc")
+	volumeDetails := CreateVolumeDetails(modifyVolumeTest.CreateVolumeParameters, volumeSize)
+	testVolume, _ := volumeDetails.SetupDynamicPersistentVolumeClaim(c, ns, ebsDriver)
+	defer testVolume.Cleanup()
+
+	By("deploying pod continuously writing to volume")
+	formatOptionMountPod := createPodWithVolume(c, ns, PodCmdContinuousWrite(DefaultMountPath), testVolume, volumeDetails)
+	defer formatOptionMountPod.Cleanup()
+	formatOptionMountPod.WaitForRunning()
+
+	if modifyVolumeTest.ShouldTestInvalidModificationRecovery {
+		By("modifying the pvc with invalid annotations")
+		attemptInvalidModification(c, ns, testVolume)
+	}
+
+	By("modifying the pvc")
+	modifyingPvc, _ := c.CoreV1().PersistentVolumeClaims(ns.Name).Get(context.TODO(), testVolume.persistentVolumeClaim.Name, metav1.GetOptions{})
+	AnnotatePvc(modifyingPvc, modifyVolumeTest.ModifyVolumeAnnotations)
+
+	var updatedPvcSize resource.Quantity
+	if modifyVolumeTest.ShouldResizeVolume {
+		By("resizing the pvc")
+		updatedPvcSize = IncreasePvcObjectStorage(modifyingPvc, DefaultSizeIncreaseGi)
+	}
+
+	modifiedPvc, err := c.CoreV1().PersistentVolumeClaims(ns.Name).Update(context.TODO(), modifyingPvc, metav1.UpdateOptions{})
+	if err != nil {
+		framework.ExpectNoError(err, fmt.Sprintf("fail to modify pvc(%s): %v", modifyingPvc.Name, err))
+	}
+	framework.Logf("updated pvc: %s\n", modifiedPvc.Annotations)
+
+	// Confirm Volume Modified
+	By("wait for and confirm pv modification")
+	err = WaitForPvToModify(c, ns, testVolume.persistentVolume.Name, modifyVolumeTest.ModifyVolumeAnnotations, DefaultModificationTimeout, DefaultK8sApiPollingInterval)
+	framework.ExpectNoError(err, fmt.Sprintf("fail to modify pv(%s): %v", modifyingPvc.Name, err))
+	if modifyVolumeTest.ShouldResizeVolume {
+		err = WaitForPvToResize(c, ns, testVolume.persistentVolume.Name, updatedPvcSize, DefaultResizeTimout, DefaultK8sApiPollingInterval)
+		framework.ExpectNoError(err, fmt.Sprintf("fail to resize pv(%s): %v", modifyingPvc.Name, err))
+	}
+}
+
+func attemptInvalidModification(c clientset.Interface, ns *v1.Namespace, testVolume *TestPersistentVolumeClaim) {
+	modifyingPvc, _ := c.CoreV1().PersistentVolumeClaims(ns.Name).Get(context.TODO(), testVolume.persistentVolumeClaim.Name, metav1.GetOptions{})
+	AnnotatePvc(modifyingPvc, invalidAnnotations)
+	modifiedPvc, err := c.CoreV1().PersistentVolumeClaims(ns.Name).Update(context.TODO(), modifyingPvc, metav1.UpdateOptions{})
+	if err != nil {
+		framework.ExpectNoError(err, fmt.Sprintf("fail to modify pvc(%s): %v", modifyingPvc.Name, err))
+	}
+	framework.Logf("pvc %q/%q has been modified with invalid annotations: %s", ns.Name, modifiedPvc.Name, modifiedPvc.Annotations)
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Test-coverage

**What is this PR about? / Why do we need it?**
Note: This PR has been rebased since merging #1845 

The purposes of each commit exclusive to this PR are:
- [Refactor E2E: Extract resize-related helper functions](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/74108d8198c5e448a299bd783ad00e513ac43dcc)
  - We want to ensure that customers who both expand the size of a volume and modify a volume's performance parameters at the same time can do so (without waiting for the 6 hour modifyVolume EC2 API cooldown. This implicitly testing request coalescing). Therefore we should extract resize-related helper functions into the shared e2e-utils file (and hopefully someday a separate e2e-utils package). 
- [Add E2E tests for modifying volumes via annotations](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/417e416a43b1773a65c152744e35c9c71f7882ee)
  - We currently have no E2E test coverage for our [modify-volume feature](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/modify-volume.md). 

**What testing is done?** 
Running E2E tests locally with volume-modifier-for-k8s deployed while manually confirming state of K8s objects and EBS volumes.  

```
❯ ginkgo --focus='modify-volume' -p
Running Suite: AWS EBS CSI Driver End-to-End Tests - /workplace/andsirey/aws-ebs-csi-driver/tests/e2e
==========================
Random Seed: 1700859607

Will run 7 of 51 specs
Running in parallel across 15 processes
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••

Ran 7 of 51 Specs in 93.699 seconds
SUCCESS! -- 7 Passed | 0 Failed | 0 Pending | 44 Skipped
```

Example verbose output of a test:

```
❯ ginkgo --focus='modify-volume' -v
  W1124 21:04:10.564530   27551 test_context.go:509] Unable to find in-cluster config, using default host : https://127.0.0.1:6443
  Nov 24 21:04:10.564: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
Running Suite: AWS EBS CSI Driver End-to-End Tests - /workplace/andsirey/aws-ebs-csi-driver/tests/e2e
=====================================================================================================
Random Seed: 1700859846

Will run 7 of 51 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[ebs-csi-e2e] [single-az] [modify-volume] Modifying a PVC from io2 to gp3 with larger size and new iops and throughput annotations will modify associated PV and EBS Volume
/workplace/andsirey/aws-ebs-csi-driver/tests/e2e/modify_volume.go:127
  STEP: Creating a kubernetes client @ 11/24/23 21:04:10.566
  Nov 24 21:04:10.566: INFO: >>> kubeConfig: /home/andsirey/.kube/config
  STEP: Building a namespace api object, basename ebs @ 11/24/23 21:04:10.568
  STEP: Waiting for a default service account to be provisioned in namespace @ 11/24/23 21:04:11.947
  STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 11/24/23 21:04:12.07
  STEP: setting up pvc @ 11/24/23 21:04:12.193
  STEP: setting up the StorageClass @ 11/24/23 21:04:12.194
  STEP: creating a StorageClass  @ 11/24/23 21:04:12.194
  STEP: setting up the PVC and PV @ 11/24/23 21:04:12.259
  STEP: creating a PVC @ 11/24/23 21:04:12.259
  STEP: waiting for PVC to be in phase "Bound" @ 11/24/23 21:04:12.333
  Nov 24 21:04:12.333: INFO: Waiting up to timeout=5m0s for PersistentVolumeClaims [pvc-q2ks7] to have phase Bound
  Nov 24 21:04:12.397: INFO: PersistentVolumeClaim pvc-q2ks7 found but phase is Pending instead of Bound.
  Nov 24 21:04:14.462: INFO: PersistentVolumeClaim pvc-q2ks7 found but phase is Pending instead of Bound.
  Nov 24 21:04:16.528: INFO: PersistentVolumeClaim pvc-q2ks7 found but phase is Pending instead of Bound.
  Nov 24 21:04:18.593: INFO: PersistentVolumeClaim pvc-q2ks7 found and phase=Bound (6.259909505s)
  STEP: checking the PVC @ 11/24/23 21:04:18.593
  STEP: validating provisioned PV @ 11/24/23 21:04:18.657
  STEP: checking the PV @ 11/24/23 21:04:18.721
  STEP: deploying pod continously writing to volume @ 11/24/23 21:04:18.721
  W1124 21:04:18.815721   27551 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "volume-tester" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "volume-tester" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "volume-tester" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "volume-tester" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  STEP: modifying the pvc @ 11/24/23 21:04:31.295
  STEP: resizing the pvc @ 11/24/23 21:04:31.358
  Nov 24 21:04:31.425: INFO: updated pvc: map[ebs.csi.aws.com/iops:4000 ebs.csi.aws.com/throughput:150 ebs.csi.aws.com/volumeType:gp3 pv.kubernetes.io/bind-completed:yes pv.kubernetes.io/bound-by-controller:yes volume.beta.kubernetes.io/storage-provisioner:ebs.csi.aws.com volume.kubernetes.io/storage-provisioner:ebs.csi.aws.com]

  STEP: wait for and confirm pv modification @ 11/24/23 21:04:31.425
  Nov 24 21:04:31.425: INFO: waiting up to 3m0s for pv in namespace "ebs-8170" to be modified
  Nov 24 21:04:41.625: INFO: pv annotations are updated to map[ebs.csi.aws.com/iops:4000 ebs.csi.aws.com/throughput:150 ebs.csi.aws.com/volumeType:gp3 pv.kubernetes.io/provisioned-by:ebs.csi.aws.com volume.kubernetes.io/provisioner-deletion-secret-name: volume.kubernetes.io/provisioner-deletion-secret-namespace:]
  Nov 24 21:04:41.625: INFO: waiting up to 1m0s for pv resize in namespace "ebs-8170" to be complete
  Nov 24 21:04:41.689: INFO: pv size is updated to 11Gi
  Nov 24 21:04:41.689: INFO: deleting Pod "ebs-8170"/"ebs-volume-tester-f7mgr"
  Nov 24 21:04:41.770: INFO: Pod ebs-volume-tester-f7mgr has the following logs:
  STEP: Deleting pod ebs-volume-tester-f7mgr in namespace ebs-8170 @ 11/24/23 21:04:41.77
  Nov 24 21:04:41.837: INFO: deleting PVC "ebs-8170"/"pvc-q2ks7"
  Nov 24 21:04:41.837: INFO: Deleting PersistentVolumeClaim "pvc-q2ks7"
  STEP: waiting for claim's PV "pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568" to be deleted @ 11/24/23 21:04:41.909
  Nov 24 21:04:41.909: INFO: Waiting up to 10m0s for PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 to get deleted
  Nov 24 21:04:41.973: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (64.502569ms)
  Nov 24 21:04:47.041: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (5.132730617s)
  Nov 24 21:04:52.110: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (10.20093835s)
  Nov 24 21:04:57.178: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (15.269120863s)
  Nov 24 21:05:02.246: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (20.337128434s)
  Nov 24 21:05:07.315: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (25.406100254s)
  Nov 24 21:05:12.380: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Bound (30.471429661s)
  Nov 24 21:05:17.449: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Released (35.5401519s)
  Nov 24 21:05:22.517: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Released (40.607836016s)
  Nov 24 21:05:27.585: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 found and phase=Released (45.676542314s)
  Nov 24 21:05:32.653: INFO: PersistentVolume pvc-b6a153b9-01f5-43c2-9fd7-2961e3227568 was removed
  Nov 24 21:05:32.653: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-q2ks7 to be removed
  Nov 24 21:05:32.717: INFO: Claim "pvc-q2ks7" in namespace "ebs-8170" doesn't exist in the system
  STEP: Destroying namespace "ebs-8170" for this suite. @ 11/24/23 21:05:32.717
• [82.218 seconds]

```

NOTE: Tests currently fail because we need to turn volumeModification parameter on in CI. This change should be a part of this PR. 