### PR TITLE
Log number of images in ECR repository for CI

### DIFF
--- a/hack/e2e/ecr.sh
+++ b/hack/e2e/ecr.sh
@@ -23,6 +23,14 @@ function ecr_build_and_push() {
   IMAGE_TAG=${4}
   IMAGE_ARCH=${5}
 
+  # https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html
+  MAX_IMAGES=10000
+  IMAGE_COUNT=$(aws ecr list-images --repository-name ${IMAGE_NAME} --region ${REGION} --query 'length(imageIds[])')
+
+  if [ $IMAGE_COUNT -ge $MAX_IMAGES ]; then
+    loudecho "Repository image limit reached. Unable to push new images."
+  fi
+
   loudecho "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
   aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
 


### PR DESCRIPTION
CI is down:

```
ERROR: failed to solve: failed to push 209411653980.dkr.ecr.us-west-2.amazonaws.com/aws-ebs-csi-driver:fc52f7d8597340d52f263923768024b8-windows-amd64-ltsc2022: failed commit on ref "manifest-sha256:cf82f3a2999248be710bf71eebfced344c2ceeccdb1a3f412b1f051ae9aebda0": unexpected status from PUT request to https://209411653980.dkr.ecr.us-west-2.amazonaws.com/v2/aws-ebs-csi-driver/manifests/fc52f7d8597340d52f263923768024b8-windows-amd64-ltsc2022: 403 Forbidden
```

The root cause is that we've hit a limit for images per repository quota. Specifically, the `aws-ebs-csi-driver` ECR repository had 10,000 images. See https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html

This PR adds a helpful log to help debug future occurrences of this issue which may happen once aws-janitor is updated to clean up images but there is a regression which results in hitting the quota.