### PR TITLE
Add K8s 1.31 to CI by pinning kops commit instead of version

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -35,7 +35,7 @@ OUTPOST_INSTANCE_TYPE=${OUTPOST_INSTANCE_TYPE:-${INSTANCE_TYPE}}
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
 # NOTE: Keep KOPS at v1.29.x until ELB usage bug fixed
-K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.29.6}
+K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.31.1}
 K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-1.31}
 
 EBS_INSTALL_SNAPSHOT=${EBS_INSTALL_SNAPSHOT:-"true"}

--- a/hack/e2e/kops/kops.sh
+++ b/hack/e2e/kops/kops.sh
@@ -32,6 +32,7 @@ function kops_create_cluster() {
   KOPS_PATCH_FILE=${10}
   KOPS_PATCH_NODE_FILE=${11}
   KOPS_STATE_FILE=${12}
+  declare -x KOPS_TOO_NEW_VERSION=true
 
   if kops_cluster_exists "${CLUSTER_NAME}" "${KOPS_BIN}" "${KOPS_STATE_FILE}"; then
     loudecho "Replacing cluster $CLUSTER_NAME with $CLUSTER_FILE"

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -33,8 +33,8 @@ GOMPLATE_VERSION="v4.1.0"
 # https://github.com/helm/helm
 HELM_VERSION="v3.16.2"
 # https://github.com/kubernetes/kops
-# NOTE: Keep at v1.29.0 until ELB usage bug fixed
-KOPS_VERSION="v1.29.0"
+# NOTE: We pin kops to a commit instead of a release to support newer versions of k8s earlier
+KOPS_COMMIT="aaa35cc5304f9b191ca9828b552e62bddc5b263a"
 # https://pkg.go.dev/sigs.k8s.io/kubetest2?tab=versions
 KUBETEST2_VERSION="v0.0.0-20240905095256-f6e8664cd2b1"
 # https://github.com/golang/mock
@@ -153,9 +153,11 @@ function install_helm() {
 }
 
 function install_kops() {
+  # Build from source so we can test latest Kubernetes version earlier.
   INSTALL_PATH="${1}"
 
-  install_binary "${INSTALL_PATH}" "https://github.com/kubernetes/kops/releases/download/${KOPS_VERSION}/kops-${OS}-${ARCH}" "kops"
+  # Lower max processes to avoid oom-killed
+  GOMAXPROCS=1 install_go "${INSTALL_PATH}" "k8s.io/kops/cmd/kops@${KOPS_COMMIT}"
 }
 
 function install_kubetest2() {


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
CI

**What is this PR about? / Why do we need it?**

This PR should not be merged until we fix any rate-limit issues in our CI (likely by submitting a PR to kops for different retry policies) 

We want our CI to test changes to the EBS CSI Driver against the latest stable version of Kubernetes to proactively spot issues and guarantee that we pass the Kubernetes Storage conformance tests.

However, EKS and recently kOps do not release support for the latest stable Kubernetes version until 1-2 months afterwards, which blocks us from upgrading our CI to the latest Kubernetes version.

Many of upstream e2e tests run against newer versions of Kubernetes without the latest kops version (see [test-infra jobs](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/kops)). This is because there are usually a few unreleased fixes on the main branch that allow kops to be used for newer Kubernetes versions when combined with exporting `KOPS_RUN_TOO_NEW_VERSION=true`. This PR pins our CI to a Kops commit instead of a release so that we can do the same with our custom cluster testing system. 

**What testing is done?** 

Local + CI
