### PR TITLE
Replace coalescer implementation with new coalescer package

### DIFF
--- a/pkg/driver/controller_modify_volume.go
+++ b/pkg/driver/controller_modify_volume.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/awslabs/volume-modifier-for-k8s/pkg/rpc"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/coalescer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -44,150 +44,6 @@ const (
 type modifyVolumeRequest struct {
 	newSize           int64
 	modifyDiskOptions cloud.ModifyDiskOptions
-	// Channel for sending the response to the request caller
-	responseChan chan modifyVolumeResponse
-}
-
-type modifyVolumeResponse struct {
-	volumeSize int32
-	err        error
-}
-
-type modifyVolumeRequestHandler struct {
-	volumeID string
-	// Merged request from the requests that have been accepted for the volume
-	mergedRequest *modifyVolumeRequest
-	// Channel for sending requests to the goroutine for the volume
-	requestChan chan *modifyVolumeRequest
-}
-
-type modifyVolumeManager struct {
-	// Map of volume ID to modifyVolumeRequestHandler
-	requestHandlerMap sync.Map
-}
-
-func newModifyVolumeManager() *modifyVolumeManager {
-	return &modifyVolumeManager{
-		requestHandlerMap: sync.Map{},
-	}
-}
-
-func newModifyVolumeRequestHandler(volumeID string, request *modifyVolumeRequest) modifyVolumeRequestHandler {
-	requestChan := make(chan *modifyVolumeRequest)
-	return modifyVolumeRequestHandler{
-		requestChan:   requestChan,
-		mergedRequest: request,
-		volumeID:      volumeID,
-	}
-}
-
-// This function validates the new request against the merged request for the volume.
-// If the new request has a volume property that's already included in the merged request and its value is different from that in the merged request,
-// this function will return an error and the new request will be rejected.
-func (h *modifyVolumeRequestHandler) validateModifyVolumeRequest(r *modifyVolumeRequest) error {
-	if r.newSize != 0 && h.mergedRequest.newSize != 0 && r.newSize != h.mergedRequest.newSize {
-		return fmt.Errorf("Different size was requested by a previous request. Current: %d, Requested: %d", h.mergedRequest.newSize, r.newSize)
-	}
-	if r.modifyDiskOptions.IOPS != 0 && h.mergedRequest.modifyDiskOptions.IOPS != 0 && r.modifyDiskOptions.IOPS != h.mergedRequest.modifyDiskOptions.IOPS {
-		return fmt.Errorf("Different IOPS was requested by a previous request. Current: %d, Requested: %d", h.mergedRequest.modifyDiskOptions.IOPS, r.modifyDiskOptions.IOPS)
-	}
-	if r.modifyDiskOptions.Throughput != 0 && h.mergedRequest.modifyDiskOptions.Throughput != 0 && r.modifyDiskOptions.Throughput != h.mergedRequest.modifyDiskOptions.Throughput {
-		return fmt.Errorf("Different throughput was requested by a previous request. Current: %d, Requested: %d", h.mergedRequest.modifyDiskOptions.Throughput, r.modifyDiskOptions.Throughput)
-	}
-	if r.modifyDiskOptions.VolumeType != "" && h.mergedRequest.modifyDiskOptions.VolumeType != "" && r.modifyDiskOptions.VolumeType != h.mergedRequest.modifyDiskOptions.VolumeType {
-		return fmt.Errorf("Different volume type was requested by a previous request. Current: %s, Requested: %s", h.mergedRequest.modifyDiskOptions.VolumeType, r.modifyDiskOptions.VolumeType)
-	}
-	return nil
-}
-
-func (h *modifyVolumeRequestHandler) mergeModifyVolumeRequest(r *modifyVolumeRequest) {
-	if r.newSize != 0 {
-		h.mergedRequest.newSize = r.newSize
-	}
-	if r.modifyDiskOptions.IOPS != 0 {
-		h.mergedRequest.modifyDiskOptions.IOPS = r.modifyDiskOptions.IOPS
-	}
-	if r.modifyDiskOptions.Throughput != 0 {
-		h.mergedRequest.modifyDiskOptions.Throughput = r.modifyDiskOptions.Throughput
-	}
-	if r.modifyDiskOptions.VolumeType != "" {
-		h.mergedRequest.modifyDiskOptions.VolumeType = r.modifyDiskOptions.VolumeType
-	}
-}
-
-// processModifyVolumeRequests method starts its execution with a timer that has modifyVolumeRequestHandlerTimeout as its timeout value.
-// When the Timer times out, it calls the ec2 API to perform the volume modification. processModifyVolumeRequests method sends back the response of
-// the ec2 API call to the CSI Driver main thread via response channels.
-// This method receives requests from CSI driver main thread via the request channel. When a new request is received from the request channel, we first
-// validate the new request. If the new request is acceptable, it will be merged with the existing request for the volume.
-func (d *ControllerService) processModifyVolumeRequests(h *modifyVolumeRequestHandler, responseChans []chan modifyVolumeResponse) {
-	klog.V(4).InfoS("Start processing ModifyVolumeRequest for ", "volume ID", h.volumeID)
-	process := func(req *modifyVolumeRequest) {
-		if err := h.validateModifyVolumeRequest(req); err != nil {
-			req.responseChan <- modifyVolumeResponse{err: err}
-		} else {
-			h.mergeModifyVolumeRequest(req)
-			responseChans = append(responseChans, req.responseChan)
-		}
-	}
-
-	for {
-		select {
-		case req := <-h.requestChan:
-			process(req)
-		case <-time.After(d.options.ModifyVolumeRequestHandlerTimeout):
-			d.modifyVolumeManager.requestHandlerMap.Delete(h.volumeID)
-			// At this point, no new requests can come in on the request channel because it has been removed from the map
-			// However, the request channel may still have requests waiting on it
-			// Thus, process any requests still waiting in the channel
-			for loop := true; loop; {
-				select {
-				case req := <-h.requestChan:
-					process(req)
-				default:
-					loop = false
-				}
-			}
-			actualSizeGiB, err := d.executeModifyVolumeRequest(h.volumeID, h.mergedRequest)
-			for _, c := range responseChans {
-				select {
-				case c <- modifyVolumeResponse{volumeSize: actualSizeGiB, err: err}:
-				default:
-					klog.V(6).InfoS("Ignoring response channel because it has no receiver", "volumeID", h.volumeID)
-				}
-			}
-			return
-		}
-	}
-}
-
-// When a new request comes in, we look up requestHandlerMap using the volume ID of the request.
-// If there's no ModifyVolumeRequestHandler for the volume, meaning that there’s no inflight requests for the volume, we will start a goroutine
-// for the volume calling processModifyVolumeRequests method, and ModifyVolumeRequestHandler for the volume will be added to requestHandlerMap.
-// If there’s ModifyVolumeRequestHandler for the volume, meaning that there is inflight request(s) for the volume, we will send the new request
-// to the goroutine for the volume via the receiving channel.
-// Note that each volume with inflight requests has their own goroutine which follows timeout schedule of their own.
-func (d *ControllerService) addModifyVolumeRequest(volumeID string, r *modifyVolumeRequest) {
-	requestHandler := newModifyVolumeRequestHandler(volumeID, r)
-	handler, loaded := d.modifyVolumeManager.requestHandlerMap.LoadOrStore(volumeID, requestHandler)
-	if loaded {
-		h := handler.(modifyVolumeRequestHandler)
-		h.requestChan <- r
-	} else {
-		responseChans := []chan modifyVolumeResponse{r.responseChan}
-		go d.processModifyVolumeRequests(&requestHandler, responseChans)
-	}
-}
-
-func (d *ControllerService) executeModifyVolumeRequest(volumeID string, req *modifyVolumeRequest) (int32, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	actualSizeGiB, err := d.cloud.ResizeOrModifyDisk(ctx, volumeID, req.newSize, &req.modifyDiskOptions)
-	if err != nil {
-		return 0, err
-	} else {
-		return actualSizeGiB, nil
-	}
 }
 
 func (d *ControllerService) GetCSIDriverModificationCapability(
@@ -202,8 +58,9 @@ func (d *ControllerService) ModifyVolumeProperties(
 	req *rpc.ModifyVolumePropertiesRequest,
 ) (*rpc.ModifyVolumePropertiesResponse, error) {
 	klog.V(4).InfoS("ModifyVolumeProperties called", "req", req)
-	if err := validateModifyVolumePropertiesRequest(req); err != nil {
-		return nil, err
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "Volume name not provided")
 	}
 
 	options, err := parseModifyVolumeParameters(req.GetParameters())
@@ -211,8 +68,9 @@ func (d *ControllerService) ModifyVolumeProperties(
 		return nil, err
 	}
 
-	name := req.GetName()
-	err = d.modifyVolumeWithCoalescing(ctx, name, options)
+	_, err = d.modifyVolumeCoalescer.Coalesce(name, modifyVolumeRequest{
+		modifyDiskOptions: *options,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -220,12 +78,54 @@ func (d *ControllerService) ModifyVolumeProperties(
 	return &rpc.ModifyVolumePropertiesResponse{}, nil
 }
 
-func validateModifyVolumePropertiesRequest(req *rpc.ModifyVolumePropertiesRequest) error {
-	name := req.GetName()
-	if name == "" {
-		return status.Error(codes.InvalidArgument, "Volume name not provided")
+func newModifyVolumeCoalescer(c cloud.Cloud, o *Options) coalescer.Coalescer[modifyVolumeRequest, int32] {
+	return coalescer.New[modifyVolumeRequest, int32](o.ModifyVolumeRequestHandlerTimeout, mergeModifyVolumeRequest, executeModifyVolumeRequest(c))
+}
+
+func mergeModifyVolumeRequest(input modifyVolumeRequest, existing modifyVolumeRequest) (modifyVolumeRequest, error) {
+	if input.newSize != 0 {
+		if existing.newSize != 0 && input.newSize != existing.newSize {
+			return existing, fmt.Errorf("Different size was requested by a previous request. Current: %d, Requested: %d", existing.newSize, input.newSize)
+		}
+		existing.newSize = input.newSize
 	}
-	return nil
+	if input.modifyDiskOptions.IOPS != 0 {
+		if existing.modifyDiskOptions.IOPS != 0 && input.modifyDiskOptions.IOPS != existing.modifyDiskOptions.IOPS {
+			return existing, fmt.Errorf("Different IOPS was requested by a previous request. Current: %d, Requested: %d", existing.modifyDiskOptions.IOPS, input.modifyDiskOptions.IOPS)
+		}
+		existing.modifyDiskOptions.IOPS = input.modifyDiskOptions.IOPS
+	}
+	if input.modifyDiskOptions.Throughput != 0 {
+		if existing.modifyDiskOptions.Throughput != 0 && input.modifyDiskOptions.Throughput != existing.modifyDiskOptions.Throughput {
+			return existing, fmt.Errorf("Different throughput was requested by a previous request. Current: %d, Requested: %d", existing.modifyDiskOptions.Throughput, input.modifyDiskOptions.Throughput)
+		}
+		existing.modifyDiskOptions.Throughput = input.modifyDiskOptions.Throughput
+	}
+	if input.modifyDiskOptions.VolumeType != "" {
+		if existing.modifyDiskOptions.VolumeType != "" && input.modifyDiskOptions.VolumeType != existing.modifyDiskOptions.VolumeType {
+			return existing, fmt.Errorf("Different volume type was requested by a previous request. Current: %s, Requested: %s", existing.modifyDiskOptions.VolumeType, input.modifyDiskOptions.VolumeType)
+		}
+		existing.modifyDiskOptions.VolumeType = input.modifyDiskOptions.VolumeType
+	}
+
+	return existing, nil
+}
+
+func executeModifyVolumeRequest(c cloud.Cloud) func(string, modifyVolumeRequest) (int32, error) {
+	return func(volumeID string, req modifyVolumeRequest) (int32, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		actualSizeGiB, err := c.ResizeOrModifyDisk(ctx, volumeID, req.newSize, &req.modifyDiskOptions)
+		if err != nil {
+			// Kubernetes sidecars treats "Invalid Argument" errors as infeasible and retries less aggressively
+			if errors.Is(err, cloud.ErrInvalidArgument) {
+				return 0, status.Errorf(codes.InvalidArgument, "Could not modify volume (invalid argument) %q: %v", volumeID, err)
+			}
+			return 0, status.Errorf(codes.Internal, "Could not modify volume %q: %v", volumeID, err)
+		} else {
+			return actualSizeGiB, nil
+		}
+	}
 }
 
 func parseModifyVolumeParameters(params map[string]string) (*cloud.ModifyDiskOptions, error) {
@@ -258,29 +158,4 @@ func parseModifyVolumeParameters(params map[string]string) (*cloud.ModifyDiskOpt
 	}
 
 	return &options, nil
-}
-
-func (d *ControllerService) modifyVolumeWithCoalescing(ctx context.Context, volume string, options *cloud.ModifyDiskOptions) error {
-	responseChan := make(chan modifyVolumeResponse)
-	request := modifyVolumeRequest{
-		modifyDiskOptions: *options,
-		responseChan:      responseChan,
-	}
-
-	// Intentionally not pass in context as we deal with context locally in this method
-	d.addModifyVolumeRequest(volume, &request) //nolint:contextcheck
-
-	select {
-	case response := <-responseChan:
-		if response.err != nil {
-			if errors.Is(response.err, cloud.ErrInvalidArgument) {
-				return status.Errorf(codes.InvalidArgument, "Could not modify volume %q: %v", volume, response.err)
-			}
-			return status.Errorf(codes.Internal, "Could not modify volume %q: %v", volume, response.err)
-		}
-	case <-ctx.Done():
-		return status.Errorf(codes.Internal, "Could not modify volume %q: context cancelled", volume)
-	}
-
-	return nil
 }

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -3567,10 +3567,10 @@ func TestControllerExpandVolume(t *testing.T) {
 			mockCloud.EXPECT().ResizeOrModifyDisk(gomock.Any(), gomock.Eq(tc.req.GetVolumeId()), gomock.Any(), gomock.Any()).Return(retSizeGiB, nil).AnyTimes()
 
 			awsDriver := ControllerService{
-				cloud:               mockCloud,
-				inFlight:            internal.NewInFlight(),
-				options:             &Options{},
-				modifyVolumeManager: newModifyVolumeManager(),
+				cloud:                 mockCloud,
+				inFlight:              internal.NewInFlight(),
+				options:               &Options{},
+				modifyVolumeCoalescer: newModifyVolumeCoalescer(mockCloud, &Options{}),
 			}
 
 			resp, err := awsDriver.ControllerExpandVolume(ctx, tc.req)


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

Replaces the previous mixed-in coalescer implementation with the new package from #2024

What this PR does NOT do, on purpose:
- *Significantly change the unit tests*: The unit tests could be refactored to mock the coalescer instead of cloud for the ModifyVolume tests (and probably should be, in the future). I chose not to do this in this iteration because it would be a significant overhaul, and keeping the unit tests as close as possible to the original best demonstrates this PR introduces no new bugs. I plan to refactor the coalescing-related tests in a follow up PR.
- *Refactor `cloud.ModifyDiskOptions` and `cloud.ModifyOrResizeDisk`*: I think the remaining `ModifyVolume` code could be greatly simplified by moving the size into `ModifyDiskOptions` (rather than having it as a separate parameter), but this PR is not the place to do so

**What testing is done?** 
CI/Unit Tests