### PR TITLE
Add ext3 test coverage to our e2e-kubernetes storage conformance tests

### DIFF
--- a/tests/e2e-kubernetes/manifests.yaml
+++ b/tests/e2e-kubernetes/manifests.yaml
@@ -14,6 +14,7 @@ DriverInfo:
   SupportedFsType:
     xfs: {}
     ext4: {}
+    ext3: {}
     ntfs: {}
   SupportedMountOption:
     dirsync: {}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
E2E Test coverage

**What is this PR about? / Why do we need it?**
Add ext3 FSType coverage to our runs of the [upstream k8s storage conformance suite](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external). 

This would add the following K8s storage conformance tests to our CI's Linux e2e-kubernetes jobs:

- [Dynamic PV (ext3)] volumes should allow exec of files on the volume
- [Dynamic PV (ext3)] volumes should store data
- [Inline-volume (ext3)] volumes should allow exec of files on the volume
- [Inline-volume (ext3)] volumes should store data
- [Pre-provisioned PV (ext3)] volumes should allow exec of files on the volume
- [Pre-provisioned PV (ext3)] volumes should store data


**What testing is done?** 
CI