### PR TITLE
Remove regression for GP3 storage classes below 3000 IOPS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1168,8 +1168,8 @@ golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0
 golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
-golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
-golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1517,6 +1517,8 @@ func capIOPS(volumeType string, requestedCapacityGiB int64, requestedIops int64,
 		if allowIncrease {
 			iops = minTotalIOPS
 			klog.V(5).InfoS("[Debug] Increased IOPS to the min supported limit", "volumeType", volumeType, "requestedCapacityGiB", requestedCapacityGiB, "limit", iops)
+		} else if volumeType == VolumeTypeGP3 {
+			klog.V(5).InfoS("[Debug] Did not increase IOPS", "volumeType", volumeType, "requestedCapacityGiB", requestedCapacityGiB)
 		} else {
 			return 0, fmt.Errorf("invalid IOPS: %d is too low, it must be at least %d", iops, minTotalIOPS)
 		}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
This regression first appears in v1.12.0 of the driver, and blocks workloads (pods, deployments, stateful-sets) that dynamically provision GP3 volumes but explicitly specify an IOPS below the GP3 minimum of 3000.

In other words, the workload produced from the following manifests will run when driver v1.8 is deployed, but NOT when v1.25 is deployed.
```
...
kind: StorageClass
metadata:
  name: ebs-sc
parameters:
  type: gp3
  iops: "1500"
---
...
kind: PersistentVolumeClaim
spec:
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 8Gi
---
...
kind: Pod
spec:
  containers:
    ...
  volumes:
  - name: persistent-storage
    persistentVolumeClaim:
      claimName: ebs-claim
```

If these K8s objects were created while v1.8.0 of the driver is deployed

* There would have been a GP3 EBS volume created (but clamped to 3000 IOPS by EC2 API) 
* The workload will successfully deploy and run


If these K8s objects were created while v1.25.0 of the driver is deployed

* The pod’s status will be stuck in Pending because of the error: 
    * `FailedScheduling... pod has unbound immediate PersistentVolumeClaims` 
* Describing the PVC will show: 
    * `Warning ProvisioningFailed... ebs.csi.aws.com_ebs-csi-controller... failed to provision volume with StorageClass "ebs-sc": rpc error: code = Internal desc =`
    *  `Could not create volume "pvc-5a995c47-4620-4615-b020-3d55cdbdedd0": invalid IOPS: 1500 is too low, it must be at least 3000`


That error, `Could not create volume... invalid IOPS: 1500 is too low, it must be at least 3000` comes from the driver [prematurely failing the CreateVolume rpc call](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/277d76fb5ca67a574a0e9ddfa4e44dfa0ea5be44/pkg/cloud/cloud.go#L1521), not from the EC2 API itself. 

V1.25.0 of the driver never tried calling EC2 CreateVolume (with `--volume-type gp3 --size 8 --iops 1500`)

Had the driver called EC2 CreateVolume, a GP3 volume with the minimum 3000 IOPS would have been created* (This is what happens with v1.8.0)

EC2 CLI example: An EC2 CreateVolume API Call with size=8Gi, iops=1500 succeeds. 
```
❯ aws ec2 create-volume --volume-type gp3 --size 8 --iops 1500 --availability-zone us-west-2a
{
    ...
    "Size": 8,
    "State": "creating",
    "VolumeId": "vol-0ad3ca34130ed06c8",
    "Iops": 3000,
    "VolumeType": "gp3",
}
```
**What testing is done?** 
`make test` & manual testing (will post logs Dec 22) 
