### PR TITLE
Fixup Helm test job

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -199,11 +199,13 @@ metadata:
 spec:
   containers:
     - name: kubetest2
-      image: {{ default "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240211-f101bf4199-master" (.Values.helmTester).image }}
+      image: {{ .Values.helmTester.image }}
       resources:
         requests:
-          cpu: 1600m
-          memory: 3Gi
+          cpu: 2000m
+          memory: 4Gi
+        limits:
+          memory: 4Gi
       command: [ "/bin/sh", "-c" ]
       args:
         - |
@@ -212,12 +214,11 @@ spec:
           kubectl config set-context kubetest2 --cluster=cluster
           kubectl config set-credentials sa --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
           kubectl config set-context kubetest2 --user=sa && kubectl config use-context kubetest2
-          kubectl get crd volumesnapshots.snapshot.storage.k8s.io
-          if [ $? -eq 0 ]; then
-            SNAPSHOTS="|snapshot fields"
+          export FOCUS_REGEX='\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data$SNAPSHOTS)'
+          if kubectl get crd volumesnapshots.snapshot.storage.k8s.io; then
+            FORCUS_REGEX="${FOCUS_REGEX}|snapshot fields"
           fi
-          export FOCUS_REGEX="\bebs.csi.aws.com\b.+(validate content|resize volume|offline PVC|AllowedTopologies|store data$SNAPSHOTS)"
-          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version=$(curl -L https://dl.k8s.io/release/stable-1.28.txt) --skip-regex='\[Disruptive\]|\[Serial\]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
+          kubetest2 noop --run-id='e2e-kubernetes' --test=ginkgo -- --test-package-version="$(curl -L https://dl.k8s.io/release/stable-1.29.txt)" --skip-regex='[Disruptive]|[Serial]' --focus-regex="$FOCUS_REGEX" --parallel=25 --test-args='-storage.testdriver=/etc/config/manifests.yaml'
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -467,4 +467,4 @@ useOldCSIDriver: false
 helmTester:
   enabled: true
   # Supply a custom image to the ebs-csi-driver-test pod in helm-tester.yaml
-  image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20231206-f7b83ffbe6-master"
+  image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240311-b09cdeb92c-master"

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -47,6 +47,7 @@ test-e2e-external-kustomize)
   ;;
 test-helm-chart)
   TEST="helm-ct"
+  export INSTANCE_TYPE="c5.xlarge"
   ;;
 *)
   echo "Unknown e2e test ${1}" >&2


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"Bug fix" for CI

**What is this PR about? / Why do we need it?**

1. Fixes quoting issues in Helm test pod causing disruptive tests to run (also cleans up the logic a bit to greatly increase readability)
2. Bumps kubekins image to latest tag
3. Removes `--reuse-values` workaround that is no longer needed
4. Add memory limit to tester pod, bump requests
5. Bump instance type to `c5.xlarge` for helm CI job

**What testing is done?** 

CI