### PR TITLE
Update VolumeAttributesClass example to beta

### DIFF
--- a/docs/modify-volume.md
+++ b/docs/modify-volume.md
@@ -12,12 +12,14 @@ The EBS CSI Driver (starting from v1.19.0) supports volume modification through 
 
 To use this feature, it must be enabled in the following places:
 - `VolumeAttributesClass` feature gate on `kube-apiserver` (consult your Kubernetes distro's documentation)
-- `storage.k8s.io/v1alpha1` enabled in `kube-apiserver` via [`runtime-config`](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/) (consult your Kubernetes distro's documentation)
+- `storage.k8s.io/v1alpha1` (Kubernetes 1.30 and before) or `storage.k8s.io/v1alpha1` (Kubernetes 1.31 and later) enabled in `kube-apiserver` via [`runtime-config`](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/) (consult your Kubernetes distro's documentation)
 - `VolumeAttributesClass` feature gate on `kube-controller-manager` (consult your Kubernetes distro's documentation)
-- `VolumeAttributesClass` feature gate on `external-provisioner` (add `--feature-gates=VolumeAttributesClass=true` to `sidecars.provisioner.additionalArgs` when using the EBS CSI Helm chart)
-- `VolumeAttributesClass` feature gate on `kube-controller-manager` (add `--feature-gates=VolumeAttributesClass=true` to `sidecars.resizer.additionalArgs` when using the EBS CSI Helm chart)
+- `VolumeAttributesClass` feature gate on `external-provisioner` sidecar
+- `VolumeAttributesClass` feature gate on `external-resizer` sidecar
 
-For more information, see the [Kubernetes documentation for the feature](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/).
+The EBS CSI Driver Helm chart will automatically enable the `VolumeAttributesClass` feature gate on the sidecars if `VolumeAttributesClass` object is detected with a beta API version (Kubernetes 1.31 and later). You (or your Kubernetes distro, on your behalf) are responsible for enabling the feature gate on the control plane components (`kube-apiserver` and `kube-controller-manager`).
+
+For more information, see the [Kubernetes documentation for Volume Attributes Classes](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/).
 
 ### `volume-modifier-for-k8s`
 
@@ -32,6 +34,8 @@ Users can specify the following modification parameters:
 - `type`: to update the volume type
 - `iops`: to update the IOPS
 - `throughput`: to update the throughput
+
+The EBS CSI Driver also supports modifying tags of existing volumes (only available for `VolumeAttributesClass`), see [the modification section in the tagging documentation](tagging.md#adding-modifying-and-deleting-tags-of-existing-volumes) for more information.
 
 ## Considerations
 

--- a/docs/modify-volume.md
+++ b/docs/modify-volume.md
@@ -12,7 +12,7 @@ The EBS CSI Driver (starting from v1.19.0) supports volume modification through 
 
 To use this feature, it must be enabled in the following places:
 - `VolumeAttributesClass` feature gate on `kube-apiserver` (consult your Kubernetes distro's documentation)
-- `storage.k8s.io/v1alpha1` (Kubernetes 1.30 and before) or `storage.k8s.io/v1alpha1` (Kubernetes 1.31 and later) enabled in `kube-apiserver` via [`runtime-config`](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/) (consult your Kubernetes distro's documentation)
+- `storage.k8s.io/v1alpha1` (Kubernetes 1.30 and before) or `storage.k8s.io/v1beta1` (Kubernetes 1.31 and later) enabled in `kube-apiserver` via [`runtime-config`](https://kubernetes.io/docs/tasks/administer-cluster/enable-disable-api/) (consult your Kubernetes distro's documentation)
 - `VolumeAttributesClass` feature gate on `kube-controller-manager` (consult your Kubernetes distro's documentation)
 - `VolumeAttributesClass` feature gate on `external-provisioner` sidecar
 - `VolumeAttributesClass` feature gate on `external-resizer` sidecar

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -103,7 +103,7 @@ The AWS EBS CSI Driver supports the modifying of tags of existing volumes throug
 
 If a key has the prefix `tagSpecification`, the CSI driver will treat the value as a key-value pair to be added to the existing volume. If there is already an existing tag with the specified key, the CSI driver will overwrite the value of that tag with the new value specified. 
 ```
-apiVersion: storage.k8s.io/v1alpha1
+apiVersion: storage.k8s.io/v1beta1
 kind: VolumeAttributesClass
 metadata:
   name: io2-class
@@ -116,7 +116,7 @@ parameters:
 
 If a key has the prefix `tagDeletion`, the CSI driver will treat the value as a tag key, and the existing tag with that key will be removed from the volume.
 ```
-apiVersion: storage.k8s.io/v1alpha1
+apiVersion: storage.k8s.io/v1beta1
 kind: VolumeAttributesClass
 metadata:
   name: io2-class

--- a/examples/kubernetes/modify-volume/README.md
+++ b/examples/kubernetes/modify-volume/README.md
@@ -50,7 +50,7 @@ This example will only work on a cluster with the `VolumeAttributesClass` featur
     ```sh
     $ kubectl get pvc ebs-claim
     NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
-    ebs-claim   Bound    pvc-076b2d14-b643-47d4-a2ce-fbf9cd36572b   100Gi      RWO            ebs-sc         io2-class               5m54s
+    ebs-claim   Bound    pvc-076b2d14-b643-47d4-a2ce-fbf9cd36572b   10Gi      RWO            ebs-sc         io2-class               5m54s
     ```
 
 7. (Optional) Delete example resources

--- a/examples/kubernetes/modify-volume/manifests/pod-with-volume.yaml
+++ b/examples/kubernetes/modify-volume/manifests/pod-with-volume.yaml
@@ -32,7 +32,7 @@ spec:
   storageClassName: ebs-sc
   resources:
     requests:
-      storage: 100Gi
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Pod

--- a/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
+++ b/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 ---
-apiVersion: storage.k8s.io/v1alpha1
+apiVersion: storage.k8s.io/v1beta1
 kind: VolumeAttributesClass
 metadata:
   name: io2-class
 driverName: ebs.csi.aws.com
 parameters:
   type: io2
-  iops: "10000"
+  iops: "3000"
   tagSpecification_1: "location=Seattle"
   tagSpecification_2: "cost-center="


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Update

**What is this PR about? / Why do we need it?**

The current ModifyVolume example will not work with aws-ebs-csi-driver version >= v1.35.0 due to the VolumeAttributesClass object upgrading to v1beta1 in Kubernetes v1.31 and external sidecars. 

Also decreased volume size and iops to be more frugal.

Am open to updating `modify-volume.md` further to remove steps that are no longer relevant for aws-ebs-csi-driver >= 1.35.0 (i.e. adding feature gate on sidecars manually instead of relying on our helm chart)

**What testing is done?** 
Going through example manually