### PR TITLE
Fix kubernetes/cloud-provider-aws CI - DNM

### DIFF
--- a/hack/e2e/policy.json
+++ b/hack/e2e/policy.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DescribeRegions",
+          "ecr:GetAuthorizationToken",
+          "events:ListRules",
+          "iam:ListRoles",
+          "ssm:GetParameters",
+          "iam:ListInstanceProfiles",
+          "s3:*",
+          "s3-object-lambda:*",
+          "ec2-instance-connect:SendSSHPublicKey"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -16,7 +16,19 @@
 
 set -euo pipefail
 
+unset AWS_ROLE_ARN
+unset AWS_WEB_IDENTITY_TOKEN_FILE
 BASE_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+HELM_CT_TEST=${HELM_CT_TEST:-"false"}
+
+if [[ "${HELM_CT_TEST}" == true ]]; then
+aws iam put-role-policy \
+    --role-name aws-shared-testing-role \
+    --policy-name aws-shared-testing-role \
+    --policy-document "file://${BASE_DIR}/policy.json"
+  echo "10-4"
+fi
+
 source "${BASE_DIR}"/ecr.sh
 source "${BASE_DIR}"/eksctl.sh
 source "${BASE_DIR}"/helm.sh


### PR DESCRIPTION
CI still needs fixing over at https://github.com/kubernetes/cloud-provider-aws

```
 I1213 23:09:40.518894   20503 runner.go:177] instance connect err = sending SSH Public key for serial console access for ec2-user, AccessDeniedException: User: arn:aws:sts::209411653980:assumed-role/aws-shared-testing-role/e9668d92-4fda-45df-958f-d062269baf2f is not authorized to perform: ec2-instance-connect:SendSSHPublicKey on resource: arn:aws:ec2:us-east-1:209411653980:instance/i-0dfccb19d6a801734 because no identity-based policy allows the ec2-instance-connect:SendSSHPublicKey action 
```
Periodic: https://testgrid.k8s.io/provider-aws-periodics#ci-cloud-provider-aws-e2e-with-kubernetes-master

Doing the needful.
/hold