### PR TITLE
feat: Added new policy to PodDisruptionBudget

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -11,6 +11,9 @@ spec:
     matchLabels:
       app: ebs-csi-controller
       {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
+  {{- if .Values.controller.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.controller.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
   {{- if le (.Values.controller.replicaCount | int) 2 }}
   maxUnavailable: 1
   {{- else }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -249,6 +249,7 @@ controller:
     # Warning: Disabling PodDisruptionBudget may lead to delays in stateful workloads starting due to controller
     # pod restarts or evictions.
     enabled: true
+    # unhealthyPodEvictionPolicy:
   priorityClassName: system-cluster-critical
   # AWS region to use. If not specified then the region will be looked up via the AWS EC2 metadata
   # service.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

New feature

**What is this PR about? / Why do we need it?**

I opened an issue #2146 asking for support for the new `unhealthyPodEvictionPolicy` for the PDB in the chart.

**What testing is done?** 
I generated a helm template file locally and tried to set `unhealthyPodEvictionPolicy` in the chart values to `AlwaysAllow` with a successful output.

![Screen Shot 2024-09-30 at 16 00 18 PM](https://github.com/user-attachments/assets/cb3a227a-3f25-46ae-bab6-ea0251b79d49)


