### PR TITLE
Sanitize CSI RPC request logs

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -77,7 +77,7 @@ func NewControllerService(c cloud.Cloud, o *Options) *ControllerService {
 }
 
 func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	klog.V(4).InfoS("CreateVolume: called", "args", *req)
+	klog.V(4).InfoS("CreateVolume: called", "args", util.SanitizeRequest(req))
 	if err := validateCreateVolumeRequest(req); err != nil {
 		return nil, err
 	}
@@ -366,7 +366,7 @@ func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {
 }
 
 func (d *ControllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	klog.V(4).InfoS("DeleteVolume: called", "args", *req)
+	klog.V(4).InfoS("DeleteVolume: called", "args", util.SanitizeRequest(req))
 	if err := validateDeleteVolumeRequest(req); err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func validateDeleteVolumeRequest(req *csi.DeleteVolumeRequest) error {
 }
 
 func (d *ControllerService) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	klog.V(4).InfoS("ControllerPublishVolume: called", "args", *req)
+	klog.V(4).InfoS("ControllerPublishVolume: called", "args", util.SanitizeRequest(req))
 	if err := validateControllerPublishVolumeRequest(req); err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func validateControllerPublishVolumeRequest(req *csi.ControllerPublishVolumeRequ
 }
 
 func (d *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	klog.V(4).InfoS("ControllerUnpublishVolume: called", "args", *req)
+	klog.V(4).InfoS("ControllerUnpublishVolume: called", "args", util.SanitizeRequest(req))
 
 	if err := validateControllerUnpublishVolumeRequest(req); err != nil {
 		return nil, err
@@ -541,7 +541,7 @@ func (d *ControllerService) ValidateVolumeCapabilities(ctx context.Context, req 
 }
 
 func (d *ControllerService) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	klog.V(4).InfoS("ControllerExpandVolume: called", "args", *req)
+	klog.V(4).InfoS("ControllerExpandVolume: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -579,7 +579,7 @@ func (d *ControllerService) ControllerExpandVolume(ctx context.Context, req *csi
 }
 
 func (d *ControllerService) ControllerModifyVolume(ctx context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
-	klog.V(4).InfoS("ControllerModifyVolume: called", "args", *req)
+	klog.V(4).InfoS("ControllerModifyVolume: called", "args", util.SanitizeRequest(req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -660,7 +660,7 @@ func isValidVolumeContext(volContext map[string]string) bool {
 }
 
 func (d *ControllerService) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
-	klog.V(4).InfoS("CreateSnapshot: called", "args", req)
+	klog.V(4).InfoS("CreateSnapshot: called", "args", util.SanitizeRequest(req))
 	if err := validateCreateSnapshotRequest(req); err != nil {
 		return nil, err
 	}
@@ -789,7 +789,7 @@ func validateCreateSnapshotRequest(req *csi.CreateSnapshotRequest) error {
 }
 
 func (d *ControllerService) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
-	klog.V(4).InfoS("DeleteSnapshot: called", "args", req)
+	klog.V(4).InfoS("DeleteSnapshot: called", "args", util.SanitizeRequest(req))
 	if err := validateDeleteSnapshotRequest(req); err != nil {
 		return nil, err
 	}
@@ -822,7 +822,7 @@ func validateDeleteSnapshotRequest(req *csi.DeleteSnapshotRequest) error {
 }
 
 func (d *ControllerService) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
-	klog.V(4).InfoS("ListSnapshots: called", "args", req)
+	klog.V(4).InfoS("ListSnapshots: called", "args", util.SanitizeRequest(req))
 	var snapshots []*cloud.Snapshot
 
 	snapshotID := req.GetSnapshotId()

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -113,7 +113,7 @@ func NewNodeService(o *Options, md metadata.MetadataService, m mounter.Mounter, 
 }
 
 func (d *NodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	klog.V(4).InfoS("NodeStageVolume: called", "args", *req)
+	klog.V(4).InfoS("NodeStageVolume: called", "args", util.SanitizeRequest(req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -349,7 +349,7 @@ func (d *NodeService) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 }
 
 func (d *NodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	klog.V(4).InfoS("NodeExpandVolume: called", "args", *req)
+	klog.V(4).InfoS("NodeExpandVolume: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -413,7 +413,7 @@ func (d *NodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 }
 
 func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	klog.V(4).InfoS("NodePublishVolume: called", "args", *req)
+	klog.V(4).InfoS("NodePublishVolume: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")
@@ -466,7 +466,7 @@ func (d *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 }
 
 func (d *NodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	klog.V(4).InfoS("NodeUnpublishVolume: called", "args", *req)
+	klog.V(4).InfoS("NodeUnpublishVolume: called", "args", util.SanitizeRequest(req))
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID not provided")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -143,4 +144,21 @@ func NormalizeWindowsPath(path string) string {
 		normalizedPath = "c:" + normalizedPath
 	}
 	return normalizedPath
+}
+
+// SanitizeRequest takes a request object and returns a copy of the request with
+// the "Secrets" field cleared.
+func SanitizeRequest(req interface{}) interface{} {
+	v := reflect.ValueOf(&req).Elem()
+	e := reflect.New(v.Elem().Type()).Elem()
+
+	e.Set(v.Elem())
+
+	f := reflect.Indirect(e).FieldByName("Secrets")
+
+	if f.IsValid() && f.CanSet() && f.Kind() == reflect.Map {
+		f.Set(reflect.MakeMap(f.Type()))
+		v.Set(e)
+	}
+	return req
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -184,3 +184,40 @@ func TestIsAlphanumeric(t *testing.T) {
 		})
 	}
 }
+
+type TestRequest struct {
+	Name    string
+	Secrets map[string]string
+}
+
+func TestSanitizeRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      interface{}
+		expected interface{}
+	}{
+		{
+			name: "Request with Secrets",
+			req: &TestRequest{
+				Name: "Test",
+				Secrets: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expected: &TestRequest{
+				Name:    "Test",
+				Secrets: map[string]string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeRequest(tt.req)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SanitizeRequest() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Security enhancement

**What is this PR about? / Why do we need it?**

The EBS CSI Driver does not support [Token Requests](https://kubernetes-csi.github.io/docs/token-requests.html) , however - out of an abundance of caution - this PR addresses the potential vulnerability of sensitive information being logged inadvertently.

The main change is adding a new utility function `SanitizeRequest` that takes a request object and returns a copy of the request with the "Secrets" field cleared. This function creates a new instance of the same type as the input request, copies all the fields from the original request to the new instance, and sets the "Secrets" field to an empty map if it exists.

**What testing is done?** 

- `make verify && make test`
- CI 
- manual testing
