### PR TITLE
Release aws-ebs-csi-driver v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v1.26.0
+### Announcements
+* [The EBS CSI Driver Helm chart will stop supporting `--reuse-values` in a future release](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1864)
+
+### Notable Changes
+* Add retry and background run to node taint removal ([#1861](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1861), [@ConnorJC3](https://github.com/ConnorJC3))
+* Add U7i attachment limits ([#1867](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1867), [@AndrewSirenko](https://github.com/AndrewSirenko))
+
+### Bug Fixes
+* Clamp minimum reported attachment limit to 1 to prevent undefined limit (This will prevent K8s from unrestricted scheduling of stateful workloads) ([#1859](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1859), [@torredil](https://github.com/torredil))
+* Instances listed under `maxVolumeLimits` not taking into account ENIs/Instance storage ([#1860](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1860), [@torredil](https://github.com/torredil))
+
+### Improvements
+* Upgrade dependencies for aws-ebs-csi-driver v1.26.0 ([#1867](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1867), [@AndrewSirenko](https://github.com/AndrewSirenko))
+* Bump otelhttp to fix CVE-2023-45142 ([#1858](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1858), [@jsafrane](https://github.com/jsafrane))
+
 # v1.25.0
 ### Notable Changes
 * Feature: Multi-Attach for io2 block devices ([#1799](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1799), [@torredil](https://github.com/torredil))

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION?=v1.25.0
+VERSION?=v1.26.0
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| v1.25.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.25.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0                      |
+| v1.26.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.26.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0                      |
 
 <details>
 <summary>Previous Images</summary>
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| v1.25.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.25.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0                      |
 | v1.24.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.1                      |
 | v1.24.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0                      |
 | v1.23.2        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.2                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.2                      |

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm chart
 
+## v2.26.0
+* Bump driver version to `v1.26.0`
+* Bump sidecar container versions ([#1867](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1867), [@AndrewSirenko](https://github.com/AndrewSirenko)) 
+* Add warning about --reuse-values deprecation to NOTES.txt ([#1865](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1865), [@ConnorJC3](https://github.com/ConnorJC3))
+
 ## v2.25.0
 * Bump driver version to `v1.25.0`
 * Update default sidecar timeout values ([#1824](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1824), [@torredil](https://github.com/torredil))

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.25.0
+appVersion: 1.26.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.25.0
+version: 2.26.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -61,7 +61,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -52,7 +52,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0
           imagePullPolicy: IfNotPresent
           args:
             - node

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,7 +52,7 @@ You may deploy the EBS CSI driver via Kustomize, Helm, or as an [Amazon EKS mana
 
 #### Kustomize
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.25"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.26"
 ```
 
 *Note: Using the master branch to deploy the driver is not supported as the master branch may contain upcoming features incompatible with the currently released stable version of the driver.*


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Release

**What is this PR about? / Why do we need it?**
Releases aws-ebs-csi-driver v1.26

**What testing is done?** 
    * Updates changelog.md
    * Updates readme.md latest version and install table
    * Updates Makefile VERSION 
    * Updates install.md all occurences of old version
    * Updates charts/aws-ebs-csi-driver/Chart.yaml with new version & appVersion 
    * Updates charts/aws-ebs-csi-driver/CHANGELOG.md with Helm changelog
    * Updates overlays by running make generate-kustomize

