### PR TITLE
Add code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ bin
 # Test binary, build with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Output of the go coverage tool
 *.out
+coverage.html
 
 # Vagrant
 .vagrant

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,13 @@ clean:
 test:
 	go test -v -race ./cmd/... ./pkg/...
 
+.PHONY: test/coverage
+test/coverage:
+	go test -coverprofile=cover.out ./cmd/... ./pkg/...
+	grep -v "mock" cover.out > filtered_cover.out
+	go tool cover -html=filtered_cover.out -o coverage.html
+	rm cover.out filtered_cover.out
+
 .PHONY: test-sanity
 test-sanity:
 	go test -v -race ./tests/sanity/...

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -88,6 +88,10 @@ Build and push a multi-arch image of the driver based on the OSes in `ALL_OS`, a
 
 Run all unit tests with race condition checking enabled.
 
+### `make test/coverage`
+
+Outputs a filtered version of the each package's unit test coverage profiling via go's coverage tool to a local `coverage.html` file.
+
 ### `make test-sanity`
 
 Run the official [CSI sanity tests](https://github.com/kubernetes-csi/csi-test). _Warning: Currently, 3 of the tests are known to fail incorrectly._


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

This PR makes modifications to `make test` to generate a test coverage report that explicitly excludes all generated mock files, giving contributors and maintainers more insight into code coverage.

In place of using the `grep` tech to filter out mock files, I initially attempted to split out mocked code into its own separate package. However, I quickly discovered that this is not possible due to a circular dependencies issue. To prevent the import cycle we'd have to bring in the tests over to the mock package as well - this is undesirable as a) it would effectively break the code coverage measurement altogether and b) not a standard Go practice.

**What testing is done?** 

```
make test
```
<img width="1416" alt="Screenshot 2024-02-13 at 6 24 20 PM" src="https://github.com/kubernetes-sigs/aws-ebs-csi-driver/assets/99845161/c52a2f1a-5b7f-44ba-a501-9b2825cc1b08">
