### PR TITLE
Fix Small Papercuts 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,56 +14,14 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 * **Block Volumes** - Consume an EBS volume as a [raw block device](https://kubernetes-csi.github.io/docs/raw-block.html).
 * **Volume Snapshots** - Create and restore [snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) taken from a volume in Kubernetes.
 * **Volume Resizing** - Expand the volume by specifying a new size in the [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims) (PVC).
+* **Volume Modification** - Change the properties (type, iops, or throughput) [via a `VolumeAttributesClass`](examples/kubernetes/modify-volume).
 
 ## Container Images
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | v1.28.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.28.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.28.0                      |
-
-<details>
-<summary>Previous Images</summary>
-
-| Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
-|----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | v1.27.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.27.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.27.0                      |
-| v1.26.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.26.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.1                      |
-| v1.26.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.26.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.26.0                      |
-| v1.25.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.25.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.25.0                      |
-| v1.24.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.1                      |
-| v1.24.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.24.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.24.0                      |
-| v1.23.2        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.2                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.2                      |
-| v1.23.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.1                      |
-| v1.23.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.23.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.23.0                      |
-| v1.22.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.22.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.22.1                      |
-| v1.22.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.22.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.22.0                      |
-| v1.21.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.21.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.21.0                      |
-| v1.20.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.20.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.20.0                      |
-| v1.19.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.19.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.19.0                      |
-| v1.18.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.18.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.18.0                      |
-| v1.17.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.17.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.17.0                      |
-| v1.16.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.16.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1                      |
-| v1.16.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.16.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.16.0                      |
-| v1.15.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.15.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.15.1                      |
-| v1.15.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.15.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.15.0                      |
-| v1.14.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.14.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.14.1                      |
-| v1.14.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.14.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.14.0                      |
-| v1.13.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.13.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.13.0                      |
-| v1.12.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.12.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.12.1                      |
-| v1.12.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.12.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.12.0                      |
-| v1.11.5        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.11.5                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.11.5                      |
-| v1.11.4        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.11.4                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.11.4                      |
-| v1.11.3        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.11.3                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.11.3                      |
-| v1.11.2        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.11.2                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.11.2                      |
-| v1.10.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.10.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.10.0                      |
-| v1.9.0         | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.9.0                                            | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.9.0                       |
-| v1.8.0         | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.8.0                                            | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.8.0                       |
-| v1.7.0         | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.7.0                                            | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.7.0                       |
-| v1.6.2         | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.2                                            | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.6.2                       |
-| v1.6.1         | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.1                                            | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.6.1                       |
-| v1.6.0         | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.6.0                                            | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.6.0                       |
-
-</details>
 
 ## Releases
 
@@ -85,7 +43,9 @@ This policy is non-binding and subject to change.
 
 ## Compatibility
 
-The EBS CSI Driver is compatible with Kubernetes versions v1.17+ and implements the CSI Specification v1.1.0.
+The EBS CSI Driver is compatible with all Kubernetes versions supported by [the Kubernetes project](https://kubernetes.io/releases/) and/or [Amazon EKS (including extended support versions)](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html).
+
+The EBS CSI Driver implements the [Container Storage Interface specification](https://github.com/container-storage-interface/spec/blob/master/spec.md) version `v1.9.0`.
 
 ## Documentation
 

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -161,6 +161,16 @@ func TestGetOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "no options at all - expect all mode",
+			testFunc: func(t *testing.T) {
+				options := testFunc(t, nil, false, false, false)
+
+				if options.DriverMode != driver.AllMode {
+					t.Fatalf("expected driver mode to be %q but it is %q", driver.AllMode, options.DriverMode)
+				}
+			},
+		},
+		{
 			name: "all mode given - expect all mode",
 			testFunc: func(t *testing.T) {
 				options := testFunc(t, []string{"all"}, true, true, true)

--- a/hack/e2e/kops/kops.sh
+++ b/hack/e2e/kops/kops.sh
@@ -149,6 +149,6 @@ function json_to_yaml() {
   OUT=${2}
   for ((i = 0; i < $(jq length "$IN"); i++)); do
     echo "---" >>"$OUT"
-    jq ".[$i]" "$IN" | kubectl patch -f - --local -p "{}" --type merge -o yaml >>"$OUT"
+    jq ".[$i]" "$IN" | kubectl patch --kubeconfig /dev/null -f - --local -p "{}" --type merge -o yaml >>"$OUT"
   done
 }

--- a/hack/release-scripts/generate-release-pr
+++ b/hack/release-scripts/generate-release-pr
@@ -24,7 +24,7 @@ log() {
 }
 
 check_dependencies() {
-  local readonly dependencies=("yq" "git" "vi" "sed")
+  local readonly dependencies=("yq" "git" "sed")
 
   for cmd in "${dependencies[@]}"; do
     if ! command -v "${cmd}" &>/dev/null; then
@@ -88,10 +88,14 @@ parse_args() {
 
 update_readme() {
   log "Updating README.md"
-  # vi macro that adds new driver version 'Container Images' row to README.md
-  vi -s <(echo "gg/## Container Images
-  jjjjyy:%s/${PREV_DRIVER_VERSION}/${NEW_DRIVER_VERSION}/g
-  jjjjjjp:wq") "$README_PATH"
+  $SED "/^## Container Images$/,+5 s/$PREV_DRIVER_VERSION/$NEW_DRIVER_VERSION/g" -i "$README_PATH"
+
+  # If the major/minor version has changed, we also need to replace the old prev version with the new previous version
+  # (If not, that means this is a patch release, and we shouldn't change the other version)
+  if [ "${PREV_DRIVER_VERSION%.*}" != "${NEW_DRIVER_VERSION%.*}" ]; then
+    OLD_VERSION_TO_REPLACE=$($SED -n "/^## Container Images$/,+5 p" "$README_PATH" | tail -n 1 | grep -o " v[^ ]* " | tr -d " ")
+    $SED "/^## Container Images$/,+5 s/$OLD_VERSION_TO_REPLACE/$PREV_DRIVER_VERSION/g" -i "$README_PATH"
+  fi
 }
 
 update_makefile() {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Largely bug fix

**What is this PR about? / Why do we need it?**

Fixes three small issues:

**[Add missing kubeconfig in kops.sh](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/2af98faaa1f5a168a43ca71632af1dc67fbd0b30)**

Adds a `--kubeconfig dev/null` missed in #1933

**[Cleanup README images and compatibility](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/f66e87d9dde2b65ba4104d3df9cda48606e0d0c4)**

Change README section to only supported images, update release PRs script to account for this change.

**[Refactor options.go so that flags are always loaded](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/c8128be91f70cfde09aecd077b77908dfbea822b)**

Fixes #1952 by refactoring the logic to greatly simplify the control flow, also adds a unit test for an entirely blank arguments set.

**What testing is done?** 

Manual/Added unit test/CI