### PR TITLE
Fix Trivy image scanner

### DIFF
--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -30,8 +30,27 @@ jobs:
         image: ${{ fromJson(needs.build-matrix.outputs.images) }}
     
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GitHubCI
+          aws-region: us-east-1
+          role-duration-seconds: 1800
+          role-skip-session-tagging: true
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+          
+      - name: Pull container image
+        run: docker pull ${{ matrix.image }}
+
       - name: Scan container image
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.16.1
         with:
           image-ref: '${{ matrix.image }}'
           output: 'results.sarif'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.12.0
+        uses: aquasecurity/trivy-action@0.16.1
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

This PR addresses a recurring issue with the Trivy image scanner action:

```
2024-01-21T00:26:20.3634014Z 2024-01-21T00:26:20.362Z	[31mFATAL[0m	image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
2024-01-21T00:26:20.3637568Z 	* unable to inspect the image (public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.1.3): Error response from daemon: No such image: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.1.3
2024-01-21T00:26:20.3639509Z 	* containerd socket not found: /run/containerd/containerd.sock
2024-01-21T00:26:20.3640750Z 	* unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
2024-01-21T00:26:20.3643245Z 	* GET https://public.ecr.aws/v2/ebs-csi-driver/volume-modifier-for-k8s/manifests/sha256:8e7a38bbcd7799567dd53cd912ef81d31f06354aeef15c7b9dc6a624e88ce254: TOOMANYREQUESTS: Rate exceeded
2024-01-21T00:26:20.3645075Z 
2024-01-21T00:26:20.3645084Z 
2024-01-21T00:26:20.5549268Z ##[group]Run github/codeql-action/upload-sarif@v2
2024-01-21T00:26:20.5549656Z with:
2024-01-21T00:26:20.5549873Z   sarif_file: results.sarif
2024-01-21T00:26:20.5550298Z   checkout_path: /home/runner/work/aws-ebs-csi-driver/aws-ebs-csi-driver
2024-01-21T00:26:20.5550934Z   token: ***
2024-01-21T00:26:20.5551366Z   matrix: {
  "image": "public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.1.3"
}
2024-01-21T00:26:20.5551875Z   wait-for-processing: true
```

More specifically, this PR fixes errors during image pulls due to unauthenticated rate limits and adds an explicit step to pull the container images before initiating the Trivy scan.

See the [logs](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/actions/runs/7597753219/job/20692955471)

**What testing is done?** 

Manual
