### PR TITLE
Automate image dependency upgrades & Migrate to kubekins-e2e-v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,10 @@ generate-sidecar-tags: update-truth-sidecars charts/aws-ebs-csi-driver/values.ya
 .PHONY: update-sidecar-dependencies
 update-sidecar-dependencies: update-truth-sidecars generate-sidecar-tags update/kustomize
 
+.PHONY: update-image-dependencies
+update-image-dependencies: update-sidecar-dependencies
+	./hack/release-scripts/update-e2e-images
+
 ## CI aliases
 # Targets intended to be executed mostly or only by CI jobs
 

--- a/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
+++ b/charts/aws-ebs-csi-driver/templates/tests/helm-tester.yaml
@@ -225,10 +225,8 @@ spec:
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config
-  # kubekins-e2e v1 image is linux amd64 only.
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.io/arch: amd64
   serviceAccountName: ebs-csi-driver-test
   volumes:
     - name: config-vol

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -490,4 +490,4 @@ nodeComponentOnly: false
 helmTester:
   enabled: true
   # Supply a custom image to the ebs-csi-driver-test pod in helm-tester.yaml
-  image: "gcr.io/k8s-staging-test-infra/kubekins-e2e:v20240903-6a352c5344-master"
+  image: "us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:v20240903-6a352c5344-master"

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -199,9 +199,13 @@ Test the EBS CSI Driver Helm chart via the [Helm `chart-testing` tool](https://g
 
 ## Release Scripts
 
+### 'make update-image-dependencies'
+
+Convenience target to perform all image updates (including sidecars, kubekins-e2e-v2, and gcb-docker-gcloud). This is the primary target to use unless more granular control is needed.
+
 ### `make update-sidecar-dependencies`
 
-Convenience target to perform all sidecar updates and regenerate the manifests. This is the primary target to use unless more granular control is needed.
+Convenience target to perform all sidecar updates and regenerate the manifests. 
 
 ### `make update-truth-sidecars`
 

--- a/hack/release-scripts/update-e2e-images
+++ b/hack/release-scripts/update-e2e-images
@@ -53,17 +53,15 @@ check_dependencies
 log "Fetching latest kubekins-e2e-v2 image from $KUBEKINS_REPO"
 KUBEKINS_TAG=$(crane ls "$KUBEKINS_REPO" | grep -E 'master$' | sort -V | tail -n 1)
 export KUBEKINS_IMAGE="$KUBEKINS_REPO:$KUBEKINS_TAG"
-log "Found $KUBEKINS_IMAGE"
 
-log "Updating kubekins-e2e-v2 image in $HELM_VALUES_FILEPATH"
+log "Updating kubekins-e2e-v2 image in $HELM_VALUES_FILEPATH to $KUBEKINS_IMAGE"
 yq ".helmTester.image = env(KUBEKINS_IMAGE)" -i "$HELM_VALUES_FILEPATH"
 
 log "Fetching latest gcb-docker-gcloud image from $GCB_REPO"
 GCB_TAG=$(crane ls "$GCB_REPO" | sort -V | tail -n 1)
 export GCB_IMAGE="$GCB_REPO:$GCB_TAG"
-log "Found $GCB_IMAGE"
 
-log "Updating gcb-docker-gcloud image in $CLOUDBUILD_FILEPATH"
+log "Updating gcb-docker-gcloud image in $CLOUDBUILD_FILEPATH to $GCB_IMAGE"
 yq ".steps[0].name = env(GCB_IMAGE)" -i "$CLOUDBUILD_FILEPATH"
 
 log "Success! Updated kubekins-e2e-v2 and gcb-docker-gcloud images!"

--- a/hack/release-scripts/update-e2e-images
+++ b/hack/release-scripts/update-e2e-images
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---
+# This script updates images used by aws-ebs-csi-driver CI
+
+set -euo pipefail # Exit on any error
+
+# --- Environment Variables
+export KUBEKINS_IMAGE GCB_IMAGE
+
+SCRIPT_PATH=$(dirname $(realpath "$0"))
+ROOT_DIRECTORY="$SCRIPT_PATH/../.."
+
+CLOUDBUILD_FILEPATH="$ROOT_DIRECTORY/cloudbuild.yaml"
+HELM_VALUES_FILEPATH="$ROOT_DIRECTORY/charts/aws-ebs-csi-driver/values.yaml"
+
+KUBEKINS_REPO="us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e"
+GCB_REPO="gcr.io/k8s-staging-test-infra/gcb-docker-gcloud"
+
+# --- Script Tools
+log() {
+  printf "%s [INFO] - %s\n" "$(date +"%Y-%m-%d %H:%M:%S")" "${*}" >&2
+}
+
+check_dependencies() {
+  local readonly dependencies=("yq" "git" "crane")
+
+  for cmd in "${dependencies[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log "${cmd} binary could not be found, please install it."
+      exit 1
+    fi
+  done
+}
+
+# --- Script
+
+check_dependencies
+
+log "Fetching latest kubekins-e2e-v2 image from $KUBEKINS_REPO"
+KUBEKINS_TAG=$(crane ls "$KUBEKINS_REPO" | grep -E 'master$' | sort -V | tail -n 1)
+export KUBEKINS_IMAGE="$KUBEKINS_REPO:$KUBEKINS_TAG"
+log "Found $KUBEKINS_IMAGE"
+
+log "Updating kubekins-e2e-v2 image in $HELM_VALUES_FILEPATH"
+yq ".helmTester.image = env(KUBEKINS_IMAGE)" -i "$HELM_VALUES_FILEPATH"
+
+log "Fetching latest gcb-docker-gcloud image from $GCB_REPO"
+GCB_TAG=$(crane ls "$GCB_REPO" | sort -V | tail -n 1)
+export GCB_IMAGE="$GCB_REPO:$GCB_TAG"
+log "Found $GCB_IMAGE"
+
+log "Updating gcb-docker-gcloud image in $CLOUDBUILD_FILEPATH"
+yq ".steps[0].name = env(GCB_IMAGE)" -i "$CLOUDBUILD_FILEPATH"
+
+log "Success! Updated kubekins-e2e-v2 and gcb-docker-gcloud images!"

--- a/hack/release-scripts/update-e2e-images
+++ b/hack/release-scripts/update-e2e-images
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023 The Kubernetes Authors.
+# Copyright 2024 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Automation

**What is this PR about? / Why do we need it?**

First, this PR automates two manual steps of our release process: updating the kubekins e2e image in our Helm chart, and updating the gcb-docker-gcloud image in our cloudbuild.yaml.

It combines these updates with our sidecar update script in the new Makefile target: `update-image-dependencies`

---

Second, kubekins-e2e is [deprecated](https://github.com/kubernetes/test-infra/tree/master/images/kubekins-e2e), so let's move to [kubekins-e2e-v2](https://github.com/kubernetes/test-infra/tree/master/images/kubekins-e2e-v2)

Quote from [Kubernetes SIG-Testing slack](https://kubernetes.slack.com/archives/C09QZ4DQB/p1708956700866859):
- It is leaner than the old image. We got rid of many legacy CI deps/tooling that are specific to k/k and don't need to be used in most repos
- It is a multiarch image, amd64 and arm64. This is important as we'll be running arm64 nodes in Prow in the future and someone recently proposed dynamic scheduling in Prow so if it works out, we would benefit from having many cloud and architecture agnostic jobs.
- It is built directly from debian:bookworm instead of bootstrap(a sig-testing image built from debian with legacy CI deps).

Will update internal runbook after merge. 

**What testing is done?** 

`./hack/release-scripts/update-e2e-images` works!
`make update-image-dependencies` works!

Lets hope CI is a fan of kubekins-e2e-v2...
