### PR TITLE
Fix `ebs-csi-driver-test` CT pod timeout

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -129,7 +129,7 @@ if [[ "${HELM_CT_TEST}" == true ]]; then
     while true; do
       if kubectl get pod ebs-csi-driver-test -n kube-system --kubeconfig "${KUBECONFIG}" &>/dev/null; then
         echo "Pod found, waiting for it to become ready..."
-        if kubectl wait --for=condition=ready pod ebs-csi-driver-test -n kube-system --timeout=60s --kubeconfig "${KUBECONFIG}"; then
+        if kubectl wait --for=condition=ready pod ebs-csi-driver-test -n kube-system --timeout=300s --kubeconfig "${KUBECONFIG}"; then
           echo "Pod is ready, fetching logs..."
           kubectl logs -f ebs-csi-driver-test -n kube-system -c kubetest2 --kubeconfig "${KUBECONFIG}"
         fi


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Ran locally and found that pulling the new image can take longer than 60 seconds, which is longer than the current timeout value.

**What testing is done?**

```
ct lint-and-install --config tests/ct-config.yaml &

------------------------------------------------------------------------------------------------------------------------
 ✔︎ aws-ebs-csi-driver => (version: "2.28.1", path: "charts/aws-ebs-csi-driver")
------------------------------------------------------------------------------------------------------------------------
All charts linted and installed successfully
```
