### PR TITLE
Bugfix: Instances listed under `maxVolumeLimits` not taking into account ENIs/Instance storage

### DIFF
--- a/pkg/cloud/volume_limits.go
+++ b/pkg/cloud/volume_limits.go
@@ -78,7 +78,7 @@ func GetMaxAttachments(nitro bool) int {
 // / https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html
 var maxVolumeLimits = map[string]int{
 	"d3.8xlarge":    3,
-	"d3.12xlarge":   3,
+	"d3en.12xlarge": 3,
 	"g5.48xlarge":   9,
 	"inf1.xlarge":   26,
 	"inf1.2xlarge":  26,

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -779,7 +779,10 @@ func (d *nodeService) getVolumesLimit() int64 {
 	availableAttachments := cloud.GetMaxAttachments(isNitro)
 	blockVolumes := d.metadata.GetNumBlockDeviceMappings()
 	dedicatedLimit := cloud.GetDedicatedLimitForInstanceType(instanceType)
-
+	maxEBSAttachments, ok := cloud.GetEBSLimitForInstanceType(instanceType)
+	if ok {
+		availableAttachments = min(maxEBSAttachments, availableAttachments)
+	}
 	// For special dedicated limit instance types, the limit is only for EBS volumes
 	// For (all other) Nitro instances, attachments are shared between EBS volumes, ENIs and NVMe instance stores
 	if dedicatedLimit != 0 {
@@ -792,11 +795,6 @@ func (d *nodeService) getVolumesLimit() int64 {
 	availableAttachments = availableAttachments - blockVolumes - 1 // -1 for root device
 	if availableAttachments <= 0 {
 		availableAttachments = 1
-	}
-
-	maxEBSAttachments, ok := cloud.GetEBSLimitForInstanceType(instanceType)
-	if ok {
-		availableAttachments = min(maxEBSAttachments, availableAttachments)
 	}
 
 	return int64(availableAttachments)

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -2112,7 +2112,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      1,
-			expMaxVolumes:     19,
+			expMaxVolumes:     17,
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -2123,7 +2123,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      1,
-			expMaxVolumes:     16,
+			expMaxVolumes:     14,
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -2134,7 +2134,7 @@ func TestNodeGetInfo(t *testing.T) {
 			region:            "us-west-2",
 			volumeAttachLimit: -1,
 			attachedENIs:      1,
-			expMaxVolumes:     11,
+			expMaxVolumes:     9,
 			outpostArn:        emptyOutpostArn,
 		},
 		{
@@ -2194,6 +2194,17 @@ func TestNodeGetInfo(t *testing.T) {
 			volumeAttachLimit: -1,
 			attachedENIs:      2,
 			expMaxVolumes:     127, // 128 (max) - 1 (root)
+			outpostArn:        emptyOutpostArn,
+		},
+		{
+			name:              "d3.8xlarge instance max EBS attachment limit",
+			instanceID:        "i-123456789abcdef01",
+			instanceType:      "d3.8xlarge",
+			availabilityZone:  "us-west-2b",
+			region:            "us-west-2",
+			volumeAttachLimit: -1,
+			attachedENIs:      1,
+			expMaxVolumes:     1,
 			outpostArn:        emptyOutpostArn,
 		},
 	}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -2207,6 +2207,17 @@ func TestNodeGetInfo(t *testing.T) {
 			expMaxVolumes:     1,
 			outpostArn:        emptyOutpostArn,
 		},
+		{
+			name:              "d3en.12xlarge instance max EBS attachment limit",
+			instanceID:        "i-123456789abcdef01",
+			instanceType:      "d3en.12xlarge",
+			availabilityZone:  "us-west-2b",
+			region:            "us-west-2",
+			volumeAttachLimit: -1,
+			attachedENIs:      1,
+			expMaxVolumes:     1,
+			outpostArn:        emptyOutpostArn,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bugfix
closes #1688 

**What is this PR about? / Why do we need it?**

This PR addresses a bug in the driver where the calculation that subtracts ENIs and Instance store values is bypassed for certain instance types. More specifically, instance types included in `maxVolumeLimits`:  https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/v1.21.0/pkg/cloud/volume_limits.go#L56-66. 

As an example, `d3.8xlarge` (nitro instance) reports a value of `3`: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/6f2db761cfa352e05483b7f360b4ed9053b382d6/pkg/cloud/volume_limits.go#L57C3-L57C13 even when several ENIs are attached.

Following the current logic, `availableAttachments` is equal to the default value of `nitroMaxAttachments=28`  when enis and instance store volumes are taken into account. Finally, taking the min of `maxVolumeLimits` and `availableAttachments`, the value is incorrectly set to 3. 

With this change, `availableAttachments` is set to `maxVolumeLimits`  if necessary before the calculation is performed so that enis and instance store volumes can be correctly taken into account.

**What testing is done?** 
- `make test`
- Manual
