### PR TITLE
Fix small papercuts

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -74,11 +74,7 @@ spec:
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            {{- if ne .Release.Name "kustomize" }}
             - controller
-            {{- else }}
-            # - {all,controller,node} # specify the driver mode
-            {{- end }}
             - --endpoint=$(CSI_ENDPOINT)
             {{- if .Values.controller.extraVolumeTags }}
               {{- include "aws-ebs-csi-driver.extra-volume-tags" . | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml
@@ -10,11 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if eq .Release.Name "kustomize" }}
-  #Enable if EKS IAM roles for service accounts (IRSA) is used. See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
-  #annotations:
-  #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
-  {{- end }}
 {{- if .Values.controller.serviceAccount.automountServiceAccountToken }}
 automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -65,7 +65,7 @@ spec:
           image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.33.0
           imagePullPolicy: IfNotPresent
           args:
-            # - {all,controller,node} # specify the driver mode
+            - controller
             - --endpoint=$(CSI_ENDPOINT)
             - --batching=true
             - --logging-format=text

--- a/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
+++ b/deploy/kubernetes/base/serviceaccount-csi-controller.yaml
@@ -6,7 +6,4 @@ metadata:
   name: ebs-csi-controller-sa
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
-  #Enable if EKS IAM roles for service accounts (IRSA) is used. See https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html for details.
-  #annotations:
-  #  eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
 automountServiceAccountToken: true

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -68,16 +68,21 @@ func TestNameAllocatorLikelyBadName(t *testing.T) {
 		})
 	}
 
+	// Test likely bad name fallback when it is the only device name available
+	// We should receive the likely bad device name because it is the only option left
+	lastName, _ := allocator.GetNext(existingNames, likelyBadNames)
+	if lastName != skippedNameNew {
+		t.Errorf("test %q: expected %q, got %q (likelyBadNames fallback)", skippedNameNew, skippedNameNew, lastName)
+	}
+	existingNames[skippedNameNew] = ""
+
+	// Test likely bad name fallback when the likely bad device name already exists
+	// Because the device name already exists, this should return an error
 	onlyExisting := new(sync.Map)
 	onlyExisting.Store(skippedNameExisting, struct{}{})
 	_, err := allocator.GetNext(existingNames, onlyExisting)
 	if err != nil {
 		t.Errorf("got nil when error expected (likelyBadNames with only existing names)")
-	}
-
-	lastName, _ := allocator.GetNext(existingNames, likelyBadNames)
-	if lastName != skippedNameNew {
-		t.Errorf("test %q: expected %q, got %q (likelyBadNames fallback)", skippedNameNew, skippedNameNew, lastName)
 	}
 }
 

--- a/pkg/expiringcache/expiring_cache_test.go
+++ b/pkg/expiringcache/expiring_cache_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	testExpiration = time.Millisecond * 50
-	testSleep      = time.Millisecond * 35
+	testExpiration = time.Millisecond * 100
+	testSleep      = time.Millisecond * 80
 	testKey        = "key"
 )
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix, mostly

**What is this PR about? / Why do we need it?**

Fixes three small papercuts:

## [Cleanup TestNameAllocatorLikelyBadName to prevent code coverage flapping](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/eaaaf0da703693c5e2ced1ced4b84342dfc83351)

This should prevent code coverage constantly flapping on this test by properly setting up the `existingNames` map. Also, added some comments to make the test more clear.

## [Adjust TestExpiringCache timeouts to decrease CI flakes](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/ffc2c44e98ede634e2ccd4bddaa23977417b9831)

This test flakes all the time in CI, especially on the Windows unit tests. I bumped up the sleeps to hopefully combat this, it's set to run in parallel so shouldn't make a significant difference to overall test time.

## [Standardize deployment methods by removing Kustomize-specific changes](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/a4da81950393dfdca2df41c40a74aaa4cad35595)

Our helm chart contains two places that are used to magically inject comments into the Kustomize deployment. Remove these to standardize the chart and because they're bad:

- In `controller.yaml`, the Kustomize deployment comments out the mode by default, thus running the driver in `All` mode and running the node server on the controller. This is pointless, wastes RAM and CPU, and increases the attack surface.

- In `serviceaccount-csi-controller.yaml`, the Kustomize deployment has a comment about IRSA. Documenting via comments in the manifests is a horrible practice, EKS Pod Identity is superior to and largely replaces IRSA, and the EKS docs already appropriately document how to use IRSA.

**What testing is done?** 

CI/Manual
