### PR TITLE
Set RuntimeDefault as default seccompProfile in securityContext

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -37,6 +37,8 @@ sidecars:
       # renewDeadline: "10s"
       # retryPeriod: "5s"
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
   attacher:
@@ -62,6 +64,8 @@ sidecars:
     additionalClusterRoleRules: []
     resources: {}
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
   snapshotter:
@@ -79,6 +83,8 @@ sidecars:
     additionalClusterRoleRules: []
     resources: {}
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
   livenessProbe:
@@ -115,6 +121,8 @@ sidecars:
     additionalClusterRoleRules: []
     resources: {}
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
   nodeDriverRegistrar:
@@ -158,6 +166,8 @@ sidecars:
     additionalArgs: []
     resources: {}
     securityContext:
+      seccompProfile:
+        type: RuntimeDefault
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
 
@@ -311,6 +321,8 @@ controller:
   # ---
   # securityContext on the controller container (see sidecars for securityContext on sidecar containers)
   containerSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
   initContainers: []
@@ -417,6 +429,7 @@ node:
   #   mountPath: /mount/path
   # ---
   # securityContext on the node container (see sidecars for securityContext on sidecar containers)
+  # Privileged containers always run as `Unconfined`, which means that they are not restricted by a seccomp profile.
   containerSecurityContext:
     readOnlyRootFilesystem: true
     privileged: true

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -128,6 +128,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
         - name: csi-provisioner
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v4.0.1-eks-1-30-4
           imagePullPolicy: IfNotPresent
@@ -157,6 +159,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
         - name: csi-attacher
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.5.1-eks-1-30-4
           imagePullPolicy: IfNotPresent
@@ -183,6 +187,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
         - name: csi-snapshotter
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-snapshotter/csi-snapshotter:v7.0.2-eks-1-30-4
           imagePullPolicy: IfNotPresent
@@ -208,6 +214,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
         - name: csi-resizer
           image: public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.10.1-eks-1-30-4
           imagePullPolicy: IfNotPresent
@@ -235,6 +243,8 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
         - name: liveness-probe
           image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.12.0-eks-1-30-4
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Helm parameter

**What is this PR about? / Why do we need it?**

**Note to reviewers:** `seccompProfile` has now been set to `RuntimeDefault`, which uses the default seccomp profile provided by the container runtime. This helps to restrict the system calls the containers can make, enhancing security. Do note that this changes the current default (unspecified, thus `Unconfined`):

```
const (
	// SeccompProfileTypeUnconfined is when no seccomp profile is applied (A.K.A. unconfined).
	SeccompProfileTypeUnconfined SeccompProfileType = "Unconfined"
	// SeccompProfileTypeRuntimeDefault represents the default container runtime seccomp profile.
	SeccompProfileTypeRuntimeDefault SeccompProfileType = "RuntimeDefault"
	// SeccompProfileTypeLocalhost represents custom made profiles stored on the node's disk.
	SeccompProfileTypeLocalhost SeccompProfileType = "Localhost"
)
```

^ https://github.com/kubernetes/kubernetes/blob/6e8e1f53b09328849f655d38eae9bacbbeb3445e/pkg/apis/core/types.go#L3749C1-L3756C2 

For more information, see https://kubernetes.io/docs/tutorials/security/seccomp/.

closes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1882

**What testing is done?** 

```
make verify && make test 
CI
```