### PR TITLE
[release-1.29] Hardcode buildkit verison to 0.12.5

### DIFF
--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -29,7 +29,7 @@ function ecr_build_and_push() {
   # Only setup buildx builder on Prow, allow local users to use docker cache
   if [ -n "${PROW_JOB_ID:-}" ]; then
     trap "docker buildx rm ebs-csi-multiarch-builder" EXIT
-    docker buildx create --bootstrap --use --name ebs-csi-multiarch-builder
+    docker buildx create --driver-opt=image=moby/buildkit:v0.12.5 --bootstrap --use --name ebs-csi-multiarch-builder
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   fi
 

--- a/hack/prow.sh
+++ b/hack/prow.sh
@@ -32,7 +32,7 @@ loudecho "Set up Docker Buildx"
 # and https://github.com/kubernetes-csi/csi-release-tools/blob/master/build.make#L132
 export DOCKER_CLI_EXPERIMENTAL=enabled
 trap "docker buildx rm multiarchimage-buildertest" EXIT
-docker buildx create --bootstrap --use --name multiarchimage-buildertest
+docker buildx create --driver-opt=image=moby/buildkit:v0.12.5 --bootstrap --use --name multiarchimage-buildertest
 
 loudecho "Set up QEMU"
 # See https://github.com/docker/setup-qemu-action


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

Buildkit 0.13.0 and above don't correctly forward `os.version` for Windows images in multi-arch manifests. Hardcode buildkit to 0.12.5

**What testing is done?** 

Manually tested locally via `./hack/prow.sh` (need to modify registry inside)