### PR TITLE
`Makefile` & `hack/` Process Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ all-push: all-image-registry push-manifest
 cluster/create: bin/kops bin/eksctl bin/aws
 	./hack/e2e/create-cluster.sh
 
+.PHONY: cluster/kubeconfig
+cluster/kubeconfig:
+	@./hack/e2e/kubeconfig.sh
+
 .PHONY: cluster/delete
 cluster/delete: bin/kops bin/eksctl
 	./hack/e2e/delete-cluster.sh

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ cluster/create: bin/kops bin/eksctl bin/aws
 cluster/kubeconfig:
 	@./hack/e2e/kubeconfig.sh
 
+.PHONY: cluster/image
+cluster/image: bin/aws
+	./hack/e2e/build-image.sh
+
 .PHONY: cluster/delete
 cluster/delete: bin/kops bin/eksctl
 	./hack/e2e/delete-cluster.sh
@@ -137,11 +141,6 @@ e2e/multi-az: bin/helm bin/ginkgo
 .PHONY: e2e/external
 e2e/external: bin/helm bin/kubetest2
 	COLLECT_METRICS="true" \
-	./hack/e2e/run.sh
-
-.PHONY: e2e/external-arm64
-e2e/external-arm64: bin/helm bin/kubetest2
-	IMAGE_ARCH="arm64" \
 	./hack/e2e/run.sh
 
 .PHONY: e2e/external-windows

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,6 @@ ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})
 
 CLUSTER_NAME?=ebs-csi-e2e.k8s.local
 CLUSTER_TYPE?=kops
-WINDOWS?=false
-WINDOWS_HOSTPROCESS?=false
 
 # split words on hyphen, access by 1-index
 word-hyphen = $(word $2,$(subst -, ,$1))

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test/coverage:
 #	go test -v -race ./tests/sanity/...
 
 .PHONY: tools
-tools: bin/aws bin/ct bin/eksctl bin/ginkgo bin/golangci-lint bin/helm bin/kops bin/kubetest2 bin/mockgen bin/shfmt
+tools: bin/aws bin/ct bin/eksctl bin/ginkgo bin/golangci-lint bin/gomplate bin/helm bin/kops bin/kubetest2 bin/mockgen bin/shfmt
 
 .PHONY: update
 update: update/gofmt update/kustomize update/mockgen update/gomod update/shfmt
@@ -104,7 +104,7 @@ verify: verify/govet verify/golangci-lint verify/update
 all-push: all-image-registry push-manifest
 
 .PHONY: cluster/create
-cluster/create: bin/kops bin/eksctl bin/aws
+cluster/create: bin/kops bin/eksctl bin/aws bin/gomplate
 	./hack/e2e/create-cluster.sh
 
 .PHONY: cluster/kubeconfig

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -153,6 +153,23 @@ export CLUSTER_TYPE="eksctl"
 make cluster/create
 ```
 
+### `make cluster/kubeconfig`
+
+Prints the `KUBECONFIG` environment variable for a cluster. You must pass the same `CLUSTER_TYPE` and `CLUSTER_NAME` as used when creating the cluster. This command must be `eval`ed to import the environment variables into your shell.
+
+#### Example: Export the `KUBECONFIG` for a default cluster
+
+```bash
+eval "$(make cluster/kubeconfig)"
+```
+
+#### Example: Export the `KUBECONFIG` for an `eksctl` cluster
+
+```bash
+export CLUSTER_TYPE="eksctl"
+eval "$(make cluster/kubeconfig)"
+```
+
 ### `make cluster/delete`
 
 Deletes a cluster created by `make cluster/create`. You must pass the same `CLUSTER_TYPE` and `CLUSTER_NAME` as used when creating the cluster.

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -153,6 +153,30 @@ export CLUSTER_TYPE="eksctl"
 make cluster/create
 ```
 
+### `make cluster/image`
+
+Builds an image for use in the E2E tests. This will automatically build the most appropriate image (for example, skipping Windows builds unless `WINDOWS` is set to `true`).
+
+#### Example: Build a standard image
+
+```bash
+make cluster/image
+```
+
+#### Example: Build an arm64 image
+
+```bash
+export IMAGE_ARCH="arm64"
+make cluster/image
+```
+
+#### Example: Build a Windows-compatible image
+
+```bash
+export WINDOWS="true"
+make cluster/image
+```
+
 ### `make cluster/kubeconfig`
 
 Prints the `KUBECONFIG` environment variable for a cluster. You must pass the same `CLUSTER_TYPE` and `CLUSTER_NAME` as used when creating the cluster. This command must be `eval`ed to import the environment variables into your shell.
@@ -176,7 +200,7 @@ Deletes a cluster created by `make cluster/create`. You must pass the same `CLUS
 
 ## E2E Tests
 
-Run E2E tests against a cluster created by `make cluster/create`. You must pass the same `CLUSTER_TYPE` and `CLUSTER_NAME` as used when creating the cluster.
+Run E2E tests against a cluster created by `make cluster/create`. You must pass the same `CLUSTER_TYPE` and `CLUSTER_NAME` as used when creating the cluster. You must have already run `make cluster/image` to build the image for the cluster, or provide an image of your own.
 
 Alternatively, you may run on an externally created cluster by passing `CLUSTER_TYPE` (required to determine which `values.yaml` to deploy) and `KUBECONFIG`. For `kops` clusters, the node IAM role should include the appropriate IAM policies to use the driver (see [the installation docs](./install.md#set-up-driver-permissions)). For `eksctl` clusters, the `ebs-csi-controller-sa` service account should be pre-created and setup to supply an IRSA role with the appropriate policies.
 
@@ -191,10 +215,6 @@ Run the single-AZ EBS CSI E2E tests. Requires a cluster with only one Availabili
 ### `make e2e/multi-az`
 
 Run the multi-AZ EBS CSI E2E tests. Requires a cluster with at least two Availability Zones.
-
-### `make e2e/external-arm64`
-
-Run the Kubernetes upstream [external storage E2E tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/README.md) using an ARM64 image of the EBS CSI Driver. Requires a cluster with Graviton nodes.
 
 ### `make e2e/external-windows`
 

--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -14,9 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script builds the EBS CSI Driver image for the e2e tests
+# Environment variables have default values (see config.sh) but
+# many can be overridden on demand if needed
+
 set -euo pipefail
 
-function ecr_build_and_push() {
+BASE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+BIN="${BASE_DIR}/../../bin"
+
+source "${BASE_DIR}/config.sh"
+source "${BASE_DIR}/util.sh"
+
+function build_and_push() {
   REGION=${1}
   AWS_ACCOUNT_ID=${2}
   IMAGE_NAME=${3}
@@ -25,7 +35,7 @@ function ecr_build_and_push() {
 
   # https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html
   MAX_IMAGES=10000
-  IMAGE_COUNT=$(aws ecr list-images --repository-name ${IMAGE_NAME} --region ${REGION} --query 'length(imageIds[])')
+  IMAGE_COUNT=$(aws ecr list-images --repository-name "${IMAGE_NAME##*/}" --region "${REGION}" --query 'length(imageIds[])')
 
   if [ $IMAGE_COUNT -ge $MAX_IMAGES ]; then
     loudecho "Repository image limit reached. Unable to push new images."
@@ -38,7 +48,9 @@ function ecr_build_and_push() {
   if [ -n "${PROW_JOB_ID:-}" ]; then
     trap "docker buildx rm ebs-csi-multiarch-builder" EXIT
     docker buildx create --driver-opt=image=moby/buildkit:v0.12.5 --bootstrap --use --name ebs-csi-multiarch-builder
-    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    # Ignore failures: Sometimes, this fails if run in parallel across multiple jobs
+    # If it fails "for real" the build later will fail, so it is safe to proceed
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || true
   fi
 
   export IMAGE="${IMAGE_NAME}"
@@ -54,3 +66,16 @@ function ecr_build_and_push() {
   fi
   make -j $(nproc) all-push
 }
+
+if [[ "${CREATE_MISSING_ECR_REPO}" == true ]]; then
+  REPO_CHECK=$(aws ecr describe-repositories --region "${AWS_REGION}")
+  if [ $(jq ".repositories | map(.repositoryName) | index(\"${IMAGE_NAME##*/}\")" <<<"${REPO_CHECK}") == "null" ]; then
+    aws ecr create-repository --region "${AWS_REGION}" --repository-name aws-ebs-csi-driver >/dev/null
+  fi
+fi
+
+build_and_push "${AWS_REGION}" \
+  "${AWS_ACCOUNT_ID}" \
+  "${IMAGE_NAME}" \
+  "${IMAGE_TAG}" \
+  "${IMAGE_ARCH}"

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -58,6 +58,3 @@ TEST_PATH=${TEST_PATH:-"./tests/e2e-kubernetes/..."}
 GINKGO_FOCUS=${GINKGO_FOCUS:-"External.Storage"}
 GINKGO_SKIP=${GINKGO_SKIP:-"\[Disruptive\]|\[Serial\]"}
 GINKGO_PARALLEL=${GINKGO_PARALLEL:-25}
-
-# TODO: Left in for now, but look into if this is still necessary and remove if not
-EKSCTL_ADMIN_ROLE=${EKSCTL_ADMIN_ROLE:-"Infra-prod-KopsDeleteAllLambdaServiceRoleF1578477-1ELDFIB4KCMXV"}

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -28,6 +28,7 @@ FIRST_ZONE=$(echo "${ZONES}" | cut -d, -f1)
 NODE_COUNT=${NODE_COUNT:-3}
 INSTANCE_TYPE=${INSTANCE_TYPE:-c5.large}
 WINDOWS=${WINDOWS:-"false"}
+WINDOWS_HOSTPROCESS=${WINDOWS_HOSTPROCESS:-"false"}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)

--- a/hack/e2e/create-cluster.sh
+++ b/hack/e2e/create-cluster.sh
@@ -59,16 +59,21 @@ elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
   eksctl_create_cluster \
     "$CLUSTER_NAME" \
     "${BIN}/eksctl" \
+    "${BIN}/gomplate" \
+    "$AWS_REGION" \
     "$ZONES" \
     "$INSTANCE_TYPE" \
     "$K8S_VERSION_EKSCTL" \
     "$CLUSTER_FILE" \
     "$KUBECONFIG" \
-    "${BASE_DIR}/eksctl/patch.yaml" \
-    "$EKSCTL_ADMIN_ROLE" \
     "$WINDOWS" \
-    "${BASE_DIR}/eksctl/vpc-resource-controller-configmap.yaml"
+    "${BASE_DIR}/eksctl/vpc-resource-controller-configmap.yaml" \
+    "${BASE_DIR}/eksctl/cluster.yaml"
 else
   echo "Cluster type ${CLUSTER_TYPE} is invalid, must be kops or eksctl" >&2
   exit 1
+fi
+
+if [[ "$WINDOWS" == true ]]; then
+  kubectl apply --kubeconfig "${KUBECONFIG}" -f "${BASE_DIR}/eksctl/vpc-resource-controller-configmap.yaml"
 fi

--- a/hack/e2e/eksctl/cluster.yaml
+++ b/hack/e2e/eksctl/cluster.yaml
@@ -1,0 +1,33 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: {{ .Env.CLUSTER_NAME }}
+  region: {{ .Env.REGION }}
+  version: "{{ .Env.K8S_VERSION }}"
+availabilityZones: [{{ .Env.ZONES }}]
+iam:
+  vpcResourceControllerPolicy: true
+  withOIDC: true
+  serviceAccounts:
+    - metadata:
+        name: ebs-csi-controller-sa
+        namespace: kube-system
+      wellKnownPolicies:
+        ebsCSIController: true
+managedNodeGroups:
+  - name: ng-linux
+    amiFamily: AmazonLinux2
+    desiredCapacity: 3
+    disablePodIMDS: true
+    instanceTypes: [{{ .Env.INSTANCE_TYPE }}]
+    ssh:
+      allow: false
+{{- if eq .Env.WINDOWS "true" }}
+  - name: ng-windows
+    amiFamily: WindowsServer2022CoreContainer
+    desiredCapacity: 3
+    disablePodIMDS: true
+    instanceTypes: [m5.2xlarge]
+    ssh:
+      allow: false
+{{- end }}

--- a/hack/e2e/eksctl/eksctl.sh
+++ b/hack/e2e/eksctl/eksctl.sh
@@ -22,68 +22,40 @@ set -euo pipefail
 function eksctl_create_cluster() {
   CLUSTER_NAME=${1}
   EKSCTL_BIN=${2}
-  ZONES=${3}
-  INSTANCE_TYPE=${4}
-  K8S_VERSION=${5}
-  CLUSTER_FILE=${6}
-  KUBECONFIG=${7}
-  EKSCTL_PATCH_FILE=${8}
-  EKSCTL_ADMIN_ROLE=${9}
+  GOMPLATE_BIN=${3}
+  REGION=${4}
+  ZONES=${5}
+  INSTANCE_TYPE=${6}
+  K8S_VERSION=${7}
+  CLUSTER_FILE=${8}
+  KUBECONFIG=${9}
   WINDOWS=${10}
   VPC_CONFIGMAP_FILE=${11}
+  TEMPLATE_FILE=${12}
 
   CLUSTER_NAME="${CLUSTER_NAME//./-}"
+
+  loudecho "Templating $CLUSTER_NAME to $CLUSTER_FILE"
+  CLUSTER_NAME="${CLUSTER_NAME}" \
+    REGION="${REGION}" \
+    K8S_VERSION="${K8S_VERSION}" \
+    ZONES="${ZONES}" \
+    INSTANCE_TYPE="${INSTANCE_TYPE}" \
+    WINDOWS="${WINDOWS}" \
+    ${GOMPLATE_BIN} -f "${TEMPLATE_FILE}" -o "${CLUSTER_FILE}"
 
   if eksctl_cluster_exists "${CLUSTER_NAME}" "${EKSCTL_BIN}"; then
     loudecho "Upgrading cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${EKSCTL_BIN} upgrade cluster -f "${CLUSTER_FILE}"
   else
-    loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE (dry run)"
-    ${EKSCTL_BIN} create cluster \
-      --managed \
-      --ssh-access=false \
-      --zones "${ZONES}" \
-      --nodes=3 \
-      --instance-types="${INSTANCE_TYPE}" \
-      --version="${K8S_VERSION}" \
-      --disable-pod-imds \
-      --dry-run \
-      "${CLUSTER_NAME}" >"${CLUSTER_FILE}"
-
-    if test -f "$EKSCTL_PATCH_FILE"; then
-      eksctl_patch_cluster_file "$CLUSTER_FILE" "$EKSCTL_PATCH_FILE"
-    fi
-
     loudecho "Creating cluster $CLUSTER_NAME with $CLUSTER_FILE"
     ${EKSCTL_BIN} create cluster -f "${CLUSTER_FILE}" --kubeconfig "${KUBECONFIG}"
   fi
 
-  loudecho "Cluster ${CLUSTER_NAME} kubecfg written to ${KUBECONFIG}"
-  loudecho "Getting cluster ${CLUSTER_NAME}"
-  ${EKSCTL_BIN} get cluster "${CLUSTER_NAME}"
-
-  if [[ -n "$EKSCTL_ADMIN_ROLE" ]]; then
-    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-    ADMIN_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:role/${EKSCTL_ADMIN_ROLE}"
-    loudecho "Granting ${ADMIN_ARN} admin access to the cluster"
-    ${EKSCTL_BIN} create iamidentitymapping --cluster "${CLUSTER_NAME}" --arn "${ADMIN_ARN}" --group system:masters --username admin
-  fi
-
   if [[ "$WINDOWS" == true ]]; then
-    ${EKSCTL_BIN} create nodegroup \
-      --managed=true \
-      --ssh-access=false \
-      --cluster="${CLUSTER_NAME}" \
-      --node-ami-family=WindowsServer2022CoreContainer \
-      --instance-types=m5.2xlarge \
-      -n ng-windows \
-      -m 3 \
-      -M 3
-
-    kubectl apply --kubeconfig "${KUBECONFIG}" -f "$VPC_CONFIGMAP_FILE"
+    loudecho "Applying VPC ConfigMap (Windows only)"
+    kubectl apply --kubeconfig "${KUBECONFIG}" -f "${VPC_CONFIGMAP_FILE}"
   fi
-
-  return $?
 }
 
 function eksctl_cluster_exists() {
@@ -107,24 +79,4 @@ function eksctl_delete_cluster() {
 
   loudecho "Deleting cluster ${CLUSTER_NAME}"
   ${EKSCTL_BIN} delete cluster "${CLUSTER_NAME}"
-}
-
-function eksctl_patch_cluster_file() {
-  CLUSTER_FILE=${1}      # input must be yaml
-  EKSCTL_PATCH_FILE=${2} # input must be yaml
-
-  loudecho "Patching cluster $CLUSTER_NAME with $EKSCTL_PATCH_FILE"
-
-  # Temporary intermediate files for patching
-  CLUSTER_FILE_0=$CLUSTER_FILE.0
-  CLUSTER_FILE_1=$CLUSTER_FILE.1
-
-  cp "$CLUSTER_FILE" "$CLUSTER_FILE_0"
-
-  # Patch only the Cluster
-  kubectl patch --kubeconfig "/dev/null" -f "$CLUSTER_FILE_0" --local --type merge --patch "$(cat "$EKSCTL_PATCH_FILE")" -o yaml >"$CLUSTER_FILE_1"
-  mv "$CLUSTER_FILE_1" "$CLUSTER_FILE_0"
-
-  # Done patching, overwrite original CLUSTER_FILE
-  mv "$CLUSTER_FILE_0" "$CLUSTER_FILE" # output is yaml
 }

--- a/hack/e2e/eksctl/patch.yaml
+++ b/hack/e2e/eksctl/patch.yaml
@@ -1,9 +1,0 @@
-iam:
-  vpcResourceControllerPolicy: true
-  withOIDC: true
-  serviceAccounts:
-    - metadata:
-        name: ebs-csi-controller-sa
-        namespace: kube-system
-      wellKnownPolicies:
-        ebsCSIController: true

--- a/hack/e2e/kubeconfig.sh
+++ b/hack/e2e/kubeconfig.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script echos the KUBECONFIG back to the caller
+# CLUSTER_NAME and CLUSTER_TYPE are expected to be specified by the caller
+
+set -euo pipefail
+
+BASE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+KUBECONFIG="${BASE_DIR}/csi-test-artifacts/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig"
+
+echo "# Makefiles cannot export environment variables directly"
+echo "# Run eval \"\$(make cluster/kubeconfig)\""
+echo "export KUBECONFIG=\"${KUBECONFIG}\""

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script builds and deploys the EBS CSI Driver and runs e2e tests
+# This script deploys the EBS CSI Driver and runs e2e tests
 # CLUSTER_NAME and CLUSTER_TYPE are expected to be specified by the caller
 # All other environment variables have default values (see config.sh) but
 # many can be overridden on demand if needed
@@ -26,7 +26,6 @@ BIN="${BASE_DIR}/../../bin"
 
 source "${BASE_DIR}/config.sh"
 source "${BASE_DIR}/util.sh"
-source "${BASE_DIR}/ecr.sh"
 source "${BASE_DIR}/metrics/metrics.sh"
 
 ## Setup
@@ -47,21 +46,6 @@ if [[ "$WINDOWS" == true ]]; then
 else
   NODE_OS_DISTRO="linux"
 fi
-
-## Build image
-
-if [[ "${CREATE_MISSING_ECR_REPO}" == true ]]; then
-  REPO_CHECK=$(aws ecr describe-repositories --region "${AWS_REGION}")
-  if [ $(jq '.repositories | map(.repositoryName) | index("aws-ebs-csi-driver")' <<<"${REPO_CHECK}") == "null" ]; then
-    aws ecr create-repository --region "${AWS_REGION}" --repository-name aws-ebs-csi-driver >/dev/null
-  fi
-fi
-
-ecr_build_and_push "${AWS_REGION}" \
-  "${AWS_ACCOUNT_ID}" \
-  "${IMAGE_NAME}" \
-  "${IMAGE_TAG}" \
-  "${IMAGE_ARCH}"
 
 ## Deploy
 

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -76,6 +76,10 @@ make cluster/create &
 PIDS[1]=$!
 make cluster/image &
 PIDS[2]=$!
+# Installing kubetest2 takes surprisingly long and blocks make e2e/${TEST}
+# Thus, to speed up CI, preinstall it while creating the cluster/image
+make bin/kubetest2 &
+PIDS[3]=$!
 
 for PID in "${PIDS[@]}"; do
   wait $PID || E2E_PASSED=1

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -61,7 +61,7 @@ test-helm-chart)
   ;;
 esac
 
-export CLUSTER_NAME="ebs-csi-e2e-${RANDOM}.k8s.local"
+export CLUSTER_NAME="e2e-${BUILD_ID:-${RANDOM}}.k8s.local"
 # Use S3 bucket created for CI
 export KOPS_BUCKET=${KOPS_BUCKET:-"k8s-kops-csi-shared-e2e"}
 # Always use us-west-2 in CI, no matter where the local client is

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -17,6 +17,10 @@
 # This script runs tests in CI by creating a cluster, running the tests,
 # cleaning up (regardless of test success/failure), and passing out the result
 
+# Prevent race conditions by frontloading tool download
+# TODO: Find a way to lock pip installs to prevent pip concurrency bugs from hurting us
+make bin/aws
+
 case ${1} in
 test-e2e-single-az)
   TEST="single-az"
@@ -29,7 +33,8 @@ test-e2e-external)
   TEST="external"
   ;;
 test-e2e-external-arm64)
-  TEST="external-arm64"
+  TEST="external"
+  export IMAGE_ARCH="arm64"
   export INSTANCE_TYPE="m7g.medium"
   export AMI_PARAMETER="/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
   ;;
@@ -67,11 +72,18 @@ export KOPS_BUCKET=${KOPS_BUCKET:-"k8s-kops-csi-shared-e2e"}
 # Always use us-west-2 in CI, no matter where the local client is
 export AWS_REGION=us-west-2
 
-if make cluster/create; then
+make cluster/create &
+PIDS[1]=$!
+make cluster/image &
+PIDS[2]=$!
+
+for PID in "${PIDS[@]}"; do
+  wait $PID || E2E_PASSED=1
+done
+
+if [[ $E2E_PASSED -eq 0 ]]; then
   make e2e/${TEST}
   E2E_PASSED=$?
-else
-  E2E_PASSED=1
 fi
 make cluster/delete
 

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -26,6 +26,8 @@ EKSCTL_VERSION="v0.175.0"
 GINKGO_VERSION="v2.17.1"
 # https://github.com/golangci/golangci-lint
 GOLANGCI_LINT_VERSION="v1.57.2"
+# https://github.com/hairyhenderson/gomplate
+GOMPLATE_VERSION="v3.11.7"
 # https://github.com/helm/helm
 HELM_VERSION="v3.14.4"
 # https://github.com/kubernetes/kops
@@ -122,6 +124,14 @@ function install_golangci-lint() {
 
   # golangci-lint recommends against installing with `go install`: https://golangci-lint.run/usage/install/#install-from-source
   install_tar_binary "${INSTALL_PATH}" "https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION:1}-${OS}-${ARCH}.tar.gz" "golangci-lint-${GOLANGCI_LINT_VERSION:1}-${OS}-${ARCH}/golangci-lint"
+}
+
+function install_gomplate() {
+  INSTALL_PATH="${1}"
+
+  # gomplate includes library from no longer existing domain inet.af, and thus cannot be installed via go install
+  # install the released binary from GitHub releases instead
+  install_binary "${INSTALL_PATH}" "https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_${OS}-${ARCH}" "gomplate"
 }
 
 function install_helm() {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"New Feature"

**What is this PR about? / Why do we need it?**

This PR is split into several much smaller commits:

<ins>Move WINDOWS and WINDOWS_HOSTPROCESS out of Makefile to correct location in config.sh</ins>
Small fix to remove unnecessary variables in the `Makefile`.

<ins>Use Prow BUILD_ID in CI jobs if present to greatly reduce the chance of cluster name collisions in CI</ins>
Prow jobs have a random chance of colliding because `$RANDOM` is only a 4 digit number (You'd think it's 1/10000 but it's much higher than that because of the [Birthday Paradox](https://en.wikipedia.org/wiki/Birthday_problem)).

Use `$BUILD_ID` in CI which is guaranteed to be unique. Had to cut off a little bit of the beginning of the name to make it short enough for `eksctl`.

<ins>Add make cluster/kubeconfig</ins>
Convenience command for local development, used to set the `KUBECONFIG` for the cluster created by `make cluster/create`.

<ins>Add make cluster/image command; Build image and cluster in parallel for CI</ins>
Parallelize building the image and creating the cluster on CI, had to split image build out into a separate command to do this.

**Breaking change for contributors:** `make cluster/e2e` style commands no longer build the image, you must either run `make cluster/image` first or bring your own image.

<ins>Template eksctl cluster file so Windows nodegroup can build in parallel</ins>
Parallelize creating the Linux and Windows nodegroup for `eksctl` clusters by using a cluster file instead of `eksctl` commands.

<ins>Parallelize kubetest2 installation in CI</ins>
`kubetest2` takes surprisingly long to install, might as well do so while building the cluster/image already.


**What testing is done?** 
CI/Manual
