### PR TITLE
Add helm wrapper to convert --reuse-values to --reset-then-reuse-values for CT testing

### DIFF
--- a/hack/tools/helm-runner.sh
+++ b/hack/tools/helm-runner.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used as a stub for helm to substitute --reset-then-reuse-values
+# for instances of --reuse-values until https://github.com/helm/chart-testing/pull/531
+# or a similar PR is merged and released
+
+exec "$(dirname "${0}")/.helm" "${@//--reuse-values/--reset-then-reuse-values}"

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -75,8 +75,7 @@ function install_tar_binary() {
   INSTALL_PATH="${1}"
   DOWNLOAD_URL="${2}"
   BINARY_PATH="${3}"
-
-  BINARY_NAME="$(basename "${BINARY_PATH}")"
+  BINARY_NAME="${4:-$(basename "${BINARY_PATH}")}"
 
   if [ "${DOWNLOAD_URL##*.}" = "gz" ]; then
     TAR_EXTRA_FLAGS="-z"
@@ -128,7 +127,8 @@ function install_golangci-lint() {
 function install_helm() {
   INSTALL_PATH="${1}"
 
-  install_tar_binary "${INSTALL_PATH}" "https://get.helm.sh/helm-${HELM_VERSION}-${OS}-${ARCH}.tar.gz" "${OS}-${ARCH}/helm"
+  install_tar_binary "${INSTALL_PATH}" "https://get.helm.sh/helm-${HELM_VERSION}-${OS}-${ARCH}.tar.gz" "${OS}-${ARCH}/helm" ".helm"
+  cp "$(dirname "${0}")/helm-runner.sh" "${INSTALL_PATH}/helm"
 }
 
 function install_kops() {


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Executes #1864 by changing CT to use `--reset-then-reuse-values` instead of `--reuse-values`

Currently this is done via a workaround until https://github.com/helm/chart-testing/pull/531 or similar is merged, I will likely be submitting our own PR to `chart-testing` to add the ability to switch the upgrade method, but this will workaround that in our e2e tests and CI until such a feature is released.

**What testing is done?** 

Manually tested + CI