### PR TITLE
Make govulncheck only run on release branches

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 name: 'govulncheck'
-on: [pull_request]
-
+on:
+  pull_request:
+    branches:
+      - 'release-*'
 jobs:
   govulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

N/A

**What is this PR about? / Why do we need it?**

This makes the govulncheck github action only run on PRs merging into release branches:
- New vulnerability blocks the merge of a new contributor, requiring a rebase. This is not a great contributor experience and has led to delays due to PR churn.

The risk here is that we suddenly find out about a vulnerability for our release PR, instead of in any pr, which may delay our release by 1-3 hours (due to waiting for CI to re-run). But that should be rare since we are bumping dependencies right before a release anyway.

**What testing is done?** 

CI
