### PR TITLE
Implement KEP3751 ("ControllerModifyVolume")

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ e2e/single-az: bin/helm bin/ginkgo
 	TEST_PATH=./tests/e2e/... \
 	GINKGO_FOCUS="\[ebs-csi-e2e\] \[single-az\]" \
 	GINKGO_PARALLEL=5 \
-	HELM_EXTRA_FLAGS="--set=controller.volumeModificationFeature.enabled=true" \
+	HELM_EXTRA_FLAGS="--set=controller.volumeModificationFeature.enabled=true,sidecars.provisioner.additionalArgs[0]='--feature-gates=VolumeAttributesClass=true',sidecars.resizer.additionalArgs[0]='--feature-gates=VolumeAttributesClass=true'" \
 	./hack/e2e/run.sh
 
 .PHONY: e2e/multi-az

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
@@ -33,6 +33,9 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get" ]
   {{- with .Values.sidecars.provisioner.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
@@ -29,6 +29,9 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get", "list", "watch" ]
   {{- with .Values.sidecars.resizer.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/deploy/kubernetes/base/clusterrole-provisioner.yaml
+++ b/deploy/kubernetes/base/clusterrole-provisioner.yaml
@@ -34,3 +34,6 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "volumeattachments" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get" ]

--- a/deploy/kubernetes/base/clusterrole-resizer.yaml
+++ b/deploy/kubernetes/base/clusterrole-resizer.yaml
@@ -30,3 +30,6 @@ rules:
   - apiGroups: [ "" ]
     resources: [ "pods" ]
     verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "volumeattributesclasses" ]
+    verbs: [ "get", "list", "watch" ]

--- a/docs/modify-volume.md
+++ b/docs/modify-volume.md
@@ -1,21 +1,37 @@
 # Volume Modification
 
-The EBS CSI Driver (starting from v1.19.0) supports volume modification through PVC annotations. This allows users to modify volume properties (e.g., volume type, IOPS, and throughput). 
+The EBS CSI Driver (starting from v1.19.0) supports volume modification through two methods:
+- Via the standardized CSI RPC `ControllerModifyVolume` (on Kubernetes, this is done via [`VolumeAttributesClass`](https://github.com/awslabs/volume-modifier-for-k8s))
+- Volume annotations via [`volume-modifier-for-k8s`](https://github.com/awslabs/volume-modifier-for-k8s)
 
 ## Installation
-This feature is opt-in. 
 
-To install this feature through the Helm chart, users must set `controller.volumeModificationFeature.enabled` in `values.yaml` to `true`.
+### `ControllerModifyVolume` via `VolumeAttributesClass` (Recommended)
+
+`VolumeAttributesClass` support is controlled by the Kubernetes `VolumeAttributesClass` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
+
+To use this feature, it must be enabled in the following places:
+- `VolumeAttributesClass` feature gate on `kube-apiserver` (consult your Kubernetes distro's documentation)
+- `storage.k8s.io/v1alpha1` enabled in `kube-apiserver` via [`runtime-config`](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/) (consult your Kubernetes distro's documentation)
+- `VolumeAttributesClass` feature gate on `kube-controller-manager` (consult your Kubernetes distro's documentation)
+- `VolumeAttributesClass` feature gate on `external-provisioner` (add `--feature-gates=VolumeAttributesClass=true` to `sidecars.provisioner.additionalArgs` when using the EBS CSI Helm chart)
+- `VolumeAttributesClass` feature gate on `kube-controller-manager` (add `--feature-gates=VolumeAttributesClass=true` to `sidecars.resizer.additionalArgs` when using the EBS CSI Helm chart)
+
+For more information, see the [Kubernetes documentation for the feature](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/).
+
+### `volume-modifier-for-k8s`
+
+To enable this feature through the Helm chart, users must set `controller.volumeModificationFeature.enabled` in `values.yaml` to `true`.
 
 This will install an additional sidecar (`volumemodifier`) that watches the Kubernetes API server for changes to PVC annotations and triggers an RPC call against the CSI driver.
 
-## Usage
+## Parameters
 
-Users can specify the following PVC annotations:
+Users can specify the following modification parameters:
 
-- `ebs.csi.aws.com/volumeType`: to update the volume type
-- `ebs.csi.aws.com/iops`: to update the IOPS
-- `ebs.csi.aws.com/throughput`: to update the throughput
+- `type`: to update the volume type
+- `iops`: to update the IOPS
+- `throughput`: to update the throughput
 
 ## Considerations
 
@@ -23,6 +39,12 @@ Users can specify the following PVC annotations:
 - Ensure that the desired volume properties are permissible. The driver does minimum client side validation. 
 
 ## Example
+
+### `ControllerModifyVolume` via `VolumeAttributesClass`
+
+See the [EBS CSI example with manifests](../examples/kubernetes/modify-volume).
+
+### `volume-modifier-for-k8s`
 
 #### 1) Create a PVC.
 

--- a/examples/kubernetes/modify-volume/README.md
+++ b/examples/kubernetes/modify-volume/README.md
@@ -1,0 +1,59 @@
+# Volume Modification via `VolumeAttributesClass`
+
+## Prerequisites
+
+This example will only work on a cluster with the `VolumeAttributesClass` feature enabled. For more information see the [installation instructions in the EBS CSI `ModifyVolume` documentation](../docs/modify-volume.md).
+
+## Usage
+
+1. Deploy the example `Pod`, `PersistentVolumeClaim`, and `StorageClass` to your cluster
+    ```sh
+    $ kubectl apply -f manifests/pod-with-volume.yaml
+
+    storageclass.storage.k8s.io/ebs-sc created
+    persistentvolumeclaim/ebs-claim created
+    pod/app created
+    ```
+
+2. Wait for the `PersistentVolumeClaim` to bind and the pod to reach the `Running` state
+    ```sh
+    $ kubectl get pvc ebs-claim
+    NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGEebs-claim   Bound    pvc-076b2d14-b643-47d4-a2ce-fbf9cd36572b   100Gi      RWO            ebs-sc         <unset>                 2m51s
+    
+    $ kubectl get pod app
+    NAME   READY   STATUS    RESTARTS   AGE
+    app    1/1     Running   0          3m24
+    ```
+
+3. Watch the logs of the pod
+    ```sh
+    $ kubectl logs -f app
+    Mon Feb 26 22:28:19 UTC 2024
+    Mon Feb 26 22:28:24 UTC 2024
+    Mon Feb 26 22:28:29 UTC 2024
+    Mon Feb 26 22:28:34 UTC 2024
+    Mon Feb 26 22:28:39 UTC 2024
+    ...
+    ```
+
+4. Simultaneously, deploy the `VolumeAttributesClass` and edit the `PersistentVolumeClaim` to point to this class
+    ```sh
+    $ kubectl patch pvc ebs-claim --patch '{"spec": {"volumeAttributesClassName": "io2-class"}}'
+    persistentvolumeclaim/ebs-claim patched
+    ```
+
+5. Wait for the `VolumeAttributesClass` to apply to the volume
+    ```sh
+    $ kubectl get pvc ebs-claim
+    NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+    ebs-claim   Bound    pvc-076b2d14-b643-47d4-a2ce-fbf9cd36572b   100Gi      RWO            ebs-sc         io2-class               5m54s
+    ```
+
+6. (Optional) Delete example resources
+    ```sh
+    $ kubectl delete -f manifests 
+    storageclass.storage.k8s.io "ebs-sc" deleted
+    persistentvolumeclaim "ebs-claim" deleted
+    pod "app" deleted
+    volumeattributesclass.storage.k8s.io "io2-class" deleted
+    ```

--- a/examples/kubernetes/modify-volume/manifests/pod-with-volume.yaml
+++ b/examples/kubernetes/modify-volume/manifests/pod-with-volume.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+  - name: app
+    image: centos
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) | tee /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: ebs-claim

--- a/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
+++ b/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: storage.k8s.io/v1alpha1
+kind: VolumeAttributesClass
+metadata:
+  name: io2-class
+driverName: ebs.csi.aws.com
+parameters:
+  type: io2
+  iops: "10000"

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -1,4 +1,12 @@
 spec:
+  kubeAPIServer:
+    featureGates:
+      VolumeAttributesClass: "true"
+    runtimeConfig:
+      storage.k8s.io/v1alpha1: "true"
+  kubeControllerManager:
+    featureGates:
+      VolumeAttributesClass: "true"
   additionalPolicies:
     node: |
       [

--- a/pkg/driver/controller_modify_volume_test.go
+++ b/pkg/driver/controller_modify_volume_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	validType          = "gp3"
+	validIops          = "2000"
+	validIopsInt       = 2000
+	validThroughput    = "500"
+	validThroughputInt = 500
+	invalidIops        = "123.546"
+	invalidThroughput  = "one hundred"
+)
+
+func TestParseModifyVolumeParameters(t *testing.T) {
+	testCases := []struct {
+		name            string
+		params          map[string]string
+		expectedOptions *cloud.ModifyDiskOptions
+		expectError     bool
+	}{
+		{
+			name:            "blank params",
+			params:          map[string]string{},
+			expectedOptions: &cloud.ModifyDiskOptions{},
+		},
+		{
+			name: "basic params",
+			params: map[string]string{
+				ModificationKeyVolumeType: validType,
+				ModificationKeyIOPS:       validIops,
+				ModificationKeyThroughput: validThroughput,
+			},
+			expectedOptions: &cloud.ModifyDiskOptions{
+				VolumeType: validType,
+				IOPS:       validIopsInt,
+				Throughput: validThroughputInt,
+			},
+		},
+		{
+			name: "deprecated type",
+			params: map[string]string{
+				ModificationKeyVolumeType:           validType,
+				DeprecatedModificationKeyVolumeType: "deprecated" + validType,
+			},
+			expectedOptions: &cloud.ModifyDiskOptions{
+				VolumeType: validType,
+			},
+		},
+		{
+			name: "invalid iops",
+			params: map[string]string{
+				ModificationKeyIOPS: invalidIops,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid throughput",
+			params: map[string]string{
+				ModificationKeyThroughput: invalidThroughput,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseModifyVolumeParameters(tc.params)
+			assert.Equal(t, tc.expectedOptions, result)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/driver/request_coalescing_test.go
+++ b/pkg/driver/request_coalescing_test.go
@@ -88,13 +88,12 @@ func TestVolumeModificationWithCoalescing(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// Not strictly necessary but required by `go vet`
-		tc := tc
-		t.Run(tc.name+" - volume-modifier-for-k8s", func(t *testing.T) {
+		tc := tc // Not strictly necessary but required by `go vet`
+		t.Run(tc.name+": volume-modifier-for-k8s", func(t *testing.T) {
 			t.Parallel()
 			tc.testFunction(t, modifierForK8sModifyVolume)
 		})
-		t.Run(tc.name+": external-resizier", func(t *testing.T) {
+		t.Run(tc.name+": external-resizer", func(t *testing.T) {
 			t.Parallel()
 			tc.testFunction(t, externalResizerModifyVolume)
 		})

--- a/tests/e2e/modify_volume.go
+++ b/tests/e2e/modify_volume.go
@@ -123,8 +123,11 @@ var _ = Describe("[ebs-csi-e2e] [single-az] [modify-volume] Modifying a PVC", fu
 	for testName, modifyVolumeTest := range modifyVolumeTests {
 		modifyVolumeTest := modifyVolumeTest
 		Context(testName, func() {
-			It("will modify associated PV and EBS Volume", func() {
-				modifyVolumeTest.Run(cs, ns, ebsDriver)
+			It("will modify associated PV and EBS Volume via volume-modifier-for-k8s", func() {
+				modifyVolumeTest.Run(cs, ns, ebsDriver, testsuites.VolumeModifierForK8s)
+			})
+			It("will modify associated PV and EBS Volume via external-resizer", func() {
+				modifyVolumeTest.Run(cs, ns, ebsDriver, testsuites.ExternalResizer)
 			})
 		})
 	}

--- a/tests/e2e/testsuites/e2e_utils.go
+++ b/tests/e2e/testsuites/e2e_utils.go
@@ -17,13 +17,14 @@ package testsuites
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"time"
 )
 
 const (
@@ -137,6 +138,21 @@ func WaitForPvToModify(c clientset.Interface, ns *v1.Namespace, pvName string, e
 		}
 	}
 	return fmt.Errorf("gave up after waiting %v for pv %q to complete modifying", timeout, pvName)
+}
+
+// WaitForVacToApplyToPv waits for a PV's VAC to match the PVC's VAC
+func WaitForVacToApplyToPv(c clientset.Interface, ns *v1.Namespace, pvName string, expectedVac string, timeout time.Duration, interval time.Duration) error {
+	framework.Logf("waiting up to %v for pv in namespace %q to be modified via VAC", timeout, ns.Name)
+
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(interval) {
+		modifyingPv, _ := c.CoreV1().PersistentVolumes().Get(context.TODO(), pvName, metav1.GetOptions{})
+
+		if modifyingPv.Spec.VolumeAttributesClassName != nil && *modifyingPv.Spec.VolumeAttributesClassName == expectedVac {
+			framework.Logf("vac updated to %v", *modifyingPv.Spec.VolumeAttributesClassName)
+			return nil
+		}
+	}
+	return fmt.Errorf("gave up after waiting %v for pv %q to complete modifying via VAC", timeout, pvName)
 }
 
 func CreateVolumeDetails(createVolumeParameters map[string]string, volumeSize string) *VolumeDetails {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

/kind feature

**What is this PR about? / Why do we need it?**

Implements support for modifying volumes via KEP3751 (https://kep.k8s.io/3751) using the EBS CSI Driver.
Change is split into multiple small commits:
- Refactor modification primitives out of ModifyVolumeProperties to separate functions
- Implement ControllerModifyVolume and MutableParameters in CreateVolume
- Update unit tests for ControllerModifyVolume/MutableParameters
- Add VolumeAttributesClass RBAC permissions to external-resizier and external-provisioner
- Add ControllerModifyVolume e2e tests

**What testing is done?** 

Manually tested, unit tests and e2e tests added