### PR TITLE
Bump GH actions (trivy, codeql, upload-artifact)

### DIFF
--- a/.github/workflows/generate-code-coverage.yaml
+++ b/.github/workflows/generate-code-coverage.yaml
@@ -41,7 +41,7 @@ jobs:
           cat base-coverage.tmp | grep -v "mock_" > base-coverage.out
 
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: base-coverage
           path: base-coverage.out
@@ -64,7 +64,7 @@ jobs:
           cat pr-coverage.tmp | grep -v "mock_" > pr-coverage.out
 
       - name: Upload report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-coverage
           path: pr-coverage.out

--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -68,7 +68,7 @@ jobs:
         run: docker pull ${{ matrix.image }}
 
       - name: Scan container image
-        uses: aquasecurity/trivy-action@0.16.1
+        uses: aquasecurity/trivy-action@0.26.0
         with:
           image-ref: '${{ matrix.image }}'
           output: 'results.sarif'
@@ -77,6 +77,6 @@ jobs:
           severity: 'HIGH,CRITICAL'
       
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'results.sarif'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.26.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -41,6 +41,6 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'results.sarif'


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Dependency

**What is this PR about? / Why do we need it?**

Bump the following GitHub actions:
- [github/codeql-action](https://github.com/github/codeql-action) from 2 to 3.
  - v2 is deprecated, support will end Dec 5, 2024 [(source)](https://github.com/github/codeql-action?tab=readme-ov-file#supported-versions-of-the-codeql-action)
- [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from 0.16.1 to 0.26.0*
  - [Changelog here](https://github.com/aquasecurity/trivy-action/releases)
- [actions/upload-artifact](https://github.com/actions/upload-artifact) from 3 to 4.

**What testing is done?** 

CI, changelog read-through, what else should be done? 

Confirmed no [upload-artifact v3 to v4 migration steps](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) applied to us:
  - Artifacts are now immutable (but we were not mutating any within job/workflow)
  - We have no hidden files
