### PR TITLE
Add EnableFSRs to example policy

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -13,7 +13,8 @@
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications"
+        "ec2:DescribeVolumesModifications",
+        "ec2:EnableFastSnapshotRestores"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

"Feature"

**What is this PR about? / Why do we need it?**

Adds `ec2:EnableFastSnapshotRestores` to the example IAM policy

**What testing is done?** 

This is already present in the policy used by kops for testing, so it is already tested