### PR TITLE
Upgrade vac to beta in e2e tests

### DIFF
--- a/tests/e2e/testsuites/modify_volume_tester.go
+++ b/tests/e2e/testsuites/modify_volume_tester.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
 	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/storage/v1alpha1"
+	"k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -74,7 +74,7 @@ func (modifyVolumeTest *ModifyVolumeTest) Run(c clientset.Interface, ns *v1.Name
 	if testType == VolumeModifierForK8s {
 		AnnotatePvc(modifyingPvc, parametersWithPrefix)
 	} else if testType == ExternalResizer {
-		vac, err := c.StorageV1alpha1().VolumeAttributesClasses().Create(context.Background(), &v1alpha1.VolumeAttributesClass{
+		vac, err := c.StorageV1beta1().VolumeAttributesClasses().Create(context.Background(), &v1beta1.VolumeAttributesClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      formatOptionMountPod.pod.Name,
 				Namespace: ns.Name,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**

External-provisioner + resizer only list v1beta1 versioned `VolumeAttributeClass`es

These tests are currently turned off in our CI due to no Kubernetes 1.31 cluster creation yet.  

**What testing is done?** 

In progress, manual single-az test on 1.31 cluster