### PR TITLE
Run taint removal only if Kubernetes API is available

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -96,11 +96,13 @@ func NewNodeService(o *Options, md metadata.MetadataService, m mounter.Mounter, 
 	region := os.Getenv("AWS_REGION")
 	klog.InfoS("regionFromSession Node service", "region", region)
 
-	// Remove taint from node to indicate driver startup success
-	// This is done at the last possible moment to prevent race conditions or false positive removals
-	time.AfterFunc(taintRemovalInitialDelay, func() {
-		removeTaintInBackground(k, taintRemovalBackoff, removeNotReadyTaint)
-	})
+	if k != nil {
+		// Remove taint from node to indicate driver startup success
+		// This is done at the last possible moment to prevent race conditions or false positive removals
+		time.AfterFunc(taintRemovalInitialDelay, func() {
+			removeTaintInBackground(k, taintRemovalBackoff, removeNotReadyTaint)
+		})
+	}
 
 	return &NodeService{
 		metadata: md,


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**

Currently, if K8s API client creation fails, it does so silently. Thus it is possible for `k8sClient` to be `nil`, which gets passed into `NewDriver` -> `NewNodeService`.  To avoid a panic, `removeTaintInBackground` should only be executed if the client is available.

```
k8sClient, err := cfg.K8sAPIClient()
	if err != nil {
		klog.V(2).InfoS("Failed to setup k8s client")
	}

drv, err := driver.NewDriver(cloud, &options, m, md, k8sClient)
```

```
driver.node = NewNodeService(o, md, m, k)
```

```
if k != nil {
	// Remove taint from node to indicate driver startup success
	// This is done at the last possible moment to prevent race conditions or false positive removals
	time.AfterFunc(taintRemovalInitialDelay, func() {
		removeTaintInBackground(k, taintRemovalBackoff, removeNotReadyTaint)
	})
}
```

**What testing is done?** 

```
make verify && make test
```