### PR TITLE
Fix Three Papercuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ update/gomod:
 
 .PHONY: update/shfmt
 update/shfmt: bin/shfmt
-	./bin/shfmt -w -i 2 -d .
+	./bin/shfmt -w -i 2 -d ./hack/
 
 ## Verifiers
 # Linters and similar

--- a/hack/e2e/kops/kops.sh
+++ b/hack/e2e/kops/kops.sh
@@ -119,7 +119,7 @@ function kops_patch_cluster_file() {
   jq "$FILTER" "$CLUSTER_FILE_JSON" >"$CLUSTER_FILE_0"
 
   # Patch only the json objects
-  kubectl patch -f "$CLUSTER_FILE_0" --local --type merge --patch "$(cat "$KOPS_PATCH_FILE")" -o json >"$CLUSTER_FILE_1"
+  kubectl patch --kubeconfig /dev/null -f "$CLUSTER_FILE_0" --local --type merge --patch "$(cat "$KOPS_PATCH_FILE")" -o json >"$CLUSTER_FILE_1"
   mv "$CLUSTER_FILE_1" "$CLUSTER_FILE_0"
 
   # Delete the original json objects, add the patched
@@ -141,7 +141,7 @@ function kops_patch_cluster_file() {
 function yaml_to_json() {
   IN=${1}
   OUT=${2}
-  kubectl patch -f "$IN" --local -p "{}" --type merge -o json | jq '.' -s >"$OUT"
+  kubectl patch --kubeconfig /dev/null -f "$IN" --local -p "{}" --type merge -o json | jq '.' -s >"$OUT"
 }
 
 function json_to_yaml() {

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -60,9 +60,12 @@ export KOPS_BUCKET=${KOPS_BUCKET:-"k8s-kops-csi-shared-e2e"}
 # Always use us-west-2 in CI, no matter where the local client is
 export AWS_REGION=us-west-2
 
-make cluster/create || exit 1
-make e2e/${TEST}
-E2E_PASSED=$?
+if make cluster/create; then
+  make e2e/${TEST}
+  E2E_PASSED=$?
+else
+  E2E_PASSED=1
+fi
 make cluster/delete
 
 echo "E2E_PASSED: ${E2E_PASSED}"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

---

**What is this PR about? / Why do we need it?**

Fixes three small papercuts (each in their own commit):

#### Fix kops clusters becoming stuck when local KUBECONFIG is invalid

When the local kubeconfig represents a cluster that no longer exists, patching (and thus creating) a kops-based cluster will get stuck. This fixes that by explcitly setting the config for patch operations to `/dev/null`

#### Restrain `shfmt` to `hack/` directory

`shfmt` was trying to modify scripts in the `venv` in `bin/`, sometimes causing `make verify/update` to fail locally.

#### Attempt to delete Prow clusters that fail to create

We already delete clusters where the e2e tests fail (as of #1856), but leave behind clusters where creation failed.

---

**What testing is done?** 

Manual/CI
