### PR TITLE
Consolidate request handling in RecordRequestsMiddleware

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -326,7 +326,6 @@ func newEC2Cloud(region string, awsSdkDebugLog bool, userAgentExtra string, batc
 	svc := ec2.NewFromConfig(cfg, func(o *ec2.Options) {
 		o.APIOptions = append(o.APIOptions,
 			RecordRequestsMiddleware(),
-			RecordThrottledRequestsMiddleware(),
 		)
 	})
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

This PR ensures that throttled requests are correctly captured in the `cloudprovider_aws_api_throttled_requests_total` metric instead of `cloudprovider_aws_api_request_errors metric`.

`RecordThrottledRequestsMiddleware` has been removed as it is no longer needed.

**What testing is done?** 

```
// RecordRequestsHandler is added to the Complete chain; called after any request
func RecordRequestsMiddleware() func(*middleware.Stack) error {
	return func(stack *middleware.Stack) error {
		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("RecordRequestsMiddleware", func(ctx context.Context, input middleware.FinalizeInput, next middleware.FinalizeHandler) (output middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
			start := time.Now()
			output, metadata, err = next.HandleFinalize(ctx, input)
			labels := createLabels(ctx)
			if err != nil {
	->			klog.InfoS("Request error", "request", labels["request"], "error", err)
				metrics.Recorder().IncreaseCount("cloudprovider_aws_api_request_errors", labels)
			} else {
				duration := time.Since(start).Seconds()
				metrics.Recorder().ObserveHistogram("cloudprovider_aws_api_request_duration_seconds", duration, labels, nil)
			}
			return output, metadata, err
		}), middleware.Before)
	}
}
```

```
I0418 18:55:46.707008       1 handlers.go:41] "Request error" request="AttachVolume" error="exceeded maximum number of attempts, 3, https response error StatusCode: 503, RequestID: 6b017ada-3ba9-473c-855d-cf37c4d413fd, api error RequestLimitExceeded: Request limit exceeded."
```
