### PR TITLE
fix: sidecars.snapshotter.logLevel not being respect

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -320,6 +320,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
+            - --v={{ .Values.sidecars.snapshotter.logLevel }}
             {{- if .Values.controller.extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -197,6 +197,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
+            - --v=2
             - --extra-create-metadata
             - --kube-api-qps=20
             - --kube-api-burst=100


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix #2101 
**What is this PR about? / Why do we need it?**
sidecars.snapshotter.logLevel does not take affect when change the log level in values.yaml.
**What testing is done?** 
