### PR TITLE
Use new client token when `CreateVolume` returns `IdempotentParameterMismatch`

### DIFF
--- a/pkg/cloud/devicemanager/allocator.go
+++ b/pkg/cloud/devicemanager/allocator.go
@@ -59,7 +59,6 @@ func (d *nameAllocator) GetNext(existingNames ExistingNames, likelyBadNames *syn
 	finalResortName := ""
 	likelyBadNames.Range(func(name, _ interface{}) bool {
 		if name, ok := name.(string); ok {
-			fmt.Println(name)
 			if _, existing := existingNames[name]; !existing {
 				finalResortName = name
 				return false

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package devicemanager
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -26,7 +27,7 @@ func TestNameAllocator(t *testing.T) {
 
 	for _, name := range deviceNames {
 		t.Run(name, func(t *testing.T) {
-			actual, err := allocator.GetNext(existingNames, map[string]struct{}{})
+			actual, err := allocator.GetNext(existingNames, new(sync.Map))
 			if err != nil {
 				t.Errorf("test %q: unexpected error: %v", name, err)
 			}
@@ -39,18 +40,24 @@ func TestNameAllocator(t *testing.T) {
 }
 
 func TestNameAllocatorLikelyBadName(t *testing.T) {
-	skippedName := deviceNames[32]
-	existingNames := map[string]string{}
+	skippedNameExisting := deviceNames[11]
+	skippedNameNew := deviceNames[32]
+	likelyBadNames := new(sync.Map)
+	likelyBadNames.Store(skippedNameExisting, struct{}{})
+	likelyBadNames.Store(skippedNameNew, struct{}{})
+	existingNames := map[string]string{
+		skippedNameExisting: "",
+	}
 	allocator := nameAllocator{}
 
 	for _, name := range deviceNames {
-		if name == skippedName {
-			// Name in likelyBadNames should be skipped until it is the last available name
+		if name == skippedNameExisting || name == skippedNameNew {
+			// Names in likelyBadNames should be skipped until it is the last available name
 			continue
 		}
 
 		t.Run(name, func(t *testing.T) {
-			actual, err := allocator.GetNext(existingNames, map[string]struct{}{skippedName: {}})
+			actual, err := allocator.GetNext(existingNames, likelyBadNames)
 			if err != nil {
 				t.Errorf("test %q: unexpected error: %v", name, err)
 			}
@@ -61,9 +68,9 @@ func TestNameAllocatorLikelyBadName(t *testing.T) {
 		})
 	}
 
-	lastName, _ := allocator.GetNext(existingNames, map[string]struct{}{skippedName: {}})
-	if lastName != skippedName {
-		t.Errorf("test %q: expected %q, got %q (likelyBadNames fallback)", skippedName, skippedName, lastName)
+	lastName, _ := allocator.GetNext(existingNames, likelyBadNames)
+	if lastName != skippedNameNew {
+		t.Errorf("test %q: expected %q, got %q (likelyBadNames fallback)", skippedNameNew, skippedNameNew, lastName)
 	}
 }
 
@@ -72,10 +79,10 @@ func TestNameAllocatorError(t *testing.T) {
 	existingNames := map[string]string{}
 
 	for i := 0; i < len(deviceNames); i++ {
-		name, _ := allocator.GetNext(existingNames, map[string]struct{}{})
+		name, _ := allocator.GetNext(existingNames, new(sync.Map))
 		existingNames[name] = ""
 	}
-	name, err := allocator.GetNext(existingNames, map[string]struct{}{})
+	name, err := allocator.GetNext(existingNames, new(sync.Map))
 	if err == nil {
 		t.Errorf("expected error, got device  %q", name)
 	}

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -68,6 +68,13 @@ func TestNameAllocatorLikelyBadName(t *testing.T) {
 		})
 	}
 
+	onlyExisting := new(sync.Map)
+	onlyExisting.Store(skippedNameExisting, struct{}{})
+	_, err := allocator.GetNext(existingNames, onlyExisting)
+	if err != nil {
+		t.Errorf("got nil when error expected (likelyBadNames with only existing names)")
+	}
+
 	lastName, _ := allocator.GetNext(existingNames, likelyBadNames)
 	if lastName != skippedNameNew {
 		t.Errorf("test %q: expected %q, got %q (likelyBadNames fallback)", skippedNameNew, skippedNameNew, lastName)

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -52,7 +52,7 @@ type DeviceManager interface {
 	// NewDevice retrieves the device if the device is already assigned.
 	// Otherwise it creates a new device with next available device name
 	// and mark it as unassigned device.
-	NewDevice(instance *types.Instance, volumeID string, likelyBadNames map[string]struct{}) (device *Device, err error)
+	NewDevice(instance *types.Instance, volumeID string, likelyBadNames *sync.Map) (device *Device, err error)
 
 	// GetDevice returns the device already assigned to the volume.
 	GetDevice(instance *types.Instance, volumeID string) (device *Device, err error)
@@ -103,7 +103,7 @@ func NewDeviceManager() DeviceManager {
 	}
 }
 
-func (d *deviceManager) NewDevice(instance *types.Instance, volumeID string, likelyBadNames map[string]struct{}) (*Device, error) {
+func (d *deviceManager) NewDevice(instance *types.Instance, volumeID string, likelyBadNames *sync.Map) (*Device, error) {
 	d.mux.Lock()
 	defer d.mux.Unlock()
 

--- a/pkg/expiringcache/expiring_cache.go
+++ b/pkg/expiringcache/expiring_cache.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expiringcache
+
+import (
+	"sync"
+	"time"
+)
+
+// ExpiringCache is a thread-safe "time expiring" cache that
+// automatically removes objects that are not accessed for a
+// configurable delay
+//
+// It is used in various places where we need to cache data for an
+// unknown amount of time, to prevent memory leaks
+//
+// From the consumer's perspective, it behaves similarly to a map
+// KeyType is the type of the object that is used as a key
+// ValueType is the type of the object that is stored
+type ExpiringCache[KeyType comparable, ValueType any] interface {
+	// Get operates identically to retrieving from a map, returning
+	// the value and/or boolean indicating if the value existed in the map
+	//
+	// Multiple callers can receive the same value simultaneously from Get,
+	// it is the caller's responsibility to ensure they are not modified
+	Get(key KeyType) (value *ValueType, ok bool)
+	// Set operates identically to setting a value in a map, adding an entry
+	// or overriding the existing value for a given key
+	Set(key KeyType, value *ValueType)
+}
+
+type timedValue[ValueType any] struct {
+	value *ValueType
+	timer *time.Timer
+}
+
+type expiringCache[KeyType comparable, ValueType any] struct {
+	expirationDelay time.Duration
+	values          map[KeyType]timedValue[ValueType]
+	mutex           sync.Mutex
+}
+
+// New returns a new ExpiringCache
+// for a given KeyType, ValueType, and expiration delay
+func New[KeyType comparable, ValueType any](expirationDelay time.Duration) ExpiringCache[KeyType, ValueType] {
+	return &expiringCache[KeyType, ValueType]{
+		expirationDelay: expirationDelay,
+		values:          make(map[KeyType]timedValue[ValueType]),
+	}
+}
+
+func (c *expiringCache[KeyType, ValueType]) Get(key KeyType) (*ValueType, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if v, ok := c.values[key]; ok {
+		v.timer.Reset(c.expirationDelay)
+		return v.value, true
+	} else {
+		return nil, false
+	}
+}
+
+func (c *expiringCache[KeyType, ValueType]) Set(key KeyType, value *ValueType) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if v, ok := c.values[key]; ok {
+		v.timer.Reset(c.expirationDelay)
+		v.value = value
+		c.values[key] = v
+	} else {
+		c.values[key] = timedValue[ValueType]{
+			timer: time.AfterFunc(c.expirationDelay, func() {
+				c.mutex.Lock()
+				defer c.mutex.Unlock()
+
+				delete(c.values, key)
+			}),
+			value: value,
+		}
+	}
+}

--- a/pkg/expiringcache/expiring_cache_test.go
+++ b/pkg/expiringcache/expiring_cache_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package expiringcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testExpiration = time.Millisecond * 50
+	testSleep      = time.Millisecond * 35
+	testKey        = "key"
+)
+
+var (
+	testValue1 = "value"
+	testValue2 = "value2"
+)
+
+func TestExpiringCache(t *testing.T) {
+	t.Parallel()
+
+	cache := New[string, string](testExpiration)
+
+	value, ok := cache.Get(testKey)
+	assert.False(t, ok, "Should not be able to Get() value before Set()ing it")
+	assert.Nil(t, value, "Value should be nil when Get() returns not ok")
+
+	cache.Set(testKey, &testValue1)
+	value, ok = cache.Get(testKey)
+	assert.True(t, ok, "Should be able to Get() after Set()ing it")
+	assert.Equal(t, &testValue1, value, "Should Get() the same value that was Set()")
+
+	cache.Set(testKey, &testValue2)
+	value, ok = cache.Get(testKey)
+	assert.True(t, ok, "Should be able to Get() after Set()ing it (after overwrite)")
+	assert.Equal(t, &testValue2, value, "Should Get() the same value that was Set() (after overwrite)")
+
+	time.Sleep(testSleep)
+	value, ok = cache.Get(testKey)
+	assert.True(t, ok, "Should be able to Get() after sleeping less than the expiration delay")
+	assert.Equal(t, &testValue2, value, "Should Get() the same value that was Set() (after sleep)")
+
+	time.Sleep(testSleep * 2)
+	value, ok = cache.Get(testKey)
+	assert.False(t, ok, "Should not be able to Get() value after it expires")
+	assert.Nil(t, value, "Value should be nil when Get() returns not ok (after expiration)")
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Fixes #1951

**What is this PR about? / Why do we need it?**

If `CreateVolume` fails for any reason (examples: the user provides an invalid KMS key, due to an EBS-side issue, etc), we retry with the same client token. However, despite the fact that the `CreateVolume` call corresponds to a volume that was never created, our client token is burned.

In the scenario where we detect this has occurred, this PR tries again with a different token. However, to prevent volume leaks, the token must follow a predictable pattern. To do this, I append `-2` to the volume id pre-hashing for the token, and if that request fails, I instead append `-3`, `-4`, etc. This is done strictly in order, so a CSI driver that crashes (or restarts for any other reason, such as an upgrade) can consistently reuse the same tokens until it reaches the 'correct' token.

To keep track of which token we have most recently used during runtime, I use an expiring cache, similar to the existing "likely bad names" cache implementation. In order to DRY up the code, the first two commits of this PR migrate that implementation to the `util` package (commit 1) and then migrate the existing `likelyBadNames` implementation to use the `util` version (commit 2). Finally, this PR implements the above described change using this cache (commit 3).

**What testing is done?** 

Added/updated unit tests, CI, manual