### PR TITLE
Add terminationGracePeriodSeconds as a helm parameter

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -40,6 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
+      terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriodSeconds }}
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -44,6 +44,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ .Values.node.serviceAccount.name }}
+      terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriodSeconds }}
       priorityClassName: {{ .Values.node.priorityClassName | default "system-node-critical" }}
       tolerations:
         {{- if .Values.node.tolerateAllTaints }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -358,8 +358,8 @@ node:
   daemonSetAnnotations: {}
   podAnnotations: {}
   podLabels: {}
-  tolerateAllTaints: true
   terminationGracePeriodSeconds: 30
+  tolerateAllTaints: true
   tolerations:
   - operator: Exists
     effect: NoExecute

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -359,6 +359,7 @@ node:
   podAnnotations: {}
   podLabels: {}
   tolerateAllTaints: true
+  terminationGracePeriodSeconds: 30
   tolerations:
   - operator: Exists
     effect: NoExecute

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -42,6 +42,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: ebs-csi-node-sa
+      terminationGracePeriodSeconds: 30
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists


### PR DESCRIPTION
Is this a bug fix or adding new feature?

This is adding a new feature.

What is this PR about? / Why do we need it?

This PR gives the customer the ability to change their EBS CSI Node Pod termination grace period.  

What testing is done?

I ran helm locally on my dev cluster with a 

--set node.terminationGracePeriodSeconds=34

and with no terminationGracePeriodSecounds parameter and could see that with no parameter terminationGracePeriodSecounds was set to 30 on my pods and with the 
--set node.terminationGracePeriodSeconds=34 i could see that terminationGracePeriodSeconds on my pod was 34 seconds 


![Screenshot 2024-06-11 at 11 40 41 AM](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/assets/118852979/a5044865-53b6-48fb-8f60-c45f2d93daac)

![Screenshot 2024-06-11 at 9 46 25 AM](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/assets/118852979/3e17219c-2d88-4b39-a367-0083f1965aa9)

