### PR TITLE
Address GO-2024-2824

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,4 +187,4 @@ replace (
 	vbom.ml/util => github.com/fvbommel/util v0.0.2 // Mitigate https://github.com/fvbommel/util/issues/6
 )
 
-go 1.22.2
+go 1.22.3


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

CVE Fix

**What is this PR about? / Why do we need it?**

```
Vulnerability #1: GO-2024-2824
    Malformed DNS message can cause infinite loop in net
  More info: https://pkg.go.dev/vuln/GO-2024-2824
  Standard library
    Found in: net@go1.22.2
    Fixed in: net@go1.22.3
    Example traces found:
Error:       #1: tests/e2e/testsuites/testsuites.go:752:78: testsuites.podLogs calls rest.Request.Do, which eventually calls net.Dialer.DialContext
Error:       #2: pkg/driver/driver.go:99:29: driver.Driver.Run calls net.Listen
Error:       #3: pkg/cloud/cloud.go:331:38: cloud.newEC2Cloud calls config.LoadDefaultConfig, which eventually calls net.LookupHost
Error:       #4: tests/e2e/format_options.go:33:17: e2e.init calls ginkgo.Describe, which eventually calls net.Resolver.LookupHost
Error:       #5: tests/e2e/format_options.go:33:17: e2e.init calls ginkgo.Describe, which eventually calls net.Resolver.LookupSRV
Error:       #6: tests/e2e/format_options.go:33:17: e2e.init calls ginkgo.Describe, which eventually calls net.Resolver.LookupTXT
```
**What testing is done?** 

```
make verify && make test
```
