### PR TITLE
Update Support Issue Template to Reflect Correct Slack Channel Name for AWS Provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -10,7 +10,7 @@ STOP -- PLEASE READ!
 
 GitHub is not the right place for support requests.
 
-If you're looking for help, post your question on the [Kubernetes Slack ](http://slack.k8s.io/) Sig-AWS Channel.
+If you're looking for help, post your question on the [Kubernetes Slack ](http://slack.k8s.io/) provider-aws Channel.
 
 If the matter is security related, please disclose it privately via https://kubernetes.io/security/.
 -->


### PR DESCRIPTION
This PR updates the support issue template for the EBS CSI Driver repository to rectify an outdated reference to the Slack channel. Currently, the template mentions the non-existent channel name sig-aws, which may mislead users seeking support. The correct channel name is provider-aws. This update ensures that users are directed to the appropriate channel for AWS-related support queries, enhancing the efficiency of issue resolution and community engagement.