### PR TITLE
Fix accelerators not being considered when counting allocatables

### DIFF
--- a/hack/generate-gpu-count-table.sh
+++ b/hack/generate-gpu-count-table.sh
@@ -15,6 +15,7 @@
 # Generates gpu table for `pkg/cloud/volume_limits.go` from the AWS API
 # Ensure you are opted into all opt-in regions before running
 # Ensure your account isn't in any private instance type betas before running
+# We are exluding the g5.48xlarge instance type as it is a special case that does not comply to regular ebs volume limit calculations
 
 set -euo pipefail
 
@@ -34,4 +35,4 @@ function get_all_gpus() {
   done
 }
 
-get_all_gpus | sort | uniq
+get_all_gpus | sort | uniq | grep -v "g5.48xlarge"

--- a/hack/generate-instance-store-table.sh
+++ b/hack/generate-instance-store-table.sh
@@ -17,6 +17,7 @@
 # Generates instance store table for `pkg/cloud/volume_limits.go` from the AWS API
 # Ensure you are opted into all opt-in regions before running
 # Ensure your account isn't in any private instance type betas before running
+# We are exluding the g5.48xlarge instance type as it is a special case that does not comply to regular ebs volume limit calculations
 
 set -euo pipefail
 
@@ -36,4 +37,4 @@ function get_all_instance_stores() {
   done
 }
 
-get_all_instance_stores | sort | uniq
+get_all_instance_stores | sort | uniq | grep -v "g5.48xlarge"

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1136,28 +1136,12 @@ func TestGetVolumesLimit(t *testing.T) {
 			},
 		},
 		{
-			name: "inf1.24xlarge_volume_attach_limit",
-			options: &Options{
-				VolumeAttachLimit:         -1,
-				ReservedVolumeAttachments: -1,
-			},
-			expectedVal: 9,
-			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
-				m := metadata.NewMockMetadataService(ctrl)
-				m.EXPECT().GetRegion().Return("us-west-2")
-				m.EXPECT().GetInstanceType().Return("inf1.24xlarge")
-				m.EXPECT().GetNumAttachedENIs().Return(1)
-				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
-				return m
-			},
-		},
-		{
 			name: "mac1.metal_volume_attach_limit",
 			options: &Options{
 				VolumeAttachLimit:         -1,
 				ReservedVolumeAttachments: -1,
 			},
-			expectedVal: 14,
+			expectedVal: 15,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
 				m.EXPECT().GetRegion().Return("us-west-2")
@@ -1173,7 +1157,7 @@ func TestGetVolumesLimit(t *testing.T) {
 				VolumeAttachLimit:         -1,
 				ReservedVolumeAttachments: -1,
 			},
-			expectedVal: 17,
+			expectedVal: 18,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
 				m.EXPECT().GetRegion().Return("us-west-2")
@@ -1199,7 +1183,6 @@ func TestGetVolumesLimit(t *testing.T) {
 				return m
 			},
 		},
-		// 1 gpu
 		{
 			name: "g4ad.xlarge_volume_attach_limit (1 GPU 1 InstanceStoreVolume)",
 			options: &Options{
@@ -1216,7 +1199,6 @@ func TestGetVolumesLimit(t *testing.T) {
 				return m
 			},
 		},
-		// 4 gpus
 		{
 			name: "g4dn.12xlarge_volume_attach_limit (4 GPUS, 1 InstanceStoreVolume)",
 			options: &Options{
@@ -1228,6 +1210,107 @@ func TestGetVolumesLimit(t *testing.T) {
 				m := metadata.NewMockMetadataService(ctrl)
 				m.EXPECT().GetRegion().Return("us-west-2")
 				m.EXPECT().GetInstanceType().Return("g4dn.12xlarge")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(1)
+				return m
+			},
+		},
+		{
+			name: "dl1.24xlarge_volume_attach_limit (8 Accelerator slots , 4 InstanceStoreVolume)",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 14,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetRegion().Return("us-west-2")
+				m.EXPECT().GetInstanceType().Return("dl1.24xlarge")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(1)
+				return m
+			},
+		},
+		{
+			// will and should fail if g5.48xlarge instance type is in any table other than maxVolumeLimits table
+			name: "g5.48xlarge_volume_attach_limit (Instance has attached GPUs and NVMe Instance Store volumes but should be ignored for EBS volume limits calculation)",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 8,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetRegion().Return("us-west-2")
+				m.EXPECT().GetInstanceType().Return("g5.48xlarge")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(1)
+				return m
+			},
+		},
+		{
+			// Should fail if inf1.xlarge instance type is in any table other than maxVolumeLimits table
+			name: "inf1.xlarge_volume_attach_limit (Instance has attached Accelerators but should be ignored for EBS volume limits calculation)",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 25,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetRegion().Return("us-west-2")
+				m.EXPECT().GetInstanceType().Return("inf1.xlarge")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(1)
+				return m
+			},
+		},
+		{
+			// Should fail if inf1.xlarge instance type is in any table other than maxVolumeLimits table
+			name: "inf1.2xlarge_volume_attach_limit (Instance has attached Accelerators but should be ignored for EBS volume limits calculation)",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 25,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetRegion().Return("us-west-2")
+				m.EXPECT().GetInstanceType().Return("inf1.2xlarge")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(1)
+				return m
+			},
+		},
+		{
+			// Should fail if inf1.6xlarge instance type is in any table other than maxVolumeLimits table
+			name: "inf1.6xlarge_volume_attach_limit (Instance has attached Accelerators but should be ignored for EBS volume limits calculation)",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 22,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetRegion().Return("us-west-2")
+				m.EXPECT().GetInstanceType().Return("inf1.6xlarge")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(1)
+				return m
+			},
+		},
+		{
+			// Should fail if inf1.24xlarge instance type is in any table other than maxVolumeLimits table
+			name: "inf1.24xlarge_volume_attach_limit (Instance has attached Accelerators but should be ignored for EBS volume limits calculation)",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 10,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetRegion().Return("us-west-2")
+				m.EXPECT().GetInstanceType().Return("inf1.24xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
 				return m


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2105
**What is this PR about? / Why do we need it?**
This PR fixes GH https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2105 as before we where not taking accelerators into consideration when calculating volume limits  
**What testing is done?** 
I spun up and hand added ebs volumes to an instance in each accelerator family to ensure there where no special cases outside of the VT1 family where accelerators take up two slots. 

Additionally I found that the calculation in node.go was incorrect for any instance type in the maxVolumeLimits table the documentation states that for the instance types in that table the calculation of 28 - enis - NVMeInstanceStoreVolumes - gpus/accekerators should be completely  ignored as they are [special cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html) . As such I checked with a inf1.xlarge instance type and verified you can in fact attach 26 volumes as it's eni (or anything else for that matter) should not be considered when looking at its limit.