### PR TITLE
Report zone via well-known topology key in NodeGetInfo

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -589,7 +589,8 @@ func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	zone := d.metadata.GetAvailabilityZone()
 
 	segments := map[string]string{
-		TopologyKey: zone,
+		TopologyKey:          zone,
+		WellKnownTopologyKey: zone,
 	}
 
 	outpostArn := d.metadata.GetOutpostArn()

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -2331,6 +2331,9 @@ func TestNodeGetInfo(t *testing.T) {
 			if at.Segments[TopologyKey] != tc.availabilityZone {
 				t.Fatalf("Expected topology %q, got %q", tc.availabilityZone, at.Segments[TopologyKey])
 			}
+			if at.Segments[WellKnownTopologyKey] != tc.availabilityZone {
+				t.Fatalf("Expected (well-known) topology %q, got %q", tc.availabilityZone, at.Segments[WellKnownTopologyKey])
+			}
 
 			if at.Segments[AwsAccountIDKey] != tc.outpostArn.AccountID {
 				t.Fatalf("Expected AwsAccountId %q, got %q", tc.outpostArn.AccountID, at.Segments[AwsAccountIDKey])


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Both?

**What is this PR about? / Why do we need it?**

See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/729#issuecomment-1942026577

**What testing is done?** 

- Manually tested locally by attaching volumes created by both this and a previous version of the driver, and ensuring they both attached
- e2e (see CI)