### PR TITLE
Add --kubeconfig flag for out-of-cluster auth

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	switch cmd {
 	case "pre-stop-hook":
-		clientset, clientErr := metadata.DefaultKubernetesAPIClient()
+		clientset, clientErr := metadata.DefaultKubernetesAPIClient(options.Kubeconfig)()
 		if clientErr != nil {
 			klog.ErrorS(err, "unable to communicate with k8s API")
 		} else {
@@ -140,7 +140,7 @@ func main() {
 
 	cfg := metadata.MetadataServiceConfig{
 		EC2MetadataClient: metadata.DefaultEC2MetadataClient,
-		K8sAPIClient:      metadata.DefaultKubernetesAPIClient,
+		K8sAPIClient:      metadata.DefaultKubernetesAPIClient(options.Kubeconfig),
 	}
 
 	region := os.Getenv("AWS_REGION")

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -28,6 +28,10 @@ import (
 type Options struct {
 	Mode Mode
 
+	// Kubeconfig is an absolute path to a kubeconfig file.
+	// If empty, the in-cluster config will be loaded.
+	Kubeconfig string
+
 	// #### Server options ####
 
 	//Endpoint is the endpoint for the CSI driver server
@@ -86,6 +90,8 @@ type Options struct {
 }
 
 func (o *Options) AddFlags(f *flag.FlagSet) {
+	f.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to a kubeconfig file. The default is the emtpy string, which causes the in-cluster config to be used")
+
 	// Server options
 	f.StringVar(&o.Endpoint, "endpoint", DefaultCSIEndpoint, "Endpoint for the CSI driver server")
 	f.StringVar(&o.HttpEndpoint, "http-endpoint", "", "The TCP network address where the HTTP server for metrics will listen (example: `:8080`). The default is empty string, which means the server is disabled.")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

This adds a command-line flag, `--kubeconfig`, that allows an alternative to `rest.InClusterConfig()`.  This is useful when running the CSI driver outside of a Pod.

If `--kubeconfig` is empty, the behavior is unchanged.

**What testing is done?** 

I see the k8s client instantiated successfully:
```
> CSI_NODE_NAME=ip-192-168-69-200.us-west-2.compute.internal bin/aws-ebs-csi-driver --kubeconfig ~/.kube/config

I0704 00:50:11.709966   21408 main.go:157] "Initializing metadata"
I0704 00:50:11.710049   21408 metadata.go:66] "The AWS_EC2_METADATA_DISABLED environment variable disables access to EC2 IMDS" enabled="true"
E0704 00:50:11.710363   21408 metadata.go:51] "Retrieving IMDS metadata failed, falling back to Kubernetes metadata" err="could not get EC2 instance identity metadata: operation error ec2imds: GetInstanceIdentityDocument, access disabled to EC2 IMDS via client option, or \"AWS_EC2_METADATA_DISABLED\" environment variable"
I0704 00:50:12.535331   21408 metadata.go:55] "Retrieved metadata from Kubernetes"
```