### PR TITLE
Add DNS Configuration Options to Helm Chart for Controller Pod (#1925)

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -68,6 +68,14 @@ spec:
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.controller.dnsConfig }}
+      dnsConfig:
+        options:
+          {{- range .Values.controller.dnsConfig.options }}
+          - name: {{ .name }} 
+            value: "{{ .value }}"
+          {{- end }}
+      {{- end }}      
       containers:
         - name: ebs-plugin
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -324,6 +324,10 @@ controller:
   otelTracing: {}
   #  otelServiceName: ebs-csi-controller
   #  otelExporterEndpoint: "http://localhost:4317"
+  dnsConfig:
+   options: 
+     - name : ndots
+       value : "5"
 
 node:
   env: []


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
new feature

**What is this PR about? / Why do we need it?**
This pull request adds the ability to configure DNS settings within the Helm chart

**What testing is done?**
- Performed installation tests on a Kubernetes cluster