### PR TITLE
Bump volume-modifier-for-k8s to v0.2.1

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -144,7 +144,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
-      tag: "v0.2.0"
+      tag: "v0.2.1"
     leaderElection:
       enabled: true
       # Optional values to tune lease behavior.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Dependencies

**What is this PR about? / Why do we need it?**
Bump vol-modifier-for-k8s to fix its otel-grpc [CVE-2023-47108](https://avd.aquasec.com/nvd/cve-2023-47108)

**What testing is done?** 
CI
