### PR TITLE
Add option to disable discovery of attached volumes from instance metadata

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,6 +67,7 @@ func main() {
 		driver.WithExtraVolumeTags(options.ControllerOptions.ExtraVolumeTags),
 		driver.WithMode(options.DriverMode),
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),
+		driver.WithVolumeAttachLimitFromMetadata(options.NodeOptions.DisableVolumeAttachLimitFromMetadata),
 		driver.WithKubernetesClusterID(options.ControllerOptions.KubernetesClusterID),
 		driver.WithAwsSdkDebugLog(options.ControllerOptions.AwsSdkDebugLog),
 		driver.WithWarnOnInvalidTag(options.ControllerOptions.WarnOnInvalidTag),

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -51,6 +51,9 @@ func TestGetOptions(t *testing.T) {
 		awsSdkDebugFlagValue := true
 		VolumeAttachLimitFlagName := "volume-attach-limit"
 		var VolumeAttachLimit int64 = 42
+		disableVolumeAttachLimitFromMetadataFlagName := "disable-volume-attach-limit-from-metadata"
+		disableVolumeAttachLimitFromMetadata := false
+
 		userAgentExtraFlag := "user-agent-extra"
 		userAgentExtraFlagValue := "test"
 		otelTracingFlagName := "enable-otel-tracing"
@@ -129,6 +132,13 @@ func TestGetOptions(t *testing.T) {
 			}
 			if options.NodeOptions.VolumeAttachLimit != VolumeAttachLimit {
 				t.Fatalf("expected VolumeAttachLimit to be %d but it is %d", VolumeAttachLimit, options.NodeOptions.VolumeAttachLimit)
+			}
+			disableVolumeAttachLimitFromMetadataFlag := flagSet.Lookup(disableVolumeAttachLimitFromMetadataFlagName)
+			if disableVolumeAttachLimitFromMetadataFlag == nil {
+				t.Fatalf("expected %q flag to be added but it is not", disableVolumeAttachLimitFromMetadataFlagName)
+			}
+			if options.NodeOptions.DisableVolumeAttachLimitFromMetadata != disableVolumeAttachLimitFromMetadata {
+				t.Fatalf("expected disableVolumeAttachLimitFromMetadata to be %t but it is %t", disableVolumeAttachLimitFromMetadata, options.NodeOptions.DisableVolumeAttachLimitFromMetadata)
 			}
 		}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -69,6 +69,7 @@ type DriverOptions struct {
 	extraTags                         map[string]string
 	mode                              Mode
 	volumeAttachLimit                 int64
+	disableVolumeAttachFromMetadata   bool
 	kubernetesClusterID               string
 	awsSdkDebugLog                    bool
 	batching                          bool
@@ -218,6 +219,14 @@ func WithMode(mode Mode) func(*DriverOptions) {
 func WithVolumeAttachLimit(volumeAttachLimit int64) func(*DriverOptions) {
 	return func(o *DriverOptions) {
 		o.volumeAttachLimit = volumeAttachLimit
+	}
+}
+
+func WithVolumeAttachLimitFromMetadata(disabled bool) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		if disabled {
+			o.disableVolumeAttachFromMetadata = disabled
+		}
 	}
 }
 

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -78,6 +78,15 @@ func TestWithVolumeAttachLimit(t *testing.T) {
 	}
 }
 
+func TestWithVolumeAttachLimitFromMetadata(t *testing.T) {
+	var value bool = true
+	options := &DriverOptions{}
+	WithVolumeAttachLimitFromMetadata(value)(options)
+	if options.disableVolumeAttachFromMetadata != value {
+		t.Fatalf("expected disableVolumeAttachFromMetadata option got set to %t but is set to %t", value, options.disableVolumeAttachFromMetadata)
+	}
+}
+
 func TestWithClusterID(t *testing.T) {
 	var id string = "test-cluster-id"
 	options := &DriverOptions{}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -783,7 +783,12 @@ func (d *nodeService) getVolumesLimit() int64 {
 
 	isNitro := cloud.IsNitroInstanceType(instanceType)
 	availableAttachments := cloud.GetMaxAttachments(isNitro)
-	blockVolumes := d.metadata.GetNumBlockDeviceMappings()
+
+	var blockVolumesFromMetadata int
+	if !d.driverOptions.disableVolumeAttachFromMetadata {
+		blockVolumesFromMetadata = d.metadata.GetNumBlockDeviceMappings()
+	}
+
 	dedicatedLimit := cloud.GetDedicatedLimitForInstanceType(instanceType)
 	maxEBSAttachments, ok := cloud.GetEBSLimitForInstanceType(instanceType)
 	if ok {
@@ -798,7 +803,7 @@ func (d *nodeService) getVolumesLimit() int64 {
 		nvmeInstanceStoreVolumes := cloud.GetNVMeInstanceStoreVolumesForInstanceType(instanceType)
 		availableAttachments = availableAttachments - enis - nvmeInstanceStoreVolumes
 	}
-	availableAttachments = availableAttachments - blockVolumes - 1 // -1 for root device
+	availableAttachments = availableAttachments - blockVolumesFromMetadata - 1 // -1 for root device
 	if availableAttachments <= 0 {
 		availableAttachments = 1
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/kind bug

**What is this PR about? / Why do we need it?**
Add `--disable-volume-attach-limit-from-metadata` to disable counting of attached volumes from instance metadata.

The option name and its description is not great, I know. Feel free to suggest a better one.

Instance metadata contains block volumes that were attached at the time the instance was started and then it's never updated. In case a node was rebooted with CSI volumes attached, the metadata includes these CSI volumes and the CSI driver "reserves" an attachment slot for them forever, even when they are detached later.

The option disables counting of attached volumes when computing the attach limit, because it's not able to distinguish a CSI volume (should not have a reserved attachment, because scheduler will count it on its own) and a root disk / volume attached by the system admin (should have a reserved attachment).

**What testing is done?** 
Manually I tested that `--disable-volume-attach-limit-from-metadata` ignored a second volume attached to a node.

Fixes: #1808