### PR TITLE
Modifying Tags On Existing Volume

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -25,15 +25,7 @@
       "Resource": [
         "arn:aws:ec2:*:*:volume/*",
         "arn:aws:ec2:*:*:snapshot/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "ec2:CreateAction": [
-            "CreateVolume",
-            "CreateSnapshot"
-          ]
-        }
-      }
+      ]
     },
     {
       "Effect": "Allow",

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -96,6 +96,36 @@ backup=true
 billingID=ABCDEF
 ```
 
+# Adding, Modifying, and Deleting Tags Of Existing Volumes
+The AWS EBS CSI Driver supports the modifying of tags of existing volumes through `VolumeAttributesClass.parameters` the examples below show the syntax for addition, modification, and deletion of tags within the `VolumeAttributesClass.parameters`. For a walkthrough on how to apply these modifications to a volume follow the [walkthrough for Volume Modification via VolumeAttributeClass](../examples/kubernetes/modify-volume)
+
+**Syntax for Adding or Modifying a Tag**
+
+If a key has the prefix `tagSpecification`, the CSI driver will treat the value as a key-value pair to be added to the existing volume. If there is already an existing tag with the specified key, the CSI driver will overwrite the value of that tag with the new value specified. 
+```
+apiVersion: storage.k8s.io/v1alpha1
+kind: VolumeAttributesClass
+metadata:
+  name: io2-class
+driverName: ebs.csi.aws.com
+parameters:
+  tagSpecification_1: "location=Seattle"
+  tagSpecification_2: "cost-center=" // If the value is left blank, tag is created with an empty value
+```
+**Syntax for Deleting a Tag**
+
+If a key has the prefix `tagDeletion`, the CSI driver will treat the value as a tag key, and the existing tag with that key will be removed from the volume.
+```
+apiVersion: storage.k8s.io/v1alpha1
+kind: VolumeAttributesClass
+metadata:
+  name: io2-class
+driverName: ebs.csi.aws.com
+parameters:
+  tagDeletion_1: "location" // Deletes tag with key "location"
+  tagDeletion_2: "cost-center"
+```
+
 # Snapshot Tagging
 The AWS EBS CSI Driver supports tagging snapshots through `VolumeSnapshotClass.parameters`, similarly to StorageClass tagging.
 

--- a/examples/kubernetes/modify-volume/README.md
+++ b/examples/kubernetes/modify-volume/README.md
@@ -35,21 +35,25 @@ This example will only work on a cluster with the `VolumeAttributesClass` featur
     Mon Feb 26 22:28:39 UTC 2024
     ...
     ```
+4. Deploy the `VolumeAttributesClass`
+    ```sh
+    $ kubectl apply -f manifests/volumeattributesclass.yaml
+    ```
 
-4. Simultaneously, deploy the `VolumeAttributesClass` and edit the `PersistentVolumeClaim` to point to this class
+5. Edit the `PersistentVolumeClaim` to point to this class
     ```sh
     $ kubectl patch pvc ebs-claim --patch '{"spec": {"volumeAttributesClassName": "io2-class"}}'
     persistentvolumeclaim/ebs-claim patched
     ```
 
-5. Wait for the `VolumeAttributesClass` to apply to the volume
+6. Wait for the `VolumeAttributesClass` to apply to the volume
     ```sh
     $ kubectl get pvc ebs-claim
     NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
     ebs-claim   Bound    pvc-076b2d14-b643-47d4-a2ce-fbf9cd36572b   100Gi      RWO            ebs-sc         io2-class               5m54s
     ```
 
-6. (Optional) Delete example resources
+7. (Optional) Delete example resources
     ```sh
     $ kubectl delete -f manifests 
     storageclass.storage.k8s.io "ebs-sc" deleted

--- a/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
+++ b/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
@@ -21,3 +21,5 @@ driverName: ebs.csi.aws.com
 parameters:
   type: io2
   iops: "10000"
+  tagSpecification_1: "location=Seattle"
+  tagSpecification_2: "cost-center="

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -49,15 +49,7 @@ spec:
           "Resource": [
             "arn:aws:ec2:*:*:volume/*",
             "arn:aws:ec2:*:*:snapshot/*"
-          ],
-          "Condition": {
-            "StringEquals": {
-              "ec2:CreateAction": [
-                "CreateVolume",
-                "CreateSnapshot"
-              ]
-            }
-          }
+          ]
         },
         {
           "Effect": "Allow",

--- a/pkg/cloud/ec2_interface.go
+++ b/pkg/cloud/ec2_interface.go
@@ -35,5 +35,6 @@ type EC2API interface {
 	DescribeVolumesModifications(ctx context.Context, params *ec2.DescribeVolumesModificationsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesModificationsOutput, error)
 	DescribeTags(ctx context.Context, params *ec2.DescribeTagsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTagsOutput, error)
 	CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
+	DeleteTags(ctx context.Context, params *ec2.DeleteTagsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error)
 	EnableFastSnapshotRestores(ctx context.Context, params *ec2.EnableFastSnapshotRestoresInput, optFns ...func(*ec2.Options)) (*ec2.EnableFastSnapshotRestoresOutput, error)
 }

--- a/pkg/cloud/interface.go
+++ b/pkg/cloud/interface.go
@@ -26,6 +26,7 @@ type Cloud interface {
 	DeleteDisk(ctx context.Context, volumeID string) (success bool, err error)
 	AttachDisk(ctx context.Context, volumeID string, nodeID string) (devicePath string, err error)
 	DetachDisk(ctx context.Context, volumeID string, nodeID string) (err error)
+	ModifyTags(ctx context.Context, volumeID string, tagOptions ModifyTagsOptions) (err error)
 	ResizeOrModifyDisk(ctx context.Context, volumeID string, newSizeBytes int64, options *ModifyDiskOptions) (newSize int32, err error)
 	WaitForAttachmentState(ctx context.Context, volumeID, expectedState string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*types.VolumeAttachment, error)
 	GetDiskByName(ctx context.Context, name string, capacityBytes int64) (disk *Disk, err error)

--- a/pkg/cloud/mock_cloud.go
+++ b/pkg/cloud/mock_cloud.go
@@ -244,6 +244,20 @@ func (mr *MockCloudMockRecorder) ListSnapshots(ctx, volumeID, maxResults, nextTo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSnapshots", reflect.TypeOf((*MockCloud)(nil).ListSnapshots), ctx, volumeID, maxResults, nextToken)
 }
 
+// ModifyTags mocks base method.
+func (m *MockCloud) ModifyTags(ctx context.Context, volumeID string, tagOptions ModifyTagsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyTags", ctx, volumeID, tagOptions)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ModifyTags indicates an expected call of ModifyTags.
+func (mr *MockCloudMockRecorder) ModifyTags(ctx, volumeID, tagOptions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTags", reflect.TypeOf((*MockCloud)(nil).ModifyTags), ctx, volumeID, tagOptions)
+}
+
 // ResizeOrModifyDisk mocks base method.
 func (m *MockCloud) ResizeOrModifyDisk(ctx context.Context, volumeID string, newSizeBytes int64, options *ModifyDiskOptions) (int32, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/mock_ec2.go
+++ b/pkg/cloud/mock_ec2.go
@@ -149,6 +149,26 @@ func (mr *MockEC2APIMockRecorder) DeleteSnapshot(ctx, params interface{}, optFns
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshot", reflect.TypeOf((*MockEC2API)(nil).DeleteSnapshot), varargs...)
 }
 
+// DeleteTags mocks base method.
+func (m *MockEC2API) DeleteTags(ctx context.Context, params *ec2.DeleteTagsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTags", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTagsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTags indicates an expected call of DeleteTags.
+func (mr *MockEC2APIMockRecorder) DeleteTags(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTags", reflect.TypeOf((*MockEC2API)(nil).DeleteTags), varargs...)
+}
+
 // DeleteVolume mocks base method.
 func (m *MockEC2API) DeleteVolume(ctx context.Context, params *ec2.DeleteVolumeInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVolumeOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -217,14 +217,14 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	// "Values specified in mutable_parameters MUST take precedence over the values from parameters."
 	// https://github.com/container-storage-interface/spec/blob/master/spec.md#createvolume
-	if modifyOptions.VolumeType != "" {
-		volumeType = modifyOptions.VolumeType
+	if modifyOptions.modifyDiskOptions.VolumeType != "" {
+		volumeType = modifyOptions.modifyDiskOptions.VolumeType
 	}
-	if modifyOptions.IOPS != 0 {
-		iops = modifyOptions.IOPS
+	if modifyOptions.modifyDiskOptions.IOPS != 0 {
+		iops = modifyOptions.modifyDiskOptions.IOPS
 	}
-	if modifyOptions.Throughput != 0 {
-		throughput = modifyOptions.Throughput
+	if modifyOptions.modifyDiskOptions.Throughput != 0 {
+		throughput = modifyOptions.modifyDiskOptions.Throughput
 	}
 
 	responseCtx := map[string]string{}
@@ -592,7 +592,8 @@ func (d *ControllerService) ControllerModifyVolume(ctx context.Context, req *csi
 	}
 
 	_, err = d.modifyVolumeCoalescer.Coalesce(volumeID, modifyVolumeRequest{
-		modifyDiskOptions: *options,
+		modifyDiskOptions: options.modifyDiskOptions,
+		modifyTagsOptions: options.modifyTagsOptions,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/driver/controller_modify_volume_test.go
+++ b/pkg/driver/controller_modify_volume_test.go
@@ -25,26 +25,36 @@ import (
 )
 
 const (
-	validType          = "gp3"
-	validIops          = "2000"
-	validIopsInt       = 2000
-	validThroughput    = "500"
-	validThroughputInt = 500
-	invalidIops        = "123.546"
-	invalidThroughput  = "one hundred"
+	validType                   = "gp3"
+	validIops                   = "2000"
+	validIopsInt                = 2000
+	validThroughput             = "500"
+	validThroughputInt          = 500
+	invalidIops                 = "123.546"
+	invalidThroughput           = "one hundred"
+	validTagSpecificationInput  = "key1=tag1"
+	tagSpecificationWithNoValue = "key3="
+	tagSpecificationWithNoEqual = "key1"
+	validTagDeletion            = "key2"
+	invalidTagSpecification     = "aws:test=TEST"
 )
 
 func TestParseModifyVolumeParameters(t *testing.T) {
 	testCases := []struct {
 		name            string
 		params          map[string]string
-		expectedOptions *cloud.ModifyDiskOptions
+		expectedOptions *modifyVolumeRequest
 		expectError     bool
 	}{
 		{
-			name:            "blank params",
-			params:          map[string]string{},
-			expectedOptions: &cloud.ModifyDiskOptions{},
+			name:   "blank params",
+			params: map[string]string{},
+			expectedOptions: &modifyVolumeRequest{
+				modifyTagsOptions: cloud.ModifyTagsOptions{
+					TagsToAdd:    map[string]string{},
+					TagsToDelete: []string{},
+				},
+			},
 		},
 		{
 			name: "basic params",
@@ -52,12 +62,31 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 				ModificationKeyVolumeType: validType,
 				ModificationKeyIOPS:       validIops,
 				ModificationKeyThroughput: validThroughput,
+				ModificationAddTag:        validTagSpecificationInput,
+				ModificationDeleteTag:     validTagDeletion,
 			},
-			expectedOptions: &cloud.ModifyDiskOptions{
-				VolumeType: validType,
-				IOPS:       validIopsInt,
-				Throughput: validThroughputInt,
+			expectedOptions: &modifyVolumeRequest{
+				modifyDiskOptions: cloud.ModifyDiskOptions{
+					VolumeType: validType,
+					IOPS:       validIopsInt,
+					Throughput: validThroughputInt,
+				},
+				modifyTagsOptions: cloud.ModifyTagsOptions{
+					TagsToAdd: map[string]string{
+						"key1": "tag1",
+					},
+					TagsToDelete: []string{
+						"key2",
+					},
+				},
 			},
+		},
+		{
+			name: "tag specification with inproper length",
+			params: map[string]string{
+				ModificationAddTag: tagSpecificationWithNoEqual,
+			},
+			expectError: true,
 		},
 		{
 			name: "deprecated type",
@@ -65,8 +94,14 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 				ModificationKeyVolumeType:           validType,
 				DeprecatedModificationKeyVolumeType: "deprecated" + validType,
 			},
-			expectedOptions: &cloud.ModifyDiskOptions{
-				VolumeType: validType,
+			expectedOptions: &modifyVolumeRequest{
+				modifyDiskOptions: cloud.ModifyDiskOptions{
+					VolumeType: validType,
+				},
+				modifyTagsOptions: cloud.ModifyTagsOptions{
+					TagsToAdd:    map[string]string{},
+					TagsToDelete: []string{},
+				},
 			},
 		},
 		{
@@ -80,6 +115,13 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 			name: "invalid throughput",
 			params: map[string]string{
 				ModificationKeyThroughput: invalidThroughput,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid tag specification",
+			params: map[string]string{
+				ModificationAddTag: invalidTagSpecification,
 			},
 			expectError: true,
 		},

--- a/pkg/driver/request_coalescing_test.go
+++ b/pkg/driver/request_coalescing_test.go
@@ -240,7 +240,6 @@ func testPartialFail(t *testing.T, executor modifyVolumeExecutor) {
 		volumeTypeChosen = options.VolumeType
 		return newSize, nil
 	})
-
 	options := &Options{
 		ModifyVolumeRequestHandlerTimeout: 2 * time.Second,
 	}
@@ -334,7 +333,6 @@ func testSequentialRequests(t *testing.T, executor modifyVolumeExecutor) {
 		options:               options,
 		modifyVolumeCoalescer: newModifyVolumeCoalescer(mockCloud, options),
 	}
-
 	var wg sync.WaitGroup
 	wg.Add(2)
 

--- a/tests/e2e/modify_volume.go
+++ b/tests/e2e/modify_volume.go
@@ -60,7 +60,16 @@ var (
 			ShouldResizeVolume:                    false,
 			ShouldTestInvalidModificationRecovery: false,
 		},
-		"with new throughput and iops annotations": {
+		"with a new tag annotation": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationsTagSpec: "key1=test1",
+			},
+			ShouldResizeVolume:                    false,
+			ShouldTestInvalidModificationRecovery: false,
+			ExternalResizerOnly:                   true,
+		},
+		"with new throughput, and iops annotations": {
 			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
 			ModifyVolumeAnnotations: map[string]string{
 				testsuites.AnnotationIops:       "4000",
@@ -68,6 +77,17 @@ var (
 			},
 			ShouldResizeVolume:                    false,
 			ShouldTestInvalidModificationRecovery: false,
+		},
+		"with new throughput, iops, and tag annotations": {
+			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
+			ModifyVolumeAnnotations: map[string]string{
+				testsuites.AnnotationIops:       "4000",
+				testsuites.AnnotationThroughput: "150",
+				testsuites.AnnotationsTagSpec:   "key2=test2",
+			},
+			ShouldResizeVolume:                    false,
+			ShouldTestInvalidModificationRecovery: false,
+			ExternalResizerOnly:                   true,
 		},
 		"with a larger size and new throughput and iops annotations": {
 			CreateVolumeParameters: defaultModifyVolumeTestGp3CreateVolumeParameters,
@@ -124,6 +144,9 @@ var _ = Describe("[ebs-csi-e2e] [single-az] [modify-volume] Modifying a PVC", fu
 		modifyVolumeTest := modifyVolumeTest
 		Context(testName, func() {
 			It("will modify associated PV and EBS Volume via volume-modifier-for-k8s", func() {
+				if modifyVolumeTest.ExternalResizerOnly {
+					Skip("Functionality being tested is not supported for Modification via volume-modifier-for-k8s, skipping test")
+				}
 				modifyVolumeTest.Run(cs, ns, ebsDriver, testsuites.VolumeModifierForK8s)
 			})
 			It("will modify associated PV and EBS Volume via external-resizer", func() {

--- a/tests/e2e/testsuites/e2e_utils.go
+++ b/tests/e2e/testsuites/e2e_utils.go
@@ -42,6 +42,8 @@ const (
 	AnnotationIops       = "ebs.csi.aws.com/iops"
 	AnnotationThroughput = "ebs.csi.aws.com/throughput"
 	AnnotationVolumeType = "ebs.csi.aws.com/volumeType"
+	AnnotationsTagSpec   = "ebs.csi.aws.com/tagSpecification"
+	AnnotationTagDel     = "ebs.csi.aws.com/tagDeletion"
 )
 
 var DefaultGeneratedVolumeMount = VolumeMountDetails{

--- a/tests/e2e/testsuites/modify_volume_tester.go
+++ b/tests/e2e/testsuites/modify_volume_tester.go
@@ -34,6 +34,7 @@ type ModifyVolumeTest struct {
 	ModifyVolumeAnnotations               map[string]string
 	ShouldResizeVolume                    bool
 	ShouldTestInvalidModificationRecovery bool
+	ExternalResizerOnly                   bool
 }
 
 var (


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New Feature

**What is this PR about? / Why do we need it?**

This feature allows for EBS CSI Driver customers to Add, Modify, and Delete tags of existing volumes via the official CSI `ControllerModifyVolume` RPC through a `VolumeAttributesClass`.

**What testing is done?** 

Besides running existing unit and e2e tests, this feature was tested manually by doing the following:

1. Make test cluster by running `make cluster/create`
2. Creating and uploading image of driver with changes to ECR Repo
3. Deploying driver to cluster via helm, with the necessary flags. 
4. Creating various testing VolumeAttributesClass documents
5. Applying VACs and verifying that the correct tag operations were performed on the volume by describing the volume and looking at it's tags as well as ensuring that there is proper error handling 

### Notes:
This PR has a few extra VolumeAttributeClass documents that **will be removed before merging,** they are currently there because **the unit tests and e2e tests for this feature are still being worked on  (this is why there is some commented out code in the testing files)** as well as to ensure that I can test any changes made after initial reviews.



