### PR TITLE
Supply custom image to ebs-csi-driver-test pod via Helm

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -196,7 +196,7 @@ metadata:
 spec:
   containers:
     - name: kubetest2
-      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
+      image: {{ default "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master" (.Values.helmTester).image }}
       command: [ "/bin/sh", "-c" ]
       args:
         - |

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -457,3 +457,7 @@ volumeSnapshotClasses: []
 # Intended for use with older clusters that cannot easily replace the CSIDriver object
 # This parameter should always be false for new installations
 useOldCSIDriver: false
+
+# Supply a custom image to the ebs-csi-driver-test pod in helm-tester.yaml
+helmTester:
+  image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Helm

**What is this PR about? / Why do we need it?**
Closes #1920 

Today, [helm-tester.yaml](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml) has an hardcoded image which is not modifiable by helm chart.

This PR exposes a value in our helm chart to change the registry or customize the image name/tag.

Note, the repetition of the current kubekins image across helm-tester.yaml and values.yaml will be corrected once we deprecate the use of `--reuse-values` when upgrading our helm chart. See #1864 

**What testing is done?** 

CI and manual:

```
❯ helm upgrade \
  --install aws-ebs-csi-driver \
  --namespace kube-system \
  ./charts/aws-ebs-csi-driver --dry-run --debug --set helmTester.image="test-image" | grep -i "test-image" -C 5

history.go:56: [debug] getting history for release aws-ebs-csi-driver
....
USER-SUPPLIED VALUES:
helmTester:
  image: test-image
--
...
helmTester:
  image: test-image
...
--
...
spec:
  containers:
    - name: kubetest2
      image: test-image
...


❯ helm upgrade \
  --install aws-ebs-csi-driver \
  --namespace kube-system \
  ./charts/aws-ebs-csi-driver --dry-run --debug  | grep -i "gcr" -C 5

history.go:56: [debug] getting history for release aws-ebs-csi-driver
...
helmTester:
  image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
...
--
...
spec:
  containers:
    - name: kubetest2
      image: gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master
```
