### PR TITLE
Use {{ .Release.Namespace }} in ClusterRoleBinding subject namespace

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -136,7 +136,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ebs-csi-driver-test
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ebs-csi-driver-test


### PR DESCRIPTION
Is this a bug fix or adding new feature?
Bug fix

What is this PR about? / Why do we need it?
PR is about making subject namespace in ClusterRoleBinding generated based on the namespace release is being deployed to.

With previous hardcoded value of kube-system the test was failing because ServiceAccount didn't have proper permissions assigned, if it was deployed to different namespace than kube-system.

What testing is done?
It was deployed into test cluster and ended up with successful execution after deploying to custom namespace.