### PR TITLE
Add attachment limit scripts to hack/cluster-debugging-scripts

### DIFF
--- a/hack/cluster-debugging-scripts/README.md
+++ b/hack/cluster-debugging-scripts/README.md
@@ -1,0 +1,55 @@
+# Cluster Debugging Scripts
+
+This folder contains a collection of scripts to help debug clusters.
+
+## FAQ
+
+### How can I validate that the aws-ebs-csi-driver correctly makes use of all available attachment slots for instance type X? 
+
+Answer: Perform the following steps (Which will create a nodegroup, count the Block Device Mappings + ENI for the underlying instance, deploy pods EBS PVs until the script finds the maximum amount of volumes the aws-ebs-csi-driver can attach to instance)
+
+```
+export CLUSTER_NAME="devcluster"
+export NODEGROUP_NAME="ng-attachment-limit-test"
+export INSTANCE_TYPE="m7g.large"
+
+eksctl create nodegroup -c "$CLUSTER_NAME" --nodes 1 -t "$INSTANCE_TYPE" -n "$NODEGROUP_NAME"
+
+./get-attachment-breakdown "$INSTANCE_TYPE" 
+
+eksctl delete nodegroup -c "$CLUSTER_NAME" -n "$INSTANCE_TYPE"
+```
+
+By the end of the script, you should see an output similar to this:
+```
+Attachments for ng-f3ecdf71
+BlockDeviceMappings  ENIs  Available-Attachment-Slots(Validated-by-aws-ebs-csi-driver)
+1                    2     25
+```
+
+## Scripts
+
+get-attachment-breakdown: Find the maximum amount of volumes that can be attached to a specified nodegroup node. Additionally, log how many BlockDeviceMappings and ENIs are attached the instance of the specified nodegroup. 
+
+Examples
+```
+./get_attachment_breakdown "ng-f3ecdf71"
+MIN_VOLUME_GUESS=20 MAX_VOLUME_GUESS=40 POD_TIMEOUT_SECONDS=120 ./get_attachment_breakdown "ng-f3ecdf71"
+```
+
+find-attachment-limit: Find the maximum amount of volumes the aws-ebs-csi-driver can attach to a node. 
+
+Examples:
+```
+./find-attachment-limit 'some.node.affinity.key:value'
+./find-attachment-limit 'eks.amazonaws.com/nodegroup:test-nodegroup'
+./find-attachment-limit 'node.kubernetes.io/instance-type:m5.large'
+MIN_VOLUME_GUESS=12 MAX_VOLUME_GUESS=30 POD_TIMEOUT_SECONDS=60 ./find_attachment_limit 'node.kubernetes.io/instance-type:m5.large' 
+```
+
+generate_example_manifest.go: Generate a yaml file containing a pod associated with a specified amount of PVCs based off of the template file `device_slot_test.tmpl`
+
+Example:
+```
+go run "generate_example_manifest.go" --node-affinity "some.label:value" --volume-count "22" --test-pod-name "test-pod"
+```

--- a/hack/cluster-debugging-scripts/device_slot_test.tmpl
+++ b/hack/cluster-debugging-scripts/device_slot_test.tmpl
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .PodName }}
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: {{ .NodeAffinityKey }}
+            operator: In
+            values:
+            - {{ .NodeAffinityValue }}
+  containers:
+  - name: device-limit-tester-{{ len .Volumes }}-volumes
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo hello; sleep 10;done"]
+    volumeMounts:
+{{- range $index, $value := .Volumes }}
+    - name: persistent-storage-{{ $index }}
+      mountPath: /data-{{ $index }}
+{{- end }}
+  volumes:
+{{- range $index, $value := .Volumes }}
+    - name: persistent-storage-{{ $index }}
+      persistentVolumeClaim:
+        claimName: ebs-claim-{{ $index }}
+{{- end }}
+---
+{{- range $index, $value := .Volumes }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-claim-{{ $index }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+---
+{{- end }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer

--- a/hack/cluster-debugging-scripts/find-attachment-limit
+++ b/hack/cluster-debugging-scripts/find-attachment-limit
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---
+
+set -euo pipefail # Exit on any error
+
+# --- Environment Variables
+export MIN_VOLUME_GUESS=${MIN_VOLUME_GUESS:=0}
+export MAX_VOLUME_GUESS=${MAX_VOLUME_GUESS:=130}
+export POD_TIMEOUT_SECONDS=${POD_TIMEOUT_SECONDS:=90}
+export EXTRA_LOGS_FILEPATH=${EXTRA_LOGS_FILEPATH:="/dev/null"}
+
+export TEST_POD_NAME=${TEST_POD_NAME:="attachment-limit-test-pod"}
+
+export SCRIPT_DIR ROOT_DIRECTORY GENERATE_MANIFEST_SCRIPT_FILEPATH
+SCRIPT_DIR=$(dirname $(realpath "$0"))
+GENERATE_MANIFEST_SCRIPT_FILEPATH="$SCRIPT_DIR/generate_example_manifest.go"
+
+# --- Script Tools
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("kubectl" "go")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+# --- Script
+usage() {
+  echo "Usage: $0 [NODE_AFFINITY]"
+  echo "Examples:"
+  echo "$0 'eks.amazonaws.com/nodegroup:test-nodegroup'"
+  echo "$0 'node.kubernetes.io/instance-type:m5.large'"
+  echo "You can also override the following environment variable defaults: MIN_VOLUME_GUESS=0 MAX_VOLUME_GUESS=130 POD_TIMEOUT_SECONDS=90 EXTRA_LOGS_FILEPATH='/dev/null'"
+  echo "MIN_VOLUME_GUESS=12 MAX_VOLUME_GUESS=30 POD_TIMEOUT_SECONDS=60 $0 'node.kubernetes.io/instance-type:m5.large'"
+  exit 1
+}
+
+parse_args() {
+  # Confirm 1 parameter
+  [[ $# -ne 1 ]] && usage
+
+  export NODE_AFFINITY_KEY_VALUE_PAIR=$1
+}
+
+cleanup() {
+  log "Deleting k8s objects associated with manifest $MANIFEST_FILE"
+  kubectl delete -f "$MANIFEST_FILE" >"$EXTRA_LOGS_FILEPATH" 2>&1
+  test -f "$MANIFEST_FILE" && rm "$MANIFEST_FILE"
+}
+
+deploy_manifest() {
+  VOLUME_COUNT=$1
+  log "Attempting to deploy pod with $VOLUME_COUNT PVCs on node with label '$NODE_AFFINITY_KEY_VALUE_PAIR'"
+
+  # Create pod manifest for initial guess
+  MANIFEST_FILE=$(mktemp)
+  go run "$GENERATE_MANIFEST_SCRIPT_FILEPATH" --node-affinity "$NODE_AFFINITY_KEY_VALUE_PAIR" --volume-count "$VOLUME_COUNT" --test-pod-name "$TEST_POD_NAME" >"$MANIFEST_FILE"
+
+  # Deploy pod to node
+  log "Creating k8s objects associated with manifest $MANIFEST_FILE"
+  kubectl create -f "$MANIFEST_FILE" >"$EXTRA_LOGS_FILEPATH"
+
+  # Watch for success vs error code
+  log "Waiting $POD_TIMEOUT_SECONDS seconds for 'pod/$TEST_POD_NAME to reach condition 'ready'"
+  set +e
+  kubectl wait --for=condition=ready --timeout="${POD_TIMEOUT_SECONDS}s" pod/"$TEST_POD_NAME" >"$EXTRA_LOGS_FILEPATH" 2>&1
+  WAS_POD_CREATED=$?
+  set -e
+  if [[ $WAS_POD_CREATED == 0 ]]; then
+    log "Pod with $VOLUME_COUNT PVCs successfully deployed"
+  else
+    log "Pod with $VOLUME_COUNT PVCs did not successfully deploy"
+  fi
+
+  cleanup
+}
+
+main() {
+  check_dependencies
+
+  parse_args "$@"
+
+  export WAS_POD_CREATED=0 # 0 is true in bash
+  export MANIFEST_FILE
+  trap 'cleanup' EXIT
+
+  min=$MIN_VOLUME_GUESS
+  max=$MAX_VOLUME_GUESS
+
+  while ((min < max)); do
+    # Compute the mean between min and max, rounded up to the superior unit
+    current_volume_count=$(((min + max + 1) / 2))
+    deploy_manifest $current_volume_count
+    if [[ $WAS_POD_CREATED == 0 ]]; then # 0 is True in bash
+      min=$current_volume_count
+    else
+      max=$((current_volume_count - 1))
+    fi
+  done
+
+  export MAX_ATTACHED_VOLUMES="$min"
+  log "Success!"
+  log "Maximum amount of volumes deployed with pod on node with label '$NODE_AFFINITY_KEY_VALUE_PAIR': $MAX_ATTACHED_VOLUMES"
+  trap - EXIT
+  return "$MAX_ATTACHED_VOLUMES"
+}
+
+main "$@"

--- a/hack/cluster-debugging-scripts/generate_example_manifest.go
+++ b/hack/cluster-debugging-scripts/generate_example_manifest.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+)
+
+type Manifest struct {
+	NodeAffinityKey   string
+	NodeAffinityValue string
+	PodName           string
+	Volumes           []int
+}
+
+func main() {
+	// Parse Command-Line args & flags
+	nodeAffinityPtr := flag.String("node-affinity", "", "node affinity for pod in form of 'key:value'")
+	podNamePtr := flag.String("test-pod-name", "test-pod", "name for pod used in manifest. Default is 'test-pod'")
+	volumeCountPtr := flag.Int("volume-count", 2, "amount of Volumes to provision")
+	flag.Parse()
+
+	nodeAffinityKey, nodeAffinityValue, err := parseNodeAffinityFlag(nodeAffinityPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	manifest := Manifest{
+		NodeAffinityKey:   nodeAffinityKey,
+		NodeAffinityValue: nodeAffinityValue,
+		PodName:           *podNamePtr,
+		Volumes:           make([]int, *volumeCountPtr),
+	}
+
+	// Generate manifest to stdout from template file
+	var tmplFile = "device_slot_test.tmpl"
+	tmpl, err := template.New(tmplFile).ParseFiles(tmplFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = tmpl.Execute(os.Stdout, manifest)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func parseNodeAffinityFlag(nodeAffinityPtr *string) (string, string, error) {
+	nodeAffinityKey := ""
+	nodeAffinityValue := ""
+	if len(*nodeAffinityPtr) > 0 {
+		nodeAffinity := strings.Split(*nodeAffinityPtr, ":")
+		if len(nodeAffinity) != 2 {
+			return "", "", fmt.Errorf("flag '--node-affinity' must take the form 'key:value'")
+		}
+		nodeAffinityKey = nodeAffinity[0]
+		nodeAffinityValue = nodeAffinity[1]
+	}
+	return nodeAffinityKey, nodeAffinityValue, nil
+}

--- a/hack/cluster-debugging-scripts/get-attachment-breakdown
+++ b/hack/cluster-debugging-scripts/get-attachment-breakdown
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---
+
+set -euo pipefail # Exit on any error
+
+# --- Environment Variables
+export MIN_VOLUME_GUESS=${MIN_VOLUME_GUESS:=0}
+export MAX_VOLUME_GUESS=${MAX_VOLUME_GUESS:=130}
+export POD_TIMEOUT_SECONDS=${POD_TIMEOUT_SECONDS:=120}
+export TEST_POD_NAME=${TEST_POD_NAME:="attachment-limit-test-pod"}
+
+export SCRIPT_DIR ROOT_DIRECTORY FIND_ATTACHMENT_LIMIT_FILEPATH
+SCRIPT_DIR=$(dirname $(realpath "$0"))
+FIND_ATTACHMENT_LIMIT_FILEPATH="$SCRIPT_DIR/find-attachment-limit"
+
+# --- Script Tools
+# Color codes for different text colors
+RED='\033[0;31m'    # Red color for errors
+YELLOW='\033[0;33m' # Yellow color for warnings
+NC='\033[0m'        # No color (to reset the text color)
+
+log_warning() {
+  printf "${YELLOW}%s [WARNING] - %s\n${NC}" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+log_error() {
+  printf "${RED}%s [ERROR] - %s\n${NC}" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("kubectl" "go" "aws")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+# --- Script
+usage() {
+  echo "Usage: $0 [INSTANCE_TYPE]"
+  echo "Ex: $0 'test-instance-type'"
+  echo "You can also override the following environment variable defaults: MIN_VOLUME_GUESS=0 MAX_VOLUME_GUESS=130 POD_TIMEOUT_SECONDS=90 EXTRA_LOGS_FILEPATH='/dev/null'"
+  echo "MIN_VOLUME_GUESS=12 MAX_VOLUME_GUESS=30 POD_TIMEOUT_SECONDS=60 EXTRA_LOGS_FILEPATH:='/dev/null' $0 'test-instance-type'"
+  exit 1
+}
+
+parse_args() {
+  # Confirm 1 parameter
+  [[ $# -ne 1 ]] && usage
+
+  export INSTANCE_TYPE=$1
+}
+
+main() {
+  check_dependencies
+
+  parse_args "$@"
+
+  num_nodes_with_same_INSTANCE_TYPE=$(aws ec2 describe-instances --filters Name=tag:Name,Values="*$INSTANCE_TYPE*" --query 'length(Reservations[*].Instances[*])')
+  [[ $num_nodes_with_same_INSTANCE_TYPE -ne 1 ]] && log_warning "There are $num_nodes_with_same_INSTANCE_TYPE instances with the same instance type. This script may provide inaccurate numbers."
+
+  log "Currently the instance associated with instance type $INSTANCE_TYPE has the following attachments:"
+  block_device_mappings=$(aws ec2 describe-instances --filters Name=tag:Name,Values="*$INSTANCE_TYPE*" --query 'length(Reservations[0].Instances[0].BlockDeviceMappings)')
+  log "$block_device_mappings volumes from Block Device Mappings are attached to the instance. (Including the instance's root volume)"
+
+  enis=$(aws ec2 describe-instances --filters Name=tag:Name,Values="*$INSTANCE_TYPE*" --query 'length(Reservations[0].Instances[0].NetworkInterfaces)')
+  log "$enis Elastic Network Interfaces (ENIs) are attached to the instance. (NOTE: These ENIs may not count towards volume limit for certain Nitro System instance types. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html)"
+
+  log "Checking how many additional EBS volumes are able to be attached via the aws-ebs-csi-driver. This may take a while..."
+  set +e
+  $FIND_ATTACHMENT_LIMIT_FILEPATH "node.kubernetes.io/instance-type:$INSTANCE_TYPE"
+  max_additional_volumes="$?"
+  set -e
+  log "$max_additional_volumes volumes are able to be attached to the instance."
+
+  echo "Attachments for $INSTANCE_TYPE"
+  printf "BlockDeviceMappings ENIs Available-Attachment-Slots(Validated-by-aws-ebs-csi-driver)\n%s %s %s" "$block_device_mappings" "$enis" "$max_additional_volumes" | column --table
+}
+
+main "$@"

--- a/hack/cluster-debugging-scripts/go.mod
+++ b/hack/cluster-debugging-scripts/go.mod
@@ -1,0 +1,3 @@
+module cluster_debugging
+
+go 1.21.4


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Cluster debugging tool

**What is this PR about? / Why do we need it?**
NOTE: This PR is an expansion of #1852 

These scripts help answer the question: `How can I validate that the aws-ebs-csi-driver correctly makes use of all available attachment slots for instance type X?`

This question is important because the aws-ebs-csi-driver currently [hard-codes the attachment limit for each EC2 Instance family and type](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/b894ce5d19c696195609c8cd534aacc2ee9f2ade/pkg/cloud/volume_limits.go#L223) (Due to not having an EC2 API that outputs the attachment limit of a given instance type, and whether Non-EBS-volume-attachments count towards that limit). 

See README.md for overview of each script. At a high level: 

1. get-attachment-breakdown collects instance data from EC2 API, then calls find-attachment-limit
2. find-attachment-limit generates and deploys pods with varying amounts of PVs, and finds the maximum amount of volumes the aws-ebs-csi-driver can attach to the node. 
3. Those manifests are generated via `generate_example_manifest.go` from the template `device_slot_test.tmpl`

**What testing is done?** 
Tested on m5.large and m7g.large nodegroups. M7g.large has 28 volume limit including ENIs. When instance had 1 root volume + 2 ENIs, Script correctly discovered 25 to be max amount of EBS-backed PVs a pod can be created with. 

```
❯ export CLUSTER_NAME="devcluster"
❯ export NODEGROUP_NAME="ng-attachment-limit-test"
❯ export INSTANCE_TYPE="m7g.large"

❯ eksctl create nodegroup -c "$CLUSTER_NAME" --nodes 1 -t "$INSTANCE_TYPE" -n "$NODEGROUP_NAME"

❯ MIN_VOLUME_GUESS=20 MAX_VOLUME_GUESS=40 POD_TIMEOUT_SECONDS=120 ./get-attachment-breakdown "$NODEGROUP_NAME"
2023-12-08 17:57:59 [INFO] - Currently the instance associated with nodegroup name ng-attachment-limit-test has the following attachments:
2023-12-08 17:58:01 [INFO] - 1 volumes from Block Device Mappings are attached to the instance. (Including the instance's root volume)
2023-12-08 17:58:02 [INFO] - 2 Elastic Network Interfaces (ENIs) are attached to the instance. (NOTE: These ENIs may not count towards volume limit for certain Nitro System instance types. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html)
2023-12-08 17:58:02 [INFO] - Checking how many additional EBS volumes are able to be attached via the aws-ebs-csi-driver. This may take a while...
2023-12-08 17:58:02 [INFO] - Attempting to deploy pod with 30 PVCs on node with label 'eks.amazonaws.com/nodegroup:ng-attachment-limit-test'
2023-12-08 17:58:02 [INFO] - Creating k8s objects associated with manifest /tmp/tmp.CcGYdDXEMq
2023-12-08 17:58:07 [INFO] - Waiting 120 seconds for 'pod/attachment-limit-test-pod to reach condition 'ready'
2023-12-08 18:00:07 [INFO] - Pod with 30 PVCs did not successfully deploy
2023-12-08 18:00:07 [INFO] - Deleting k8s objects associated with manifest /tmp/tmp.CcGYdDXEMq
2023-12-08 18:00:15 [INFO] - Attempting to deploy pod with 25 PVCs on node with label 'eks.amazonaws.com/nodegroup:ng-attachment-limit-test'
2023-12-08 18:00:15 [INFO] - Creating k8s objects associated with manifest /tmp/tmp.Sirt5LQA5B
2023-12-08 18:00:19 [INFO] - Waiting 120 seconds for 'pod/attachment-limit-test-pod to reach condition 'ready'
2023-12-08 18:01:22 [INFO] - Pod with 25 PVCs successfully deployed
2023-12-08 18:01:22 [INFO] - Deleting k8s objects associated with manifest /tmp/tmp.Sirt5LQA5B
2023-12-08 18:01:58 [INFO] - Attempting to deploy pod with 27 PVCs on node with label 'eks.amazonaws.com/nodegroup:ng-attachment-limit-test'
2023-12-08 18:01:58 [INFO] - Creating k8s objects associated with manifest /tmp/tmp.yEbNmyCIKQ
2023-12-08 18:02:03 [INFO] - Waiting 120 seconds for 'pod/attachment-limit-test-pod to reach condition 'ready'
2023-12-08 18:04:03 [INFO] - Pod with 27 PVCs did not successfully deploy
2023-12-08 18:04:03 [INFO] - Deleting k8s objects associated with manifest /tmp/tmp.yEbNmyCIKQ
2023-12-08 18:04:10 [INFO] - Attempting to deploy pod with 26 PVCs on node with label 'eks.amazonaws.com/nodegroup:ng-attachment-limit-test'
2023-12-08 18:04:10 [INFO] - Creating k8s objects associated with manifest /tmp/tmp.c2LShnXELL
2023-12-08 18:04:14 [INFO] - Waiting 120 seconds for 'pod/attachment-limit-test-pod to reach condition 'ready'
2023-12-08 18:06:14 [INFO] - Pod with 26 PVCs did not successfully deploy
2023-12-08 18:06:14 [INFO] - Deleting k8s objects associated with manifest /tmp/tmp.c2LShnXELL
2023-12-08 18:06:30 [INFO] - Success!
2023-12-08 18:06:30 [INFO] - Maximum amount of volumes deployed with pod on node with label 'eks.amazonaws.com/nodegroup:ng-attachment-limit-test': 25
2023-12-08 18:06:30 [INFO] - 25 volumes are able to be attached to the instance.
Attachments for ng-attachment-limit-test
BlockDeviceMappings  ENIs  Available-Attachment-Slots(Validated-by-aws-ebs-csi-driver)
1                    2     25
```