### PR TITLE
Release aws-ebs-csi-driver v1.26.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v1.26.0
+### Announcements
+* [The EBS CSI Driver Helm chart will stop supporting `--reuse-values` in a future release](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1864)
+
+### Notable Changes
+* Add retry and background run to node taint removal ([#1861](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1861), [@ConnorJC3](https://github.com/ConnorJC3))
+* Add U7i attachment limits ([#1867](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1867), [@AndrewSirenko](https://github.com/AndrewSirenko))
+
+### Bug Fixes
+* Clamp minimum reported attachment limit to 1 to prevent undefined limit (This will prevent K8s from unrestricted scheduling of stateful workloads) ([#1859](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1859), [@torredil](https://github.com/torredil))
+* Instances listed under `maxVolumeLimits` not taking into account ENIs/Instance storage ([#1860](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1860), [@torredil](https://github.com/torredil))
+
+### Improvements
+* Upgrade dependencies for aws-ebs-csi-driver v1.26.0 ([#1867](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1867), [@AndrewSirenko](https://github.com/AndrewSirenko))
+* Bump otelhttp to fix CVE-2023-45142 ([#1858](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1858), [@jsafrane](https://github.com/jsafrane))
+
 # v1.25.0
 ### Notable Changes
 * Feature: Multi-Attach for io2 block devices ([#1799](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1799), [@torredil](https://github.com/torredil))

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION?=v1.25.0
+VERSION?=v1.26.0
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| v1.25.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.25.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0                      |
+| v1.26.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.26.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0                      |
 
 <details>
 <summary>Previous Images</summary>
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| v1.25.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.25.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0                      |
 | v1.24.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.1                      |
 | v1.24.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0                      |
 | v1.23.2        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.2                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.2                      |

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm chart
 
+## v2.26.0
+* Bump driver version to `v1.26.0`
+* Bump sidecar container versions ([#1867](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1867), [@AndrewSirenko](https://github.com/AndrewSirenko)) 
+* Add warning about --reuse-values deprecation to NOTES.txt ([#1865](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1865), [@ConnorJC3](https://github.com/ConnorJC3))
+
 ## v2.25.0
 * Bump driver version to `v1.25.0`
 * Update default sidecar timeout values ([#1824](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1824), [@torredil](https://github.com/torredil))

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.25.0
+appVersion: 1.26.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.25.0
+version: 2.26.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -61,7 +61,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0
           imagePullPolicy: IfNotPresent
           args:
             # - {all,controller,node} # specify the driver mode

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -52,7 +52,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0
           imagePullPolicy: IfNotPresent
           args:
             - node

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,7 +52,7 @@ You may deploy the EBS CSI driver via Kustomize, Helm, or as an [Amazon EKS mana
 
 #### Kustomize
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.25"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.26"
 ```
 
 *Note: Using the master branch to deploy the driver is not supported as the master branch may contain upcoming features incompatible with the currently released stable version of the driver.*


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Release 

**What is this PR about? / Why do we need it?**
Merge release-1.26 branch into master

**What testing is done?** 
Confirmed that the images are available on ECR Public + GCR

```
❯ crane manifest registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.26.0
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:76aac89455f0683f7a4572cc1b66724fc4a88a7a34f7c539d8fcd4123a0752ff",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:63893ea328168f4b83049e98686f86df2cefb55e7051c1dd6914a66aa3c2a66a",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:daf1fb404b41f9d26765ad7a398a179796278154bce14f014e524e38ac28156a",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.5206"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:f3b8be70d9a28a7a4a269d29c61a394276e901c804d1571b8a2e96118c2652c3",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2159"
         }
      }
   ]
}%
❯ crane manifest public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:1.26.0
Error: fetching manifest public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:1.26.0: GET https://public.ecr.aws/v2/ebs-csi-driver/aws-ebs-csi-driver/manifests/1.26.0: MANIFEST_UNKNOWN: Requested image not found
❯ crane manifest public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:b2e0802f1e62352a302b66c5e838e2c7b334a73b5d550ae6edceafac2bf18487",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:cb28dc6fd0651496ec6e1a8a58541f645391032a41fe675188ec03ea194fda79",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:a7f066c47b442e8b51df5cef9074f9cbda84d6fabb15c07266013e247f69bfb4",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.5206"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:a86c942297212a1e4ccdffe6e1347adca7bb15eaaece7f2634c6f6475f0e9ad2",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2159"
         }
      }
   ]
}%
```