### PR TITLE
Allow driver node daemonSet annotations to be configurable

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -8,6 +8,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+  {{- with .Values.node.daemonSetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if or (kindIs "float64" .Values.node.revisionHistoryLimit) (kindIs "int64" .Values.node.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.node.revisionHistoryLimit }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+  {{- with .Values.controller.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
   {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -237,6 +237,7 @@ controller:
   logLevel: 2
   userAgentExtra: "helm"
   nodeSelector: {}
+  deploymentAnnotations: {}
   podAnnotations: {}
   podLabels: {}
   priorityClassName: system-cluster-critical

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -349,6 +349,7 @@ node:
             - a1.2xlarge
             - a1.4xlarge
   nodeSelector: {}
+  daemonSetAnnotations: {}
   podAnnotations: {}
   podLabels: {}
   tolerateAllTaints: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
helm feature

**What is this PR about? / Why do we need it?**
Closes #1918

"Running static analysis tools like KubeLinter against the chart fails due to pods (specifically ebs-plugin node.containerSecurityContext) allowing a container to run in privilege mode.

These can be ignored via annotations to the resource (not the pod but the daemonset) but currently there are no means to provide them."

**What testing is done?** 
CI

Manually testing the following values file:

```
controller:
  deploymentAnnotations:
    test.deployment.annotation/foo: bar
    some.deployment.annotation/foo2: bar2
node:
  daemonSetAnnotations:
    test.annotation/foo: bar
    test.annotation.2/foo2: bar2
  enableWindows: true
```

Result: 

```
❯ helm upgrade \
  --install aws-ebs-csi-driver \
  --namespace kube-system \
  ./charts/aws-ebs-csi-driver \
  --values test-ebs-config-values.yaml  --debug

history.go:56: [debug] getting history for release aws-ebs-csi-driver
upgrade.go:150: [debug] preparing upgrade for aws-ebs-csi-driver
upgrade.go:158: [debug] performing update for aws-ebs-csi-driver
upgrade.go:321: [debug] dry run for aws-ebs-csi-driver
Release "aws-ebs-csi-driver" has been upgraded. Happy Helming!
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Tue Feb  6 18:06:10 2024
NAMESPACE: kube-system
STATUS: pending-upgrade
REVISION: 2
USER-SUPPLIED VALUES:
node:
  daemonSetAnnotations:
    test.annotation.2/foo2: bar2
    test.annotation/foo: bar

COMPUTED VALUES:
...
# Source: aws-ebs-csi-driver/templates/node.yaml
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: ebs-csi-node
  namespace: kube-system
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: aws-ebs-csi-driver
    helm.sh/chart: aws-ebs-csi-driver-2.27.0
    app.kubernetes.io/version: "1.27.0"
    app.kubernetes.io/component: csi-driver
    app.kubernetes.io/managed-by: Helm
  annotations:
    test.annotation.2/foo2: bar2
    test.annotation/foo: bar
...
```

Proof in live cluster:

```
❯ kubectl describe daemonset ebs-csi-node -n kube-system
Name:           ebs-csi-node
Selector:       app=ebs-csi-node,app.kubernetes.io/instance=aws-ebs-csi-driver,app.kubernetes.io/name=aws-ebs-csi-driver
Node-Selector:  kubernetes.io/os=linux
Labels:         app.kubernetes.io/component=csi-driver
                app.kubernetes.io/instance=aws-ebs-csi-driver
                app.kubernetes.io/managed-by=Helm
                app.kubernetes.io/name=aws-ebs-csi-driver
                app.kubernetes.io/version=1.27.0
                helm.sh/chart=aws-ebs-csi-driver-2.27.0
Annotations:    deprecated.daemonset.template.generation: 1
                meta.helm.sh/release-name: aws-ebs-csi-driver
                meta.helm.sh/release-namespace: kube-system
                test.annotation.2/foo2: bar2
                test.annotation/foo: bar

❯ kubectl describe daemonset ebs-csi-node-windows -n kube-system
Name:           ebs-csi-node-windows
Selector:       app=ebs-csi-node,app.kubernetes.io/instance=aws-ebs-csi-driver,app.kubernetes.io/name=aws-ebs-csi-driver
Node-Selector:  kubernetes.io/os=windows
Labels:         app.kubernetes.io/component=csi-driver
                app.kubernetes.io/instance=aws-ebs-csi-driver
                app.kubernetes.io/managed-by=Helm
                app.kubernetes.io/name=aws-ebs-csi-driver
                app.kubernetes.io/version=1.27.0
                helm.sh/chart=aws-ebs-csi-driver-2.27.0
Annotations:    deprecated.daemonset.template.generation: 1
                meta.helm.sh/release-name: aws-ebs-csi-driver
                meta.helm.sh/release-namespace: kube-system

❯ kubectl describe deployment ebs-csi-controller -n kube-system
...
Annotations:            deployment.kubernetes.io/revision: 2
                        meta.helm.sh/release-name: aws-ebs-csi-driver
                        meta.helm.sh/release-namespace: kube-system
                        some.deployment.annotation/foo2: bar2
                        test.deployment.annotation/foo: bar
```