### PR TITLE
Upgrade golangci-lint to version that supports go1.21.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ bin/mockgen: | bin
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.51.2
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.54.0
 
 .PHONY: kubeval
 kubeval: bin/kubeval


### PR DESCRIPTION
Extracts a fix from #1854 that fixes the golangci-lint issue that is blocking several PRs after the kubekins image was updated to go 1.21.5