### PR TITLE
use protobuf content type instead of json for k8s client

### DIFF
--- a/pkg/cloud/metadata/k8s.go
+++ b/pkg/cloud/metadata/k8s.go
@@ -84,6 +84,8 @@ func DefaultKubernetesAPIClient(kubeconfig string) KubernetesAPIClient {
 				}
 			}
 		}
+		config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+		config.ContentType = "application/vnd.kubernetes.protobuf"
 		// creates the clientset
 		clientset, err = kubernetes.NewForConfig(config)
 		if err != nil {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**
This MR is a part of effort to elevate single eks cluster performance by migrating the EKS components to use protobuf instead of json.

Modify kubeconfig type to use content type application/vnd.kubernetes.protobuf instead of json for performance gain.

This change essentially lets the ebs driver (client) to talk to apiserver using protobuf and falls back to json if protobuf isn't supported. It will only affect the wire format between ebs driver and apiserver.

**What testing is done?** 
