### PR TITLE
Improve observability of `InsufficientVolumeCapacity` errors

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1347,6 +1347,22 @@ func TestCreateDisk(t *testing.T) {
 			},
 			expErr: fmt.Errorf("invalid AWS VolumeType %q", "invalidVolumeType"),
 		},
+		{
+			name:       "failure: InsufficientVolumeCapacity error",
+			volumeName: "vol-test-name-error",
+			diskOptions: &DiskOptions{
+				CapacityBytes:    util.GiBToBytes(1),
+				Tags:             map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
+				AvailabilityZone: expZone,
+			},
+			expCreateVolumeInput: &ec2.CreateVolumeInput{
+				Iops: aws.Int32(2000),
+			},
+			expErr: ErrInsufficientVolumeCapacity,
+			expCreateVolumeErr: &smithy.GenericAPIError{
+				Code: "InsufficientVolumeCapacity",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Neither, kaizen.
closes #2154 

**What is this PR about? / Why do we need it?**

This PR enhances the driver's ability to communicate `InsufficientVolumeCapacity` errors from the AWS API by providing a more informative error message to users.

**What testing is done?** 

```
make verify && make test
```

See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html for more information related to error codes.