### PR TITLE
fix dnsConfig indentation in controller template file

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -513,7 +513,7 @@ spec:
         {{- with .Values.controller.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-  {{- if .Values.controller.dnsConfig }}
-  dnsConfig:
-    {{- toYaml .Values.controller.dnsConfig | nindent 4 }}
-  {{- end }}
+      {{- if .Values.controller.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.controller.dnsConfig | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
Fix the indentation of `dnsConfig` option in controller.yaml. It should be at the same level of `template.spec.containers`, but before this change, it was as `template.spec` level.

**What testing is done?**
edit the values.yml and set a custom configuration, iE:

```yaml
  # Enable dnsConfig for the controller and node pods
  dnsConfig:
    options:
    - name: ndots
      value: "2"
```
The manifest you get from the previous is:

```yaml
....
      - name: liveness-probe
        image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-8
        imagePullPolicy: IfNotPresent
        args:
        - --csi-address=/csi/csi.sock
        volumeMounts:
        - name: socket-dir
          mountPath: /csi
        resources:
          limits:
            memory: 256Mi
          requests:
            cpu: 10m
            memory: 40Mi
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
      volumes:
      - name: socket-dir
        emptyDir: {}
  dnsConfig:
    options:
    - name: ndots
      value: '2'

```
but instead should be:

```yaml
...
      - name: liveness-probe
        image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.13.0-eks-1-30-8
        imagePullPolicy: IfNotPresent
        args:
        - --csi-address=/csi/csi.sock
        volumeMounts:
        - name: socket-dir
          mountPath: /csi
        resources:
          limits:
            memory: 256Mi
          requests:
            cpu: 10m
            memory: 40Mi
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
      volumes:
      - name: socket-dir
        emptyDir: {}
      dnsConfig:
        options:
        - name: ndots
          value: '2'

```

