### PR TITLE
Add explicit `AttachVolume` call in `WaitForAttachmentState`

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1024,6 +1024,15 @@ func (c *cloud) WaitForAttachmentState(ctx context.Context, volumeID, expectedSt
 		// but DescribeVolume told us volume is detached, we will short-circuit this long wait loop and return error
 		// so as AttachDisk can be retried without waiting for 20 minutes.
 		if (expectedState == volumeAttachedState) && alreadyAssigned && (attachmentState != expectedState) {
+			request := &ec2.AttachVolumeInput{
+				Device:     aws.String(expectedDevice),
+				InstanceId: aws.String(expectedInstance),
+				VolumeId:   aws.String(volumeID),
+			}
+			_, err := c.ec2.AttachVolume(ctx, request)
+			if err != nil {
+				return false, fmt.Errorf("WaitForAttachmentState AttachVolume error, expected device but be attached but was %s, volumeID=%q, instanceID=%q, Device=%q, err=%w", attachmentState, volumeID, expectedInstance, expectedDevice, err)
+			}
 			return false, fmt.Errorf("attachment of disk %q failed, expected device to be attached but was %s", volumeID, attachmentState)
 		}
 

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -3029,8 +3029,11 @@ func TestWaitForAttachmentState(t *testing.T) {
 			defer cancel()
 
 			switch tc.name {
-			case "success: detached", "failure: already assigned but wrong state":
+			case "success: detached":
 				mockEC2.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []types.Volume{detachedVol}}, nil).AnyTimes()
+			case "failure: already assigned but wrong state":
+				mockEC2.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []types.Volume{detachedVol}}, nil)
+				mockEC2.EXPECT().AttachVolume(gomock.Any(), gomock.Any()).Return(nil, nil)
 			case "success: disk not found, assumed detached", "failure: disk not found, expected attached":
 				mockEC2.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(nil, &smithy.GenericAPIError{
 					Code:    "InvalidVolume.NotFound",


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug Fix

**What is this PR about? / Why do we need it?**

Today, the driver relies on the `DescribeInstances` API to determine the attachment state of a volume to an EC2 instance. The API may incorrectly report the volume as attached due to EC2's eventual consistency model, as a result the driver will skip making an expected `AttachVolume` API call and proceed to directly poll the attachment state of the volume.

This PR adds an explicit `AttachVolume` API call in the `WaitForAttachmentState` function when there is a mismatch between the expected attachment state and the actual attachment state reported for a volume. If the `AttachVolume` call fails, it is logged for debugging purposes but the overall behavior of returning an error and triggering a retry of the `AttachDisk` operation remains unchanged.

**What testing is done?** 

- `make test && make verify`
- CI
