### PR TITLE
Add `defaultStorageClass` parameter

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/ebs-csi-default-sc.yaml
+++ b/charts/aws-ebs-csi-driver/templates/ebs-csi-default-sc.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.defaultStorageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-csi-default-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -447,6 +447,9 @@ storageClasses: []
 #   parameters:
 #     encrypted: "true"
 
+defaultStorageClass:
+  enabled: false
+
 volumeSnapshotClasses: []
 # Add VolumeSnapshotClass resources like:
 # - name: ebs-vsc


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Helm parameter

**What is this PR about? / Why do we need it?**

This PR introduces a new Helm parameter: `defaultStorageClass` which deploys a default StorageClass object.

When the `defaultStorageClass.enabled` parameter is set to `true` (disabled by default), either in the `values.yaml` file or as a CLI argument during installation or upgrade, the following default StorageClass is deployed:

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-csi-default-sc
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
allowVolumeExpansion: true
```

**What testing is done?** 

`make test && make verify`

```
helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --values ./charts/aws-ebs-csi-driver/values.yaml --set defaultStorageClass.enabled=true
```

```
kubectl get sc --all-namespaces                                                                                                                  
NAME                 PROVISIONER       RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
ebs-csi-default-sc (default)  ebs.csi.aws.com   Delete          WaitForFirstConsumer   true                   4s
```
