### PR TITLE
Fix typos in options.go and cloud_test.go

### DIFF
--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -602,7 +602,7 @@ func TestCheckDesiredState(t *testing.T) {
 		expErr         error
 	}{
 		{
-			name:           "sucess: normal path",
+			name:           "success: normal path",
 			volumeId:       "vol-001",
 			desiredSizeGiB: 5,
 			options: &ModifyDiskOptions{

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -92,7 +92,7 @@ type Options struct {
 }
 
 func (o *Options) AddFlags(f *flag.FlagSet) {
-	f.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to a kubeconfig file. The default is the emtpy string, which causes the in-cluster config to be used")
+	f.StringVar(&o.Kubeconfig, "kubeconfig", "", "Absolute path to a kubeconfig file. The default is the empty string, which causes the in-cluster config to be used")
 
 	// Server options
 	f.StringVar(&o.Endpoint, "endpoint", DefaultCSIEndpoint, "Endpoint for the CSI driver server")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
spelling fix
**What is this PR about? / Why do we need it?**
Fixes two spelling errors found from [Go report card](https://goreportcard.com/report/github.com/kubernetes-sigs/aws-ebs-csi-driver#misspell)
**What testing is done?** 
N/A
