### PR TITLE
Add ext3 and xfs fsTypes to e2e format-option test coverage

### DIFF
--- a/tests/e2e/format_options.go
+++ b/tests/e2e/format_options.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	testedFsTypes = []string{ebscsidriver.FSTypeExt4}
+	testedFsTypes = []string{ebscsidriver.FSTypeExt4, ebscsidriver.FSTypeExt3, ebscsidriver.FSTypeXfs}
 )
 
 var _ = Describe("[ebs-csi-e2e] [single-az] [format-options] Formatting a volume", func() {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Test coverage

**What is this PR about? / Why do we need it?**
Adds `ebscsidriver.FSTypeExt3` and `ebscsidriver.FSTypeXfs` as tested filesystems for our e2e format option tests. 

This is separate from turning on the `ext3` feature flag for upstream k8s storage conformance tests. See #1891 for that.

This is separate from the discussion of whether we are deprecating support for `ext2`

This would add the following tests:
```
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom blocksize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom bytesperinode parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom inodesize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom numberofinodes parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an xfs filesystem with a custom blocksize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an xfs filesystem with a custom inodesize parameter successfully mounts and is resizable
```

(Note, not all formatting-option parameters that are supported for ext4 are supported for ext3 and xfs. See [pkg/driver/constants.go](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/fd7dbc289f5ccd85020b8cb97941129a8777deae/pkg/driver/constants.go#L197-L233))

**What testing is done?** 
Manually running the new ext3 and xfs format option tests. Here is a list of those tests. 
```
❯ ginkgo run --focus 'format-options' --dry-run -v | grep -i "az"
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom blocksize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom bytesperinode parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom inodesize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext3 filesystem with a custom numberofinodes parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext4 filesystem with a custom blocksize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext4 filesystem with a custom bytesperinode parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext4 filesystem with a custom ext4bigalloc parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext4 filesystem with a custom ext4clustersize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext4 filesystem with a custom inodesize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an ext4 filesystem with a custom numberofinodes parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an xfs filesystem with a custom blocksize parameter successfully mounts and is resizable
[ebs-csi-e2e] [single-az] [format-options] Formatting a volume using an xfs filesystem with a custom inodesize parameter successfully mounts and is resizable

```