### PR TITLE
Update example-iam-policy.json

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -24,8 +24,8 @@
         "ec2:CreateTags"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:*:ec2:*:*:volume/*",
+        "arn:*:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -34,8 +34,8 @@
         "ec2:DeleteTags"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:*:ec2:*:*:volume/*",
+        "arn:*:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Resource": "arn:*:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
@@ -55,7 +55,7 @@
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Resource": "arn:*:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "aws:RequestTag/CSIVolumeName": "*"
@@ -67,7 +67,7 @@
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:aws:ec2:*:*:snapshot/*"
+      "Resource": "arn:*:ec2:*:*:snapshot/*"
     },
     {
       "Effect": "Allow",

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -47,8 +47,8 @@ spec:
             "ec2:CreateTags"
           ],
           "Resource": [
-            "arn:aws:ec2:*:*:volume/*",
-            "arn:aws:ec2:*:*:snapshot/*"
+            "arn:*:ec2:*:*:volume/*",
+            "arn:*:ec2:*:*:snapshot/*"
           ]
         },
         {
@@ -57,8 +57,8 @@ spec:
             "ec2:DeleteTags"
           ],
           "Resource": [
-            "arn:aws:ec2:*:*:volume/*",
-            "arn:aws:ec2:*:*:snapshot/*"
+            "arn:*:ec2:*:*:volume/*",
+            "arn:*:ec2:*:*:snapshot/*"
           ]
         },
         {
@@ -66,7 +66,7 @@ spec:
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:aws:ec2:*:*:volume/*",
+          "Resource": "arn:*:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
@@ -78,7 +78,7 @@ spec:
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:aws:ec2:*:*:volume/*",
+          "Resource": "arn:*:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "aws:RequestTag/CSIVolumeName": "*"
@@ -90,7 +90,7 @@ spec:
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:aws:ec2:*:*:snapshot/*"
+          "Resource": "arn:*:ec2:*:*:snapshot/*"
         },
         {
           "Effect": "Allow",


### PR DESCRIPTION
wildcard the aws partion field to prevent exclusion of partitions other than `aws`

**Is this a bug fix or adding new feature?**
bug fix

**What is this PR about? / Why do we need it?**
we noticed that a similar change on the Terraform modules for AWS [broke IaC deploys](https://github.com/terraform-aws-modules/terraform-aws-iam/pull/532) for partitions other than `aws` (like `aws-us-gov` for example)

**What testing is done?** 
