### PR TITLE
Add nodeComponentOnly parameter to helm chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-attacher.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -24,3 +25,4 @@ rules:
   {{- with .Values.sidecars.attacher.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-provisioner.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -39,3 +40,4 @@ rules:
   {{- with .Values.sidecars.provisioner.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-resizer.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,3 +36,4 @@ rules:
   {{- with .Values.sidecars.resizer.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-snapshotter.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -28,3 +29,4 @@ rules:
   {{- with .Values.sidecars.snapshotter.additionalClusterRoleRules }}
     {{- . | toYaml | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-attacher.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,3 +14,4 @@ roleRef:
   kind: ClusterRole
   name: ebs-external-attacher-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-provisioner.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,3 +14,4 @@ roleRef:
   kind: ClusterRole
   name: ebs-external-provisioner-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-resizer.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,3 +14,4 @@ roleRef:
   kind: ClusterRole
   name: ebs-external-resizer-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrolebinding-snapshotter.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,3 +14,4 @@ roleRef:
   kind: ClusterRole
   name: ebs-external-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 # Controller Service
 kind: Deployment
 apiVersion: apps/v1
@@ -518,3 +519,4 @@ spec:
       dnsConfig:
         {{- toYaml .Values.controller.dnsConfig | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 apiVersion: {{ ternary "storage.k8s.io/v1" "storage.k8s.io/v1beta1" (semverCompare ">=1.18.0-0" .Capabilities.KubeVersion.Version) }}
 kind: CSIDriver
 metadata:
@@ -10,3 +11,4 @@ spec:
   {{- if not .Values.useOldCSIDriver }}
   fsGroupPolicy: File
   {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/ebs-csi-default-sc.yaml
+++ b/charts/aws-ebs-csi-driver/templates/ebs-csi-default-sc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 {{- if .Values.defaultStorageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -8,4 +9,5 @@ metadata:
 provisioner: ebs.csi.aws.com
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
+{{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.enableMetrics -}}
+{{- if and .Values.controller.enableMetrics (not .Values.nodeComponentOnly) -}}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -15,3 +16,4 @@ spec:
   {{- else }}
   minAvailable: 2
   {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/role-leases.yaml
+++ b/charts/aws-ebs-csi-driver/templates/role-leases.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -9,3 +10,4 @@ rules:
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/rolebinding-leases.yaml
+++ b/charts/aws-ebs-csi-driver/templates/rolebinding-leases.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeComponentOnly -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -13,3 +14,4 @@ roleRef:
   kind: Role
   name: ebs-csi-leases-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.serviceAccount.create -}}
+{{- if and .Values.controller.serviceAccount.create (not .Values.nodeComponentOnly) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.helmTester.enabled -}}
+{{- if and .Values.helmTester.enabled (not .Values.nodeComponentOnly) -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -476,6 +476,8 @@ volumeSnapshotClasses: []
 # Intended for use with older clusters that cannot easily replace the CSIDriver object
 # This parameter should always be false for new installations
 useOldCSIDriver: false
+# Deploy EBS CSI Driver without controller and associated resources
+nodeComponentOnly: false
 helmTester:
   enabled: true
   # Supply a custom image to the ebs-csi-driver-test pod in helm-tester.yaml


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

/feature

**What is this PR about? / Why do we need it?**

Add a nodeComponentOnly parameter to helm chart.

**What testing is done?** 

Here are helm template results with and without setting nodeComponentOnly=true, as well as the diff (as textfiles because gists don't support yaml):

[nodeComponentOnlyTemplate.txt](https://github.com/user-attachments/files/16565770/controllerDisabledTemplate.txt)
[defaultChart.txt](https://github.com/user-attachments/files/16565771/defaultChart.txt)
[diff.txt](https://github.com/user-attachments/files/16565773/diff.txt)

Also deployed the driver with this setting:

```
helm upgrade \
  --install aws-ebs-csi-driver \
  --namespace kube-system \
  $HOME/workplace/aws-ebs-csi-driver/charts/aws-ebs-csi-driver \
  --values "$HOME/workplace/tools/driver-testing/driver-up/custom_values.yaml" \
  --set nodeComponentOnly=true

Release "aws-ebs-csi-driver" does not exist. Installing it now.
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Fri Aug  9 18:51:28 2024
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
...

❯ kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"
NAME                 READY   STATUS    RESTARTS   AGE
ebs-csi-node-4cxvv   3/3     Running   0          12s
ebs-csi-node-57f2r   3/3     Running   0          12s
ebs-csi-node-kss7k   3/3     Running   0          12s
ebs-csi-node-tq9sv   3/3     Running   0          12s
```
