### PR TITLE
Tune batcher EC2 Describe* delays

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -151,6 +151,7 @@ const (
 	snapshotTagBatcher
 
 	batchDescribeTimeout = 30 * time.Second
+	batchMaxDelay        = 500 * time.Millisecond // Minimizes RPC latency and EC2 API calls. Tuned via scalability tests.
 )
 
 var (
@@ -355,24 +356,26 @@ func newEC2Cloud(region string, awsSdkDebugLog bool, userAgentExtra string, batc
 }
 
 // newBatcherManager initializes a new instance of batcherManager.
+// Each batcher's `entries` set to maximum results returned by relevant EC2 API call without pagination.
+// Each batcher's `delay` minimizes RPC latency and EC2 API calls. Tuned via scalability tests.
 func newBatcherManager(svc EC2API) *batcherManager {
 	return &batcherManager{
-		volumeIDBatcher: batcher.New(500, 1*time.Second, func(ids []string) (map[string]*types.Volume, error) {
+		volumeIDBatcher: batcher.New(500, batchMaxDelay, func(ids []string) (map[string]*types.Volume, error) {
 			return execBatchDescribeVolumes(svc, ids, volumeIDBatcher)
 		}),
-		volumeTagBatcher: batcher.New(500, 1*time.Second, func(names []string) (map[string]*types.Volume, error) {
+		volumeTagBatcher: batcher.New(500, batchMaxDelay, func(names []string) (map[string]*types.Volume, error) {
 			return execBatchDescribeVolumes(svc, names, volumeTagBatcher)
 		}),
-		instanceIDBatcher: batcher.New(50, 300*time.Millisecond, func(ids []string) (map[string]*types.Instance, error) {
+		instanceIDBatcher: batcher.New(50, batchMaxDelay, func(ids []string) (map[string]*types.Instance, error) {
 			return execBatchDescribeInstances(svc, ids)
 		}),
-		snapshotIDBatcher: batcher.New(1000, 300*time.Millisecond, func(ids []string) (map[string]*types.Snapshot, error) {
+		snapshotIDBatcher: batcher.New(1000, batchMaxDelay, func(ids []string) (map[string]*types.Snapshot, error) {
 			return execBatchDescribeSnapshots(svc, ids, snapshotIDBatcher)
 		}),
-		snapshotTagBatcher: batcher.New(1000, 300*time.Millisecond, func(names []string) (map[string]*types.Snapshot, error) {
+		snapshotTagBatcher: batcher.New(1000, batchMaxDelay, func(names []string) (map[string]*types.Snapshot, error) {
 			return execBatchDescribeSnapshots(svc, names, snapshotTagBatcher)
 		}),
-		volumeModificationIDBatcher: batcher.New(500, 300*time.Millisecond, func(names []string) (map[string]*types.VolumeModification, error) {
+		volumeModificationIDBatcher: batcher.New(500, batchMaxDelay, func(names []string) (map[string]*types.VolumeModification, error) {
 			return execBatchDescribeVolumesModifications(svc, names)
 		}),
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Improvement

**What is this PR about? / Why do we need it?**
Given that no throttling is observed for DescribeVolumes with 7k volume scalability tests, we reduced the current 1 second max batch delay to 500ms, and set that as the standard batcher delay. 

This PR makes sure each RPC takes ~0.25s of batch latency per EC2 Describe call on average (and worst case extra delay of 0.5s).  

This PR also makes sure each batcher will execute twice per second. In the rare case that each batcher is executing at once, the combined 12 requests per second is under the default [EC2 Non-Mutating Action Bucket Refill Rate](https://docs.aws.amazon.com/ec2/latest/devguide/ec2-api-throttling.html) of 20.

**What testing is done?** 
Scalability tests with batcher delays of 1, 0.5, 0.3, and 0.2 seconds for DescribeVolumes and DescribeInstances. 

Final 5000 pod scalability test on default limits account.

|               API | Count |   OK | Client Error | Throttled |
|--|--|--|--|--|
|      CreateVolume |  5676 | 5030 |            0 |       646 |
|      DeleteVolume |  5563 | 4999 |            2 |       562 |
|      AttachVolume |  5646 | 4989 |            0 |       657 |
|      DetachVolume |  5747 | 4996 |          101 |       650 |
|   DescribeVolumes |  4482 | 4482 |            0 |         0 |
| DescribeInstances |  3760 | 3760 |            0 |         0 |

