### PR TITLE
Remember likely bad device names for an hour

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -951,14 +952,17 @@ func TestDeleteDisk(t *testing.T) {
 }
 
 func TestAttachDisk(t *testing.T) {
+	blockDeviceInUseErr := awserr.New("InvalidParameterValue", "Invalid value '"+defaultPath+"' for unixDevice. Attachment point "+defaultPath+" is already in use", nil)
+
 	testCases := []struct {
-		name     string
-		volumeID string
-		nodeID   string
-		nodeID2  string
-		path     string
-		expErr   error
-		mockFunc func(*MockEC2API, context.Context, string, string, string, string, dm.DeviceManager)
+		name         string
+		volumeID     string
+		nodeID       string
+		nodeID2      string
+		path         string
+		expErr       error
+		mockFunc     func(*MockEC2API, context.Context, string, string, string, string, dm.DeviceManager)
+		validateFunc func(t *testing.T)
 	}{
 		{
 			name:     "success: AttachVolume normal",
@@ -979,6 +983,33 @@ func TestAttachDisk(t *testing.T) {
 			},
 		},
 		{
+			name:     "success: AttachVolume skip likely bad name",
+			volumeID: defaultVolumeID,
+			nodeID:   defaultNodeID,
+			path:     "/dev/xvdab",
+			expErr:   nil,
+			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, nodeID2, path string, dm dm.DeviceManager) {
+				volumeRequest := createVolumeRequest(volumeID)
+				instanceRequest := createInstanceRequest(nodeID)
+				attachRequest := createAttachRequest(volumeID, nodeID, path)
+
+				gomock.InOrder(
+					mockEC2.EXPECT().DescribeInstancesWithContext(gomock.Any(), instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
+					mockEC2.EXPECT().AttachVolumeWithContext(gomock.Any(), attachRequest).Return(createAttachVolumeOutput(volumeID, nodeID, path), nil),
+					mockEC2.EXPECT().DescribeVolumesWithContext(gomock.Any(), volumeRequest).Return(createDescribeVolumesOutput([]*string{&volumeID}, nodeID, path, "attached"), nil),
+				)
+
+				nodeDeviceCache = map[string]cachedNode{
+					defaultNodeID: {
+						timer: time.NewTimer(1 * time.Hour),
+						likelyBadNames: map[string]struct{}{
+							defaultPath: {},
+						},
+					},
+				}
+			},
+		},
+		{
 			name:     "success: AttachVolume device already assigned",
 			volumeID: defaultVolumeID,
 			nodeID:   defaultNodeID,
@@ -989,7 +1020,7 @@ func TestAttachDisk(t *testing.T) {
 				instanceRequest := createInstanceRequest(nodeID)
 
 				fakeInstance := newFakeInstance(nodeID, volumeID, path)
-				_, err := dm.NewDevice(fakeInstance, volumeID)
+				_, err := dm.NewDevice(fakeInstance, volumeID, map[string]struct{}{})
 				assert.NoError(t, err)
 
 				gomock.InOrder(
@@ -1012,21 +1043,29 @@ func TestAttachDisk(t *testing.T) {
 					mockEC2.EXPECT().AttachVolumeWithContext(gomock.Any(), attachRequest).Return(nil, errors.New("AttachVolume error")),
 				)
 			},
+			validateFunc: func(t *testing.T) {
+				assert.NotContains(t, nodeDeviceCache, defaultNodeID)
+			},
 		},
 		{
-			name:     "fail: AttachVolume returned error volumeInUse",
+			name:     "fail: AttachVolume returned block device already in use error",
 			volumeID: defaultVolumeID,
 			nodeID:   defaultNodeID,
 			path:     defaultPath,
-			expErr:   fmt.Errorf("could not attach volume %q to node %q: %w", defaultVolumeID, defaultNodeID, ErrVolumeInUse),
+			expErr:   fmt.Errorf("could not attach volume %q to node %q: %w", defaultVolumeID, defaultNodeID, blockDeviceInUseErr),
 			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, nodeID2, path string, dm dm.DeviceManager) {
 				instanceRequest := createInstanceRequest(nodeID)
 				attachRequest := createAttachRequest(volumeID, nodeID, path)
 
 				gomock.InOrder(
 					mockEC2.EXPECT().DescribeInstancesWithContext(ctx, instanceRequest).Return(newDescribeInstancesOutput(nodeID), nil),
-					mockEC2.EXPECT().AttachVolumeWithContext(ctx, attachRequest).Return(nil, ErrVolumeInUse),
+					mockEC2.EXPECT().AttachVolumeWithContext(ctx, attachRequest).Return(nil, blockDeviceInUseErr),
 				)
+			},
+			validateFunc: func(t *testing.T) {
+				assert.Contains(t, nodeDeviceCache, defaultNodeID)
+				assert.NotNil(t, nodeDeviceCache[defaultNodeID].timer)
+				assert.Contains(t, nodeDeviceCache[defaultNodeID].likelyBadNames, defaultPath)
 			},
 		},
 		{
@@ -1079,6 +1118,9 @@ func TestAttachDisk(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Reset node likely bad names cache
+			nodeDeviceCache = map[string]cachedNode{}
+
 			mockCtrl := gomock.NewController(t)
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
@@ -1102,6 +1144,10 @@ func TestAttachDisk(t *testing.T) {
 				devicePath, err := c.AttachDisk(ctx, tc.volumeID, tc.nodeID2)
 				assert.NoError(t, err)
 				assert.Equal(t, tc.path, devicePath)
+			}
+
+			if tc.validateFunc != nil {
+				tc.validateFunc(t)
 			}
 
 			mockCtrl.Finish()

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -52,7 +52,7 @@ type DeviceManager interface {
 	// NewDevice retrieves the device if the device is already assigned.
 	// Otherwise it creates a new device with next available device name
 	// and mark it as unassigned device.
-	NewDevice(instance *ec2.Instance, volumeID string) (device *Device, err error)
+	NewDevice(instance *ec2.Instance, volumeID string, likelyBadNames map[string]struct{}) (device *Device, err error)
 
 	// GetDevice returns the device already assigned to the volume.
 	GetDevice(instance *ec2.Instance, volumeID string) (device *Device, err error)
@@ -103,7 +103,7 @@ func NewDeviceManager() DeviceManager {
 	}
 }
 
-func (d *deviceManager) NewDevice(instance *ec2.Instance, volumeID string) (*Device, error) {
+func (d *deviceManager) NewDevice(instance *ec2.Instance, volumeID string, likelyBadNames map[string]struct{}) (*Device, error) {
 	d.mux.Lock()
 	defer d.mux.Unlock()
 
@@ -124,7 +124,7 @@ func (d *deviceManager) NewDevice(instance *ec2.Instance, volumeID string) (*Dev
 		return nil, err
 	}
 
-	name, err := d.nameAllocator.GetNext(inUse)
+	name, err := d.nameAllocator.GetNext(inUse, likelyBadNames)
 	if err != nil {
 		return nil, fmt.Errorf("could not get a free device name to assign to node %s", nodeID)
 	}

--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -59,7 +59,7 @@ func TestNewDevice(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Should fail if instance is nil
-			dev1, err := dm.NewDevice(nil, tc.volumeID)
+			dev1, err := dm.NewDevice(nil, tc.volumeID, map[string]struct{}{})
 			if err == nil {
 				t.Fatalf("Expected error when nil instance is passed in, got nothing")
 			}
@@ -70,11 +70,11 @@ func TestNewDevice(t *testing.T) {
 			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
 
 			// Should create valid Device with valid path
-			dev1, err = dm.NewDevice(fakeInstance, tc.volumeID)
+			dev1, err = dm.NewDevice(fakeInstance, tc.volumeID, map[string]struct{}{})
 			assertDevice(t, dev1, false, err)
 
 			// Devices with same instance and volume should have same paths
-			dev2, err := dm.NewDevice(fakeInstance, tc.volumeID)
+			dev2, err := dm.NewDevice(fakeInstance, tc.volumeID, map[string]struct{}{})
 			assertDevice(t, dev2, true /*IsAlreadyAssigned*/, err)
 			if dev1.Path != dev2.Path {
 				t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev2.Path)
@@ -82,7 +82,7 @@ func TestNewDevice(t *testing.T) {
 
 			// Should create new Device with the same path after releasing
 			dev2.Release(false)
-			dev3, err := dm.NewDevice(fakeInstance, tc.volumeID)
+			dev3, err := dm.NewDevice(fakeInstance, tc.volumeID, map[string]struct{}{})
 			assertDevice(t, dev3, false, err)
 			if dev3.Path != dev1.Path {
 				t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev3.Path)
@@ -136,7 +136,7 @@ func TestNewDeviceWithExistingDevice(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeInstance := newFakeInstance("fake-instance", tc.existingID, tc.existingPath)
 
-			dev, err := dm.NewDevice(fakeInstance, tc.volumeID)
+			dev, err := dm.NewDevice(fakeInstance, tc.volumeID, map[string]struct{}{})
 			assertDevice(t, dev, tc.existingID == tc.volumeID, err)
 
 			if dev.Path != tc.expectedPath {
@@ -169,7 +169,7 @@ func TestGetDevice(t *testing.T) {
 			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
 
 			// Should create valid Device with valid path
-			dev1, err := dm.NewDevice(fakeInstance, tc.volumeID)
+			dev1, err := dm.NewDevice(fakeInstance, tc.volumeID, map[string]struct{}{})
 			assertDevice(t, dev1, false /*IsAlreadyAssigned*/, err)
 
 			// Devices with same instance and volume should have same paths
@@ -205,7 +205,7 @@ func TestReleaseDevice(t *testing.T) {
 			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
 
 			// Should get assigned Device after releasing tainted device
-			dev, err := dm.NewDevice(fakeInstance, tc.volumeID)
+			dev, err := dm.NewDevice(fakeInstance, tc.volumeID, map[string]struct{}{})
 			assertDevice(t, dev, false /*IsAlreadyAssigned*/, err)
 			dev.Taint()
 			dev.Release(false)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Despite our best efforts, it is difficult to conclusively determine a safe block device name to use, and sometimes we get it wrong.

After thorough testing with the AMI from #1674, it was discovered that AMIs can include block device mappings (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html#ami-block-device-mapping) that behave unintuitively: block device names used by AMIs do NOT appear in the block device mappings returned by `DescribeInstances`

This leaves us with two options:

1. *Call `DescribeImages` for every attachment operation to check for block device mappings on the AMI.*  
This was discarded because it requires spending a massive amount of additional API calls across all users for a relatively niche case. It also doesn't solve the next iteration of this problem if there's another block device name constraint we don't know about or is added.

2. *Remember block device names that are likely to be duds, and don't reuse them*  
This is the solution this PR implements. When an `AttachDisk` returns a 'block device name is in use' error, a map is updated that remembers the bad device name for that instance for a period of time (currently, an instance is remembered as long as it has had an attach in the last hour).

**What testing is done?** 

CI/Manual/Added new unit test cases