### PR TITLE
Enable kubetest2 container logs for pull-aws-ebs-csi-driver-test-helm-chart

### DIFF
--- a/tests/ct-config.yaml
+++ b/tests/ct-config.yaml
@@ -4,12 +4,12 @@ validate-maintainers: false
 check-version-increment: false
 charts:
   - charts/aws-ebs-csi-driver
-helm-extra-args: "--timeout 3000s"
+helm-extra-args: "--timeout 600s"
 upgrade: true
 skip-missing-values: true
 namespace: kube-system
 release-label: release
-kubectl-timeout: 3000s
+kubectl-timeout: 600s
 skip-clean-up: false
 print-logs: true
 debug: true


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

This PR:
- Enables kubetest2 container logs for `pull-aws-ebs-csi-driver-test-helm-chart`.
- Lowers `kubectl-timeout` from 30m -> 10m to reduce job time when the test hangs. For context, the tests complete within 3m ~99% of the time.

**What testing is done?**

CI
