### PR TITLE
Fix yq action version typo

### DIFF
--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - id: set-matrix
-        uses: mikefarah/yq@4
+        uses: mikefarah/yq@v4
         with:
           # Dynamically build the matrix of images to scan
           cmd: "yq '[{\"repository\": .image.repository, \"tag\": \"v'$(yq '.appVersion' charts/aws-ebs-csi-driver/Chart.yaml)'\"}] + (.sidecars | map(.image)) | map(.repository + \":\" + .tag) | . style=\"flow\"' charts/aws-ebs-csi-driver/values.yaml"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Bug fix

**What is this PR about? / Why do we need it?**

The version of the `yq` GitHub action was mistakenly pinned from `master` to `4` in - when it should have been pinned to `v4`.

**What testing is done?** 

N/A / CI
