### PR TITLE
Add a1compat image to publish-ecr github action

### DIFF
--- a/.github/workflows/publish-ecr.yaml
+++ b/.github/workflows/publish-ecr.yaml
@@ -70,7 +70,13 @@ jobs:
       with:
         registry-type: public
 
-    - name: Copy manifest to ECR Public
+    - name: Copy a1-compatible manifest to ECR Public
+      env:
+        ECR_PRIVATE_REPOSITORY: ${{ secrets.ECR_PRIVATE_REPOSITORY }}
+        ECR_PUBLIC_REPOSITORY: ${{ secrets.ECR_PUBLIC_REPOSITORY }}
+      run: crane copy ${ECR_PRIVATE_REPOSITORY}/aws-ebs-csi-driver:${GITHUB_REF_NAME}-linux-arm64-al2 ${ECR_PUBLIC_REPOSITORY}/aws-ebs-csi-driver:${GITHUB_REF_NAME}-a1compat
+
+    - name: Copy manifest list to ECR Public
       env:
         ECR_PRIVATE_REPOSITORY: ${{ secrets.ECR_PRIVATE_REPOSITORY }}
         ECR_PUBLIC_REPOSITORY: ${{ secrets.ECR_PUBLIC_REPOSITORY }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
CI

**What is this PR about? / Why do we need it?**
#1805 provided a workaround for the aws-ebs-csi-driver's minimal AL23 base image not working on `a1` instance family by building and maintaining `a1compat` images (that are based off of an AL2 minimal base image) for use on `a1` nodes. 

This PR automates the copying of this a1-compatible manifest to our [public ECR repository](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver).

Note: This step was placed before "Copy manifest list to ECR Public" so that the latest non-workaround manifest list shows up by default on our ECR repository. 