### PR TITLE
docs: Fix typo in volume topology zone match label

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -53,7 +53,7 @@ allowedTopologies:
 - matchLabelExpressions:
   - key: topology.kubernetes.io/zone
     values:
-    - us-east-1
+    - us-east-1a
 ```
 
 Additionally, statically provisioned volumes can be restricted to pods in the appropriate Availability Zone, see the [static provisioning example](../examples/kubernetes/static-provisioning/).


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
A typo in the documentation

**What is this PR about? / Why do we need it?**
If we compare it to: https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies, the doc contain the the availability zone and not the region.

**What testing is done?** 
None ATM, just reading the docs.