### PR TITLE
Update voluemessnapshotcontents/status RBAC

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -24,7 +24,7 @@ rules:
     verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
-    verbs: [ "update" ]
+    verbs: [ "update", "patch" ]
   {{- with .Values.sidecars.snapshotter.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}

--- a/deploy/kubernetes/base/clusterrole-snapshotter.yaml
+++ b/deploy/kubernetes/base/clusterrole-snapshotter.yaml
@@ -25,4 +25,4 @@ rules:
     verbs: [ "create", "get", "list", "watch", "update", "delete", "patch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
-    verbs: [ "update" ]
+    verbs: [ "update", "patch" ]


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Closes #1983 by adding missing 'patch' verb to `clusterrole-snapshotter.yaml`

**What testing is done?** 
Followed #1983's reproduction steps, and saw the following message on VolumeSnapshotContent object (and also a similar error on VolumeSnapshot object):

```
Name:         static-snapshot-content
...
Status:
  Error:
    Message:     Failed to check and update snapshot content: failed to list snapshot for content static-snapshot-content: "rpc error: code = Internal desc = Could not get snapshot ID \"snap-07f7084a5d87a82b7\": InvalidSnapshot.NotFound: The snapshot 'snap-07f7084a5d87a82b7' does not exist.\n\tstatus code: 400, request id: 6a7ab5c4-f023-4ace-8faa-4bdc4685b155"
    Time:        2024-03-28T19:14:12Z
...
```