### PR TITLE
Migrate CreateVolume response topology to standard label topology.kubernetes.io/zone

### DIFF
--- a/examples/kubernetes/static-provisioning/README.md
+++ b/examples/kubernetes/static-provisioning/README.md
@@ -34,7 +34,7 @@ This example shows you how to create and consume a `PersistentVolume` from an ex
         required:
           nodeSelectorTerms:
             - matchExpressions:
-                - key: topology.ebs.csi.aws.com/zone
+                - key: topology.kubernetes.io/zone
                   operator: In
                   values:
                     - {availability zone}

--- a/examples/kubernetes/static-provisioning/manifests/pv.yaml
+++ b/examples/kubernetes/static-provisioning/manifests/pv.yaml
@@ -29,7 +29,7 @@ spec:
     required:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: topology.ebs.csi.aws.com/zone
+            - key: topology.kubernetes.io/zone
               operator: In
               values:
                 - us-east-2c

--- a/examples/kubernetes/storageclass/manifests/storageclass.yaml
+++ b/examples/kubernetes/storageclass/manifests/storageclass.yaml
@@ -25,6 +25,6 @@ parameters:
   encrypted: "true"
 allowedTopologies:
 - matchLabelExpressions:
-  - key: topology.ebs.csi.aws.com/zone
+  - key: topology.kubernetes.io/zone
     values:
     - us-east-2c

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -924,7 +924,7 @@ func newCreateVolumeResponse(disk *cloud.Disk, ctx map[string]string) *csi.Creat
 		}
 	}
 
-	segments := map[string]string{ZoneTopologyKey: disk.AvailabilityZone}
+	segments := map[string]string{WellKnownZoneTopologyKey: disk.AvailabilityZone}
 
 	arn, err := arn.Parse(disk.OutpostArn)
 

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -147,11 +147,11 @@ func TestCreateVolume(t *testing.T) {
 						Requisite: []*csi.Topology{
 							{
 								Segments: map[string]string{
-									ZoneTopologyKey: expZone,
-									AwsAccountIDKey: outpostArn.AccountID,
-									AwsOutpostIDKey: outpostArn.Resource,
-									AwsRegionKey:    outpostArn.Region,
-									AwsPartitionKey: outpostArn.Partition,
+									WellKnownZoneTopologyKey: expZone,
+									AwsAccountIDKey:          outpostArn.AccountID,
+									AwsOutpostIDKey:          outpostArn.Resource,
+									AwsRegionKey:             outpostArn.Region,
+									AwsPartitionKey:          outpostArn.Partition,
 								},
 							},
 						},
@@ -164,11 +164,11 @@ func TestCreateVolume(t *testing.T) {
 					AccessibleTopology: []*csi.Topology{
 						{
 							Segments: map[string]string{
-								ZoneTopologyKey: expZone,
-								AwsAccountIDKey: outpostArn.AccountID,
-								AwsOutpostIDKey: outpostArn.Resource,
-								AwsRegionKey:    outpostArn.Region,
-								AwsPartitionKey: outpostArn.Partition,
+								WellKnownZoneTopologyKey: expZone,
+								AwsAccountIDKey:          outpostArn.AccountID,
+								AwsOutpostIDKey:          outpostArn.Resource,
+								AwsRegionKey:             outpostArn.Region,
+								AwsPartitionKey:          outpostArn.Partition,
 							},
 						},
 					},
@@ -1232,7 +1232,7 @@ func TestCreateVolume(t *testing.T) {
 					AccessibilityRequirements: &csi.TopologyRequirement{
 						Requisite: []*csi.Topology{
 							{
-								Segments: map[string]string{ZoneTopologyKey: expZone},
+								Segments: map[string]string{WellKnownZoneTopologyKey: expZone},
 							},
 						},
 					},
@@ -1245,7 +1245,7 @@ func TestCreateVolume(t *testing.T) {
 					AccessibilityRequirements: &csi.TopologyRequirement{
 						Requisite: []*csi.Topology{
 							{
-								Segments: map[string]string{ZoneTopologyKey: expZone},
+								Segments: map[string]string{WellKnownZoneTopologyKey: expZone},
 							},
 						},
 					},
@@ -1256,7 +1256,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeContext: map[string]string{},
 					AccessibleTopology: []*csi.Topology{
 						{
-							Segments: map[string]string{ZoneTopologyKey: expZone},
+							Segments: map[string]string{WellKnownZoneTopologyKey: expZone},
 						},
 					},
 				}
@@ -2084,17 +2084,17 @@ func TestGetOutpostArn(t *testing.T) {
 			requirement: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
-						Segments: map[string]string{ZoneTopologyKey: expZone},
+						Segments: map[string]string{WellKnownZoneTopologyKey: expZone},
 					},
 				},
 				Preferred: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							ZoneTopologyKey: expZone,
-							AwsAccountIDKey: outpostArn.AccountID,
-							AwsOutpostIDKey: outpostArn.Resource,
-							AwsRegionKey:    outpostArn.Region,
-							AwsPartitionKey: outpostArn.Partition,
+							WellKnownZoneTopologyKey: expZone,
+							AwsAccountIDKey:          outpostArn.AccountID,
+							AwsOutpostIDKey:          outpostArn.Resource,
+							AwsRegionKey:             outpostArn.Region,
+							AwsPartitionKey:          outpostArn.Partition,
 						},
 					},
 				},
@@ -2108,11 +2108,11 @@ func TestGetOutpostArn(t *testing.T) {
 				Requisite: []*csi.Topology{
 					{
 						Segments: map[string]string{
-							ZoneTopologyKey: expZone,
-							AwsAccountIDKey: outpostArn.AccountID,
-							AwsOutpostIDKey: outpostArn.Resource,
-							AwsRegionKey:    outpostArn.Region,
-							AwsPartitionKey: outpostArn.Partition,
+							WellKnownZoneTopologyKey: expZone,
+							AwsAccountIDKey:          outpostArn.AccountID,
+							AwsOutpostIDKey:          outpostArn.Resource,
+							AwsRegionKey:             outpostArn.Region,
+							AwsPartitionKey:          outpostArn.Partition,
 						},
 					},
 				},

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -51,8 +51,7 @@ func (d *ebsCSIDriver) GetDynamicProvisionStorageClass(parameters map[string]str
 			{
 				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
 					{
-						// TODO we should use the new topology key eventually
-						Key:    ebscsidriver.ZoneTopologyKey,
+						Key:    ebscsidriver.WellKnownZoneTopologyKey,
 						Values: allowedTopologyValues,
 					},
 				},


### PR DESCRIPTION
 *Is this a bug fix or adding new feature?**

Feature

**What is this PR about? / Why do we need it?**

See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/729#issuecomment-1942026577

**What testing is done?** 

CI/Manual