### PR TITLE
Supporting String Interpolation for Modifying Tags On Existing Volumes Through VAC

### DIFF
--- a/pkg/driver/controller_modify_volume.go
+++ b/pkg/driver/controller_modify_volume.go
@@ -28,6 +28,7 @@ import (
 	"github.com/awslabs/volume-modifier-for-k8s/pkg/rpc"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/coalescer"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util/template"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -168,6 +169,8 @@ func parseModifyVolumeParameters(params map[string]string) (*modifyVolumeRequest
 			TagsToDelete: make([]string, 0),
 		},
 	}
+	var scTags []string
+	tProps := new(template.PVProps)
 	for key, value := range params {
 		switch key {
 		case ModificationKeyIOPS:
@@ -191,20 +194,29 @@ func parseModifyVolumeParameters(params map[string]string) (*modifyVolumeRequest
 			options.modifyDiskOptions.VolumeType = value
 		case ModificationKeyVolumeType:
 			options.modifyDiskOptions.VolumeType = value
+		case PVCNameKey:
+			tProps.PVCName = value
+		case PVCNamespaceKey:
+			tProps.PVCNamespace = value
+		case PVNameKey:
+			tProps.PVName = value
 		default:
 			if strings.HasPrefix(key, ModificationAddTag) {
-				st := strings.SplitN(value, "=", 2)
-				if len(st) < 2 {
-					return nil, status.Errorf(codes.InvalidArgument, "Invalid tag specification: %v", st)
-				}
-				options.modifyTagsOptions.TagsToAdd[st[0]] = st[1]
+				scTags = append(scTags, value)
 			} else if strings.HasPrefix(key, ModificationDeleteTag) {
 				options.modifyTagsOptions.TagsToDelete = append(options.modifyTagsOptions.TagsToDelete, value)
 			}
 		}
 	}
-	if err := validateExtraTags(options.modifyTagsOptions.TagsToAdd, false); err != nil {
+	addTags, err := template.Evaluate(scTags, tProps, false)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Error interpolating the tag value: %v", err)
+	}
+	if err := validateExtraTags(addTags, false); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid tag value: %v", err)
+	}
+	for k, v := range addTags {
+		options.modifyTagsOptions.TagsToAdd[k] = v
 	}
 	return &options, nil
 }

--- a/pkg/driver/controller_modify_volume_test.go
+++ b/pkg/driver/controller_modify_volume_test.go
@@ -45,6 +45,7 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 		params          map[string]string
 		expectedOptions *modifyVolumeRequest
 		expectError     bool
+		pvcName         string
 	}{
 		{
 			name:   "blank params",
@@ -63,7 +64,9 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 				ModificationKeyIOPS:       validIops,
 				ModificationKeyThroughput: validThroughput,
 				ModificationAddTag:        validTagSpecificationInput,
+				ModificationAddTag + "_1": "key2={{ .PVCName }}",
 				ModificationDeleteTag:     validTagDeletion,
+				PVCNameKey:                "ebs-claim",
 			},
 			expectedOptions: &modifyVolumeRequest{
 				modifyDiskOptions: cloud.ModifyDiskOptions{
@@ -74,6 +77,7 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 				modifyTagsOptions: cloud.ModifyTagsOptions{
 					TagsToAdd: map[string]string{
 						"key1": "tag1",
+						"key2": "ebs-claim",
 					},
 					TagsToDelete: []string{
 						"key2",


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

This will add the support for runtime string interpolation on tag values for a volume upon modification, which allows for customers to specify placeholder values for the PVC namespace, PVC name and PV name, which will then be dynamically computed at runtime.

**What testing is done?** 

Unit tests were ran to ensure that input was parsed properly and manual testing was done after initial changes to `external-resizer` sidecar code were made to pass in the extra metadata necessary to the driver and ensuring that these tags were properly added at runtime.
