### PR TITLE
helm: add recommended autoscalar Tolerations to driver DaemonSet

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -88,6 +88,9 @@ Handle http proxy env vars
 Recommended daemonset tolerations
 */}}
 {{- define "aws-ebs-csi-driver.daemonset-tolerations" -}}
+# Prevents stateful workloads from being scheduled to node before CSI Driver reports volume attachment limit
+- key: "ebs.csi.aws.com/agent-not-ready"
+  operator: "Exists"
 # Prevents undesired eviction by Cluster Autoscalar
 - key: "ToBeDeletedByClusterAutoscaler"
   operator: Exists

--- a/charts/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -83,3 +83,18 @@ Handle http proxy env vars
 - name: NO_PROXY
   value: {{ .Values.proxy.no_proxy | quote }}
 {{- end -}}
+
+{{/*
+Recommended daemonset tolerations
+*/}}
+{{- define "aws-ebs-csi-driver.daemonset-tolerations" -}}
+# Prevents undesired eviction by Cluster Autoscalar
+- key: "ToBeDeletedByClusterAutoscaler"
+  operator: Exists
+# Prevents undesired eviction by v1 Karpenter
+- key: "karpenter.sh/disrupted"
+  operator: Exists
+# Prevents undesired eviction by v1beta1 Karpenter
+- key: "karpenter.sh/disruption"
+  operator: Exists
+{{- end -}}

--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -49,6 +49,7 @@ spec:
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "aws-ebs-csi-driver.daemonset-tolerations" . | nindent 8 }}
         {{- end }}
       {{- if .Values.node.windowsHostProcess }}
       securityContext:

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -53,6 +53,7 @@ spec:
         {{- with .Values.node.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "aws-ebs-csi-driver.daemonset-tolerations" . | nindent 8 }}
         - key: "ebs.csi.aws.com/agent-not-ready"
           operator: "Exists"
         {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -54,8 +54,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "aws-ebs-csi-driver.daemonset-tolerations" . | nindent 8 }}
-        - key: "ebs.csi.aws.com/agent-not-ready"
-          operator: "Exists"
         {{- end }}
       hostNetwork: {{ .Values.node.hostNetwork }}
       {{- with .Values.node.securityContext }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
helm

**What is this PR about? / Why do we need it?**
The driver node plugin must stay running after all stateful workloads are evicted from pod so that it can Unpublish/Unstage volumes and report that back to the Kubelet. Therefore, EBS CSI Driver Daemonset needs to tolerate auto-scalar node drain/deletion taints if customers have set `node.TolerateAllTaints=false`

With this PR we tolerate 3 common auto-scalar taints:

- [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/blob/d2077d6294bc29b7dea4d38e3aea65ecde3d598e/cluster-autoscaler/utils/taints/taints.go#L40)
- [Karpenter v1](https://github.com/kubernetes-sigs/karpenter/blob/a860293883b67cbda0b8f7917130ccd6857b6cc3/pkg/apis/v1/taints.go#L27)
- [Karpenter v1beta1](https://github.com/kubernetes-sigs/karpenter/blob/cde25b377861dbe80932ef6022f49b7aaad5760a/pkg/apis/v1beta1/taints.go#L23)

**What testing is done?** 

```
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set node.tolerateAllTaints=false > post.yml
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set node.tolerateAllTaints=false > pre.yml

❯ diff pre.yml post.yml -C 5
*** pre.yml	2024-10-02 15:28:21.971993034 +0000
--- post.yml	2024-10-02 15:28:13.722043329 +0000
***************
*** 452,461 ****
--- 452,470 ----
        priorityClassName: system-node-critical
        tolerations:
          - effect: NoExecute
            operator: Exists
            tolerationSeconds: 300
+         - effect: NoSchedule
+           key: ToBeDeletedByClusterAutoscaler
+           operator: Exists
+         - effect: NoSchedule
+           key: karpenter.sh/disrupted
+           operator: Exists
+         - effect: NoSchedule
+           key: karpenter.sh/disruption
+           operator: Exists
          - key: "ebs.csi.aws.com/agent-not-ready"
            operator: "Exists"
        hostNetwork: false
        securityContext:
          fsGroup: 0
```

Also quick test that taint is tolerated on live cluster. 