### PR TITLE
Add fix for enableLinux node parameter

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -1,5 +1,5 @@
 {{- define "node" }}
-{{- if or (eq (default true .Values.node.enableLinux) true) }}
+{{- if .Values.node.enableLinux }}
 ---
 kind: DaemonSet
 apiVersion: apps/v1


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a bug fix
**What is this PR about? / Why do we need it?**
Previously the parameter enableLinux did not work because it was set to true regardless of what you pass in as a parameter
**What testing is done?** 
I deployed my dev cluster with the change and ran the following command to install the driver with enableLinux set to false

```
helm upgrade \
  --install aws-ebs-csi-driver \
  --namespace kube-system \
  ./charts/aws-ebs-csi-driver \
  --set controller.replicaCount=1 \
  --set image.pullPolicy=Always \
  --set controller.logLevel=7 \
  --set image.repository="533267024531.dkr.ecr.us-west-2.amazonaws.com/aws-ebs-csi-driver"\
  --set image.tag="TEST-ELIJAH-linux-amd64-al2023" \
--set node.enableLinux="false"
```

I then ran ```kubectl -n kube-system get daemonset.apps with the following output```

```
NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
aws-cloud-controller-manager   1         1         1       1            1           <none>          48m
cilium                         4         4         4       4            4           <none>          48m
kops-controller                1         1         1       1            1           <none>          48m
```

Finally i ran the same helm command but with enableLinux set to true and got the following output.

```
helm upgrade \
  --install aws-ebs-csi-driver \
  --namespace kube-system \
  ./charts/aws-ebs-csi-driver \
  --set controller.replicaCount=1 \
  --set image.pullPolicy=Always \
  --set controller.logLevel=7 \
  --set image.repository="533267024531.dkr.ecr.us-west-2.amazonaws.com/aws-ebs-csi-driver"\
  --set image.tag="TEST-ELIJAH-linux-amd64-al2023" \
--set node.enableLinux="true"

 kubectl -n kube-system get daemonset.apps
NAME                           DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
aws-cloud-controller-manager   1         1         1       1            1           <none>                   49m
cilium                         4         4         4       4            4           <none>                   49m
ebs-csi-node                   4         4         4       4            4           kubernetes.io/os=linux   5s
kops-controller                1         1         1       1            1           <none>                   49m



```

Additionally I ran  ```make update && make verify && make test   ```                                                                                                                                                                                                                                                                             