### PR TITLE
Update release-script to use new makefile target

### DIFF
--- a/hack/release-scripts/generate-release-pr
+++ b/hack/release-scripts/generate-release-pr
@@ -115,7 +115,7 @@ update_chart_and_overlays() {
 
   (
     cd "$ROOT_DIRECTORY"
-    make generate-kustomize
+    make update/kustomize
   ) >"/dev/null"
 }
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug Fix

**What is this PR about? / Why do we need it?**
#1856 updated the makefile target for generating kustomize overlays based off of the helm charts. 

**What testing is done?** 
Local testing:
```
❯ ./hack/release-scripts/generate-release-pr v1.27.0 v1.27.1
2024-01-24 15:24:18 [INFO] - Confirming v1.27.0 < v1.27.1
...
2024-01-24 15:24:19 [INFO] - Updating helm chart and generates kustomize
...
SUCCESS!
...
```
