### PR TITLE
[WIP] Fix fsType xfs format errors on linux kernel <= 5.4.x

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -285,6 +285,9 @@ func (d *nodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if len(ext4ClusterSize) > 0 {
 		formatOptions = append(formatOptions, "-C", ext4ClusterSize)
 	}
+	if fsType == FSTypeXfs {
+		formatOptions = append(formatOptions, "-m", "bigtime=0,inobtcount=0,reflink=0")
+	}
 	err = d.mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fsType, mountOptions, nil, formatOptions)
 	if err != nil {
 		msg := fmt.Sprintf("could not format %q and mount it at %q: %v", source, target, err)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**

**Note: INCOMPLETE PR**
- WIP to confirm no un-forseen consequences with these options and whether `reflink=0` is necessary
- WIP to decide what kind of feature flag or createVolume parameter we should hide this logic behind with team
- WIP edit/add TestNodeStageVolume unit sub-tests

Today dynamically provisioned volumes with `xfs` `fsType` fail to mount on nodes with linux kernel <= `v5.4.x` when formatted by aws-ebs-csi-driver ≥ v1.23.0

This is due to aws-ebs-csi-driver ≥ v1.23.0 [switching to an AL23 minimal base image](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md#v1230) that relies upon `xfsprogs` `v5.18.x` to format the volume. This version of `xfsprogs` has the following issue:
- After creating a new xfs filesystem with the default "mkfs -t xfs ..." command when using mkfs.xfs `v5.18.x` the resulting filesystem cannot be mounted on systems running kernel versions 4.x and 5.4.x
- The new filesystem can be mounted with no problems on another machine that is running a ≥ 5.10 kernel. If one's new XFS mounts fail with this symptom, then one must either reformat the filesystem with new settings, or upgrade to a 5.10 kernel. 

Without this PR, the following combination leads to the the ebs volume formatted such that the volume cannot mount to nodes with kernel version ≤ 5.4 (such as default EKS 1.23 node AMI):
- EKS 1.23 default ami (kernel version 5.4.x) and EBS CSI Driver ≥ v1.23

Without this PR, the following combinations lead to workloads with xfs successfully formatting and mounting:

- EKS 1.24 default AMI (kernel version 5.10.x) and EBS CSI Driver ≥ v1.23
- EKS 1.23 optimized AL23 Ami (kernel version 6.x) and EBS CSI Driver ≥ v1.23
- EKS 1.23 default ami (kernel version 5.4.x) and EBS CSI Driver ≤ v1.22

--- 
With this PR's change, EBS CSI Driver node pods with AL23 base image (and therefore `xfsprogs` `v5.18.x`) will be able to format and mount xfs filesystems on nodes with kernel versions ≤ `v5.4.x`

---
Helpful resources:
- [XFS filesystem problems w/ kernels 4.x and 5.x](https://forums.gentoo.org/viewtopic-t-1161260.html?sid=4cdb0da2984865badd8fd32ccf58300f) offers a summary of problem, but doesn't mention that this issue is also on linux kernel `v5.4.x`. Also the `reflink` option may be red herring.
- [mkfs.xfs(8) - Linux manual page](https://man7.org/linux/man-pages/man8/mkfs.xfs.8.html)

**What testing is done?** 
Tested stateful xfs workload on EKS 1.23 cluster with AL2 nodes with kernel version `5.4.x` 