### PR TITLE
Enforce linux amd64 nodeAffinity for helm tester pod

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -214,6 +214,10 @@ spec:
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config
+  # kubekins-e2e v1 image is linux amd64 only.
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
   serviceAccountName: ebs-csi-driver-test
   volumes:
     - name: config-vol


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Bug fix

**What is this PR about? / Why do we need it?**

The [kubekins-e2e v1 image](https://github.com/kubernetes/test-infra/tree/master/images/kubekins-e2e) used in our [helm tester pod](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/33fffa3d094f4451cfd94226377b8b94706315a1/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml#L188-L222) is not multi-arch. Therefore we should assure we schedule it only on Linux `amd64` nodes. 

Closes #1921 

**What testing is done?** 
CI

TODO Attempt to run test on `arm64` only cluster. 
