### PR TITLE
fix function name in comment

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1615,7 +1615,7 @@ func isAWSErrorIdempotentParameterMismatch(err error) bool {
 	return isAWSError(err, "IdempotentParameterMismatch")
 }
 
-// isAWSErrorIdempotentParameterMismatch returns a boolean indicating whether the
+// isAWSErrorBlockDeviceInUse returns a boolean indicating whether the
 // given error appears to be a block device name already in use error.
 func isAWSErrorBlockDeviceInUse(err error) bool {
 	var apiErr smithy.APIError


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This is a fix for comment section of function.

**What is this PR about? / Why do we need it?**

This PR fixes a wrong function name in the comment above the isAWSErrorBlockDeviceInUse function.

**What testing is done?** 