### PR TITLE
Pin metrics server version; Fix minor `make cluster/create` bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ verify: verify/govet verify/golangci-lint verify/update
 all-push: all-image-registry push-manifest
 
 .PHONY: cluster/create
-cluster/create: bin/kops bin/eksctl
+cluster/create: bin/kops bin/eksctl bin/aws
 	./hack/e2e/create-cluster.sh
 
 .PHONY: cluster/delete

--- a/hack/e2e/metrics/metrics.sh
+++ b/hack/e2e/metrics/metrics.sh
@@ -13,7 +13,7 @@ metrics_collector() {
   readonly METRICS_BASE_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
   readonly METRICS_DIR_NAME="metrics-$(git rev-parse HEAD)1-${NODE_OS_DISTRO}-${DRIVER_VERSION}"
   readonly METRICS_DIR_PATH="${METRICS_BASE_DIR}/../csi-test-artifacts/${METRICS_DIR_NAME}"
-  readonly METRICS_SERVER_URL="https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml"
+  readonly METRICS_SERVER_URL="https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.4/components.yaml"
   readonly STORAGE_CLASS="${METRICS_BASE_DIR}/storageclass.yaml"
   readonly CLUSTER_LOADER_CONFIG="${METRICS_BASE_DIR}/cl2-config.yaml"
   readonly CLUSTER_LOADER_OVERRIDE="${METRICS_BASE_DIR}/override.yaml"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Pins metrics server version as the new version from 3 hours ago broke CI and is blocking our release
Also fixes a minor makefile bug I discovered along the way (`make cluster/create` didn't correctly depend on the AWS cli)

**What testing is done?** 

Manual/CI