### PR TITLE
Remove premature CreateVolume error if requested IOPS is below minimum

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1517,8 +1517,6 @@ func capIOPS(volumeType string, requestedCapacityGiB int64, requestedIops int64,
 		if allowIncrease {
 			iops = minTotalIOPS
 			klog.V(5).InfoS("[Debug] Increased IOPS to the min supported limit", "volumeType", volumeType, "requestedCapacityGiB", requestedCapacityGiB, "limit", iops)
-		} else {
-			return 0, fmt.Errorf("invalid IOPS: %d is too low, it must be at least %d", iops, minTotalIOPS)
 		}
 	}
 	if iops > maxTotalIOPS {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix

**What is this PR about? / Why do we need it?**
TODO

**What testing is done?** 
`make test` + Manual testing trying to create volumes below limit. Will post results shortly 