### PR TITLE
Remove unused 'IsExistInstance'

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -963,14 +963,6 @@ func (c *cloud) GetDiskByID(ctx context.Context, volumeID string) (*Disk, error)
 	}, nil
 }
 
-func (c *cloud) IsExistInstance(ctx context.Context, nodeID string) bool {
-	instance, err := c.getInstance(ctx, nodeID)
-	if err != nil || instance == nil {
-		return false
-	}
-	return true
-}
-
 func (c *cloud) CreateSnapshot(ctx context.Context, volumeID string, snapshotOptions *SnapshotOptions) (snapshot *Snapshot, err error) {
 	descriptions := "Created by AWS EBS CSI driver for volume " + volumeID
 

--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -15,7 +15,6 @@ type Cloud interface {
 	WaitForAttachmentState(ctx context.Context, volumeID, expectedState string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*ec2.VolumeAttachment, error)
 	GetDiskByName(ctx context.Context, name string, capacityBytes int64) (disk *Disk, err error)
 	GetDiskByID(ctx context.Context, volumeID string) (disk *Disk, err error)
-	IsExistInstance(ctx context.Context, nodeID string) (success bool)
 	CreateSnapshot(ctx context.Context, volumeID string, snapshotOptions *SnapshotOptions) (snapshot *Snapshot, err error)
 	DeleteSnapshot(ctx context.Context, snapshotID string) (success bool, err error)
 	GetSnapshotByName(ctx context.Context, name string) (snapshot *Snapshot, err error)

--- a/pkg/cloud/mock_cloud.go
+++ b/pkg/cloud/mock_cloud.go
@@ -214,20 +214,6 @@ func (mr *MockCloudMockRecorder) GetSnapshotByName(ctx, name interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshotByName", reflect.TypeOf((*MockCloud)(nil).GetSnapshotByName), ctx, name)
 }
 
-// IsExistInstance mocks base method.
-func (m *MockCloud) IsExistInstance(ctx context.Context, nodeID string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsExistInstance", ctx, nodeID)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsExistInstance indicates an expected call of IsExistInstance.
-func (mr *MockCloudMockRecorder) IsExistInstance(ctx, nodeID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExistInstance", reflect.TypeOf((*MockCloud)(nil).IsExistInstance), ctx, nodeID)
-}
-
 // ListSnapshots mocks base method.
 func (m *MockCloud) ListSnapshots(ctx context.Context, volumeID string, maxResults int64, nextToken string) (*ListSnapshotsResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Cleanup

**What is this PR about? / Why do we need it?**
`IsExistInstance` is not used anywhere in our repository. This was added in order in order to inject a fake cloud provider back in this commit: [Make sanity tests happy · kubernetes-sigs/aws-ebs-csi-driver@3527d7f](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/3527d7fa25cf33379249c613edcbe91e4036bc02#diff-d4a686c1cd62817e5e4a8c812266913ae1a6b61439c462f9d3f630c9be6e73e5). 

Because we no longer rely on this function, we should consider removing this dead code. 

**What testing is done?** 
A text search for `IsExistInstance` usages; CI
