### PR TITLE
Make scrape interval configurable

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -3,7 +3,6 @@
 * Bump driver version to `v1.30.0`
 * Update voluemessnapshotcontents/status RBAC ([#1991](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1991), [@AndrewSirenko](https://github.com/AndrewSirenko))
 * Upgrade dependencies ([#2016](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2016), [@torredil](https://github.com/torredil))
-* Add scrape interval ([#2034](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2034), [@omerap12][https://github.com/omerap12])
 
 ## v2.29.1
 * Bump driver version to `v1.29.1`

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bump driver version to `v1.30.0`
 * Update voluemessnapshotcontents/status RBAC ([#1991](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/1991), [@AndrewSirenko](https://github.com/AndrewSirenko))
 * Upgrade dependencies ([#2016](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2016), [@torredil](https://github.com/torredil))
+* Add scrape interval ([#2034](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2034), [@omerap12][https://github.com/omerap12])
 
 ## v2.29.1
 * Bump driver version to `v1.29.1`

--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -37,6 +37,6 @@ spec:
   endpoints:
     - targetPort: 3301
       path: /metrics
-      interval: 15s
+      interval: {{ .Values.controller.serviceMonitor.interval | default "15s"}}
 {{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -229,6 +229,7 @@ controller:
     # Additional labels for ServiceMonitor object
     labels:
       release: prometheus
+    interval: "15s"
   # If set to true, AWS API call metrics will be exported to the following
   # TCP endpoint: "0.0.0.0:3301"
   # ---


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Added an option to configure the interval rate.

**What is this PR about? / Why do we need it?**
Fixes: #2004 

**What testing is done?** 
helm template. using this values.yaml :
```shell
  enableMetrics: true
  serviceMonitor:
    # Enables the ServiceMonitor resource even if the prometheus-operator CRDs are not installed
    forceEnable: true
    # Additional labels for ServiceMonitor object
    labels:
      release: prometheus
    interval: "30s"
```

will get:
```shell
# Source: aws-ebs-csi-driver/templates/metrics.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: ebs-csi-controller
  namespace: default
  labels:
    app: ebs-csi-controller
    release: prometheus
spec:
  selector:
    matchLabels:
      app: ebs-csi-controller
  namespaceSelector:
    matchNames:
      - default
  endpoints:
    - targetPort: 3301
      path: /metrics
      interval: 30s
```

Default was set to 15 sec