### PR TITLE
Fix slow createDisk and batcher unit tests

### DIFF
--- a/pkg/batcher/batcher_test.go
+++ b/pkg/batcher/batcher_test.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+const (
+	defaultMaxDelay = 50 * time.Millisecond
+	slowMaxDelay    = 5 * defaultMaxDelay
+)
+
 func mockExecution(inputs []string) (map[string]string, error) {
 	results := make(map[string]string)
 	for _, input := range inputs {
@@ -39,7 +44,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: single task",
 			mockFunc:     mockExecution,
 			maxEntries:   10,
-			maxDelay:     1 * time.Second,
+			maxDelay:     defaultMaxDelay,
 			tasks:        []string{"task1"},
 			expectResult: true,
 			expectErrors: false,
@@ -48,7 +53,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: multiple tasks",
 			mockFunc:     mockExecution,
 			maxEntries:   10,
-			maxDelay:     1 * time.Second,
+			maxDelay:     defaultMaxDelay,
 			tasks:        []string{"task1", "task2", "task3"},
 			expectResult: true,
 			expectErrors: false,
@@ -57,7 +62,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: same task",
 			mockFunc:     mockExecution,
 			maxEntries:   10,
-			maxDelay:     1 * time.Second,
+			maxDelay:     defaultMaxDelay,
 			tasks:        []string{"task1", "task1", "task1"},
 			expectResult: true,
 			expectErrors: false,
@@ -66,7 +71,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: max capacity",
 			mockFunc:     mockExecution,
 			maxEntries:   5,
-			maxDelay:     100 * time.Second,
+			maxDelay:     slowMaxDelay,
 			tasks:        []string{"task1", "task2", "task3", "task4", "task5"},
 			expectResult: true,
 			expectErrors: false,
@@ -75,7 +80,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: max delay",
 			mockFunc:     mockExecution,
 			maxEntries:   100,
-			maxDelay:     2 * time.Second,
+			maxDelay:     defaultMaxDelay,
 			tasks:        []string{"task1", "task2", "task3", "task4"},
 			expectResult: true,
 			expectErrors: false,
@@ -84,7 +89,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: no execution without max delay or max entries",
 			mockFunc:     mockExecution,
 			maxEntries:   10,
-			maxDelay:     15 * time.Second,
+			maxDelay:     slowMaxDelay,
 			tasks:        []string{"task1", "task2", "task3"},
 			expectResult: false,
 		},
@@ -92,7 +97,7 @@ func TestBatcher(t *testing.T) {
 			name:         "TestBatcher: error handling",
 			mockFunc:     mockExecutionWithError,
 			maxEntries:   10,
-			maxDelay:     1 * time.Second,
+			maxDelay:     defaultMaxDelay,
 			tasks:        []string{"errorTask"},
 			expectErrors: true,
 		},
@@ -139,7 +144,7 @@ func TestBatcher(t *testing.T) {
 					if r.Result != task && tc.expectResult {
 						t.Errorf("Expected result for task %v, but got %v", task, r.Result)
 					}
-				case <-time.After(10 * time.Second):
+				case <-time.After(slowMaxDelay - defaultMaxDelay):
 					if tc.expectResult {
 						t.Errorf("Timed out waiting for result of task %d", i)
 					}

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -44,6 +44,8 @@ const (
 	defaultVolumeID = "vol-test-1234"
 	defaultNodeID   = "node-1234"
 	defaultPath     = "/dev/xvdaa"
+
+	defaultCreateDiskDeadline = time.Second * 5
 )
 
 func generateVolumes(volIdCount, volTagCount int) []*ec2.Volume {
@@ -807,7 +809,8 @@ func TestCreateDisk(t *testing.T) {
 				VolumeId:   aws.String("snap-test-volume"),
 				State:      aws.String("completed"),
 			}
-			ctx := context.Background()
+			ctx, ctxCancel := context.WithDeadline(context.Background(), time.Now().Add(defaultCreateDiskDeadline))
+			defer ctxCancel()
 
 			if tc.expCreateVolumeInput != nil {
 				matcher := eqCreateVolume(tc.expCreateVolumeInput)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Testing

**What is this PR about? / Why do we need it?**
~65s speed up for running `make test` via the following slow unit tests: 
- batcher_test.go: From 15s to 0.250s 
  - Lower timeouts still functionally test code
- Cloud TestCreateDisk: "fail: Volume is not ready to use, volume stuck in creating status and controller context deadline exceeded" subtest: From 60s to 5s 
  - Simulate a controller context deadline in the test. 
  - The whole of TestCreateDisk still needs some work such that unit tests don't sleep serially. Will work on this in a separate PR. 

**What testing is done?** 

Manual testing to make sure batcher and TestCreateDisk unit tests still fail when their implementations break.

`make test`, `make verify`

`go test -race -count=1000` on cloud and batcher packages. 

Measuring `make test` via `time` command:
`make test` pre PR:  2:29.92 
`make test` post PR: 1:25.17