### PR TITLE
Stub nodeService to improve macos devloop

### DIFF
--- a/pkg/mounter/mount_unsupported.go
+++ b/pkg/mounter/mount_unsupported.go
@@ -1,0 +1,98 @@
+//go:build darwin
+// +build darwin
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mounter
+
+import (
+	"fmt"
+	mountutils "k8s.io/mount-utils"
+)
+
+const (
+	stubMessage = "nodeService is unsupported for this platform"
+)
+
+/*
+NOTE: This is stub implementation of nodeService so that maintainers without access to a Linux/Windows workstation can
+run driver e2e tests.
+*/
+
+func NewSafeMounter() (*mountutils.SafeFormatAndMount, error) {
+	return nil, fmt.Errorf("NewSafeMounter is not supported on this platform")
+}
+
+func NewSafeMounterV2() (*mountutils.SafeFormatAndMount, error) {
+	return nil, fmt.Errorf("NewSafeMounterV2 is not supported on this platform")
+}
+
+func (m *NodeMounter) FindDevicePath(devicePath, volumeID, partition, region string) (string, error) {
+	return stubMessage, fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) PreparePublishTarget(target string) error {
+	return fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) IsBlockDevice(fullPath string) (bool, error) {
+	return false, fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) GetBlockSizeBytes(devicePath string) (int64, error) {
+	return 1, fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) appendPartition(devicePath, partition string) string {
+	return stubMessage
+}
+
+func (m NodeMounter) GetDeviceNameFromMount(mountPath string) (string, int, error) {
+	return stubMessage, 0, fmt.Errorf(stubMessage)
+}
+
+func (m NodeMounter) IsCorruptedMnt(err error) bool {
+	return false
+}
+
+func (m *NodeMounter) MakeFile(path string) error {
+	return fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) MakeDir(path string) error {
+	return fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) PathExists(path string) (bool, error) {
+	return false, fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) Resize(devicePath, deviceMountPath string) (bool, error) {
+	return false, fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	return false, fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) Unpublish(path string) error {
+	return fmt.Errorf(stubMessage)
+}
+
+func (m *NodeMounter) Unstage(path string) error {
+	return fmt.Errorf(stubMessage)
+}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Developer Experience

**What is this PR about? / Why do we need it?**
Fixes #1556 

EBS CSI Driver does not support MacOS, but contributors may only have a mac development machine. Therefore the project should compile well enough for the typical development loop (e.g. build, running unit and e2e tests). 

As issue #1556 puts it "I should be able to run the e2e tests from my laptop without having to jump through hoops."

**What testing is done?** 
`make test` and ran e2e tests 
