### PR TITLE
Add OS topology key to node segments map

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -873,22 +873,22 @@ func pickAvailabilityZone(requirement *csi.TopologyRequirement) string {
 		return ""
 	}
 	for _, topology := range requirement.GetPreferred() {
-		zone, exists := topology.GetSegments()[WellKnownTopologyKey]
+		zone, exists := topology.GetSegments()[WellKnownZoneTopologyKey]
 		if exists {
 			return zone
 		}
 
-		zone, exists = topology.GetSegments()[TopologyKey]
+		zone, exists = topology.GetSegments()[ZoneTopologyKey]
 		if exists {
 			return zone
 		}
 	}
 	for _, topology := range requirement.GetRequisite() {
-		zone, exists := topology.GetSegments()[WellKnownTopologyKey]
+		zone, exists := topology.GetSegments()[WellKnownZoneTopologyKey]
 		if exists {
 			return zone
 		}
-		zone, exists = topology.GetSegments()[TopologyKey]
+		zone, exists = topology.GetSegments()[ZoneTopologyKey]
 		if exists {
 			return zone
 		}
@@ -928,7 +928,7 @@ func newCreateVolumeResponse(disk *cloud.Disk, ctx map[string]string) *csi.Creat
 		}
 	}
 
-	segments := map[string]string{TopologyKey: disk.AvailabilityZone}
+	segments := map[string]string{ZoneTopologyKey: disk.AvailabilityZone}
 
 	arn, err := arn.Parse(disk.OutpostArn)
 

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -247,7 +247,7 @@ func TestCreateVolume(t *testing.T) {
 						Requisite: []*csi.Topology{
 							{
 								Segments: map[string]string{
-									TopologyKey:     expZone,
+									ZoneTopologyKey: expZone,
 									AwsAccountIDKey: outpostArn.AccountID,
 									AwsOutpostIDKey: outpostArn.Resource,
 									AwsRegionKey:    outpostArn.Region,
@@ -264,7 +264,7 @@ func TestCreateVolume(t *testing.T) {
 					AccessibleTopology: []*csi.Topology{
 						{
 							Segments: map[string]string{
-								TopologyKey:     expZone,
+								ZoneTopologyKey: expZone,
 								AwsAccountIDKey: outpostArn.AccountID,
 								AwsOutpostIDKey: outpostArn.Resource,
 								AwsRegionKey:    outpostArn.Region,
@@ -1283,7 +1283,7 @@ func TestCreateVolume(t *testing.T) {
 					AccessibilityRequirements: &csi.TopologyRequirement{
 						Requisite: []*csi.Topology{
 							{
-								Segments: map[string]string{TopologyKey: expZone},
+								Segments: map[string]string{ZoneTopologyKey: expZone},
 							},
 						},
 					},
@@ -1296,7 +1296,7 @@ func TestCreateVolume(t *testing.T) {
 					AccessibilityRequirements: &csi.TopologyRequirement{
 						Requisite: []*csi.Topology{
 							{
-								Segments: map[string]string{TopologyKey: expZone},
+								Segments: map[string]string{ZoneTopologyKey: expZone},
 							},
 						},
 					},
@@ -1307,7 +1307,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeContext: map[string]string{},
 					AccessibleTopology: []*csi.Topology{
 						{
-							Segments: map[string]string{TopologyKey: expZone},
+							Segments: map[string]string{ZoneTopologyKey: expZone},
 						},
 					},
 				}
@@ -2043,27 +2043,27 @@ func TestPickAvailabilityZone(t *testing.T) {
 		expZone     string
 	}{
 		{
-			name: "Return WellKnownTopologyKey if present from preferred",
+			name: "Return WellKnownZoneTopologyKey if present from preferred",
 			requirement: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: ""},
+						Segments: map[string]string{ZoneTopologyKey: ""},
 					},
 				},
 				Preferred: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: expZone, WellKnownTopologyKey: "foobar"},
+						Segments: map[string]string{ZoneTopologyKey: expZone, WellKnownZoneTopologyKey: "foobar"},
 					},
 				},
 			},
 			expZone: "foobar",
 		},
 		{
-			name: "Return WellKnownTopologyKey if present from requisite",
+			name: "Return WellKnownZoneTopologyKey if present from requisite",
 			requirement: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: expZone, WellKnownTopologyKey: "foobar"},
+						Segments: map[string]string{ZoneTopologyKey: expZone, WellKnownZoneTopologyKey: "foobar"},
 					},
 				},
 			},
@@ -2074,12 +2074,12 @@ func TestPickAvailabilityZone(t *testing.T) {
 			requirement: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: ""},
+						Segments: map[string]string{ZoneTopologyKey: ""},
 					},
 				},
 				Preferred: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: expZone},
+						Segments: map[string]string{ZoneTopologyKey: expZone},
 					},
 				},
 			},
@@ -2090,7 +2090,7 @@ func TestPickAvailabilityZone(t *testing.T) {
 			requirement: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: expZone},
+						Segments: map[string]string{ZoneTopologyKey: expZone},
 					},
 				},
 			},
@@ -2135,13 +2135,13 @@ func TestGetOutpostArn(t *testing.T) {
 			requirement: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
-						Segments: map[string]string{TopologyKey: expZone},
+						Segments: map[string]string{ZoneTopologyKey: expZone},
 					},
 				},
 				Preferred: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							TopologyKey:     expZone,
+							ZoneTopologyKey: expZone,
 							AwsAccountIDKey: outpostArn.AccountID,
 							AwsOutpostIDKey: outpostArn.Resource,
 							AwsRegionKey:    outpostArn.Region,
@@ -2159,7 +2159,7 @@ func TestGetOutpostArn(t *testing.T) {
 				Requisite: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							TopologyKey:     expZone,
+							ZoneTopologyKey: expZone,
 							AwsAccountIDKey: outpostArn.AccountID,
 							AwsOutpostIDKey: outpostArn.Resource,
 							AwsRegionKey:    outpostArn.Region,

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -51,9 +51,10 @@ const (
 	AwsRegionKey    = "topology." + DriverName + "/region"
 	AwsOutpostIDKey = "topology." + DriverName + "/outpost-id"
 
-	WellKnownTopologyKey = "topology.kubernetes.io/zone"
-	// DEPRECATED Use the WellKnownTopologyKey instead
-	TopologyKey = "topology." + DriverName + "/zone"
+	WellKnownZoneTopologyKey = "topology.kubernetes.io/zone"
+	// DEPRECATED Use the WellKnownZoneTopologyKey instead
+	ZoneTopologyKey = "topology." + DriverName + "/zone"
+	OSTopologyKey   = "kubernetes.io/os"
 )
 
 type Driver struct {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -587,10 +588,12 @@ func (d *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	klog.V(4).InfoS("NodeGetInfo: called", "args", *req)
 
 	zone := d.metadata.GetAvailabilityZone()
+	osType := runtime.GOOS
 
 	segments := map[string]string{
-		TopologyKey:          zone,
-		WellKnownTopologyKey: zone,
+		ZoneTopologyKey:          zone,
+		WellKnownZoneTopologyKey: zone,
+		OSTopologyKey:            osType,
 	}
 
 	outpostArn := d.metadata.GetOutpostArn()

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -26,6 +26,7 @@ import (
 	"io/fs"
 	"os"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -2328,11 +2329,14 @@ func TestNodeGetInfo(t *testing.T) {
 			}
 
 			at := resp.GetAccessibleTopology()
-			if at.Segments[TopologyKey] != tc.availabilityZone {
-				t.Fatalf("Expected topology %q, got %q", tc.availabilityZone, at.Segments[TopologyKey])
+			if at.Segments[ZoneTopologyKey] != tc.availabilityZone {
+				t.Fatalf("Expected topology %q, got %q", tc.availabilityZone, at.Segments[ZoneTopologyKey])
 			}
-			if at.Segments[WellKnownTopologyKey] != tc.availabilityZone {
-				t.Fatalf("Expected (well-known) topology %q, got %q", tc.availabilityZone, at.Segments[WellKnownTopologyKey])
+			if at.Segments[WellKnownZoneTopologyKey] != tc.availabilityZone {
+				t.Fatalf("Expected (well-known) topology %q, got %q", tc.availabilityZone, at.Segments[WellKnownZoneTopologyKey])
+			}
+			if at.Segments[OSTopologyKey] != runtime.GOOS {
+				t.Fatalf("Expected os topology %q, got %q", runtime.GOOS, at.Segments[OSTopologyKey])
 			}
 
 			if at.Segments[AwsAccountIDKey] != tc.outpostArn.AccountID {

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -52,7 +52,7 @@ func (d *ebsCSIDriver) GetDynamicProvisionStorageClass(parameters map[string]str
 				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 					{
 						// TODO we should use the new topology key eventually
-						Key:    ebscsidriver.TopologyKey,
+						Key:    ebscsidriver.ZoneTopologyKey,
 						Values: allowedTopologyValues,
 					},
 				},


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

This PR introduces the addition of an (OS) topology key to the node segments map returned by `NodeGetInfo` within the node service.

The change enables scoping down a StorageClass using the `allowedTopologies` attribute to an OS type. It is backward compatible and should not impact existing deployments. Nodes will simply start reporting additional topology information post-update.

Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1946

**What testing is done?** 

`make test` && manual testing && CI e2e

Example StorageClass:

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
allowedTopologies:
- matchLabelExpressions:
  - key: kubernetes.io/os
    values:
    - windows
  - key: topology.ebs.csi.aws.com/zone
    values:
    - us-east-2c
```

Without this patch:
```
  Warning  ProvisioningFailed    4s (x4 over 11s)  ebs.csi.aws.com_ebs-csi-controller-56bfc45bc5-5ckcz_d0df82a6-2e08-4622-b0ec-dbe4927673e0  failed to provision volume with StorageClass "ebs-sc": error generating accessibility requirements: topology map[topology.ebs.csi.aws.com/zone:us-east-2c topology.kubernetes.io/zone:us-east-2c] from selected node "ip-192-168-28-75.us-east-2.compute.internal" is not in requisite: [map[kubernetes.io/os:linux topology.ebs.csi.aws.com/zone:us-east-2c]]
```

With this patch:
```
  Normal   ProvisioningSucceeded  17s                ebs.csi.aws.com_ebs-csi-controller-7bf457699-8b7gk_ead7e79a-c4ee-4ad9-a66e-bf02e146c62b   Successfully provisioned volume pvc-8f101bfd-d76a-45a7-88d3-05091814375c
```