### PR TITLE
Add script to generate manifest of pod with specified amount of volumes

### DIFF
--- a/hack/device_slot_test.tmpl
+++ b/hack/device_slot_test.tmpl
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: device-limit-tester-{{ len .Volumes }}-volumes
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: {{ .NodeAffinityKey }}
+            operator: In
+            values:
+            - {{ .NodeAffinityValue }}
+  containers:
+  - name: device-limit-tester-{{ len .Volumes }}-volumes
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+{{- range $index, $value := .Volumes }}
+    - name: persistent-storage-{{ $index }}
+      mountPath: /data-{{ $index }}
+{{- end }}
+  volumes:
+{{- range $index, $value := .Volumes }}
+    - name: persistent-storage-{{ $index }}
+      persistentVolumeClaim:
+        claimName: ebs-claim-{{ $index }}
+{{- end }}
+---
+{{- range $index, $value := .Volumes }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-claim-{{ $index }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+---
+{{- end }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer

--- a/hack/generate_example_manifest.go
+++ b/hack/generate_example_manifest.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+)
+
+type Manifest struct {
+	NodeAffinityKey   string
+	NodeAffinityValue string
+	Volumes           []int
+}
+
+func main() {
+	// Parse Command-Line args & flags
+	nodeAffinityPtr := flag.String("node-affinity", "", "node affinity for pod in form of 'key:value'")
+	volumeCountPtr := flag.Int("volume-count", 2, "amount of Volumes to provision")
+	flag.Parse()
+
+	nodeAffinityKey, nodeAffinityValue := parseNodeAffinityFlag(nodeAffinityPtr)
+
+	manifest := Manifest{
+		NodeAffinityKey:   nodeAffinityKey,
+		NodeAffinityValue: nodeAffinityValue,
+		Volumes:           make([]int, *volumeCountPtr),
+	}
+
+	// Generate manifest to stdout from template file
+	var tmplFile = "device_slot_test.tmpl"
+	tmpl, err := template.New(tmplFile).ParseFiles(tmplFile)
+	if err != nil {
+		panic(err)
+	}
+	err = tmpl.Execute(os.Stdout, manifest)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func parseNodeAffinityFlag(nodeAffinityPtr *string) (string, string) {
+	nodeAffinityKey := ""
+	nodeAffinityValue := ""
+	if len(*nodeAffinityPtr) > 0 {
+		nodeAffinity := strings.Split(*nodeAffinityPtr, ":")
+		if len(nodeAffinity) != 2 {
+			panic(fmt.Errorf("flag '--node-affinity' must take the form 'key:value'"))
+		}
+		nodeAffinityKey = nodeAffinity[0]
+		nodeAffinityValue = nodeAffinity[1]
+	}
+	return nodeAffinityKey, nodeAffinityValue
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Tool
**What is this PR about? / Why do we need it?**
Adds a script to generate manifest of pod with certain # PVs and node-afinity via the go templating package. 

This script will be used in a bash script that tests the attachment limit of a specified instance type. 

**What testing is done?** 
Generating a manifest with script, and deploying it to active cluster
```
❯ go run generate_example_manifest.go --node-affinity 'kubernetes.io/os:linux' --volume-count 4
apiVersion: v1
kind: Pod
metadata:
  name: device-limit-tester-4-volumes
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux
  containers:
  - name: device-limit-tester-4-volumes
    image: centos
    command: ["/bin/sh"]
    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
    volumeMounts:
    - name: persistent-storage-0
      mountPath: /data-0
    - name: persistent-storage-1
      mountPath: /data-1
    - name: persistent-storage-2
      mountPath: /data-2
    - name: persistent-storage-3
      mountPath: /data-3
  volumes:
    - name: persistent-storage-0
      persistentVolumeClaim:
        claimName: ebs-claim-0
    - name: persistent-storage-1
      persistentVolumeClaim:
        claimName: ebs-claim-1
    - name: persistent-storage-2
      persistentVolumeClaim:
        claimName: ebs-claim-2
    - name: persistent-storage-3
      persistentVolumeClaim:
        claimName: ebs-claim-3
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim-0
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 4Gi
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim-1
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 4Gi
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim-2
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 4Gi
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim-3
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 4Gi
---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
```