### PR TITLE
fix write no permission

### DIFF
--- a/pkg/mounter/mount_linux.go
+++ b/pkg/mounter/mount_linux.go
@@ -269,7 +269,7 @@ func (m *NodeMounter) MakeFile(path string) error {
 // This function is mirrored in ./sanity_test.go to make sure sanity test covered this block of code
 // Please mirror the change to func MakeFile in ./sanity_test.go.
 func (m *NodeMounter) MakeDir(path string) error {
-	err := os.MkdirAll(path, os.FileMode(0755))
+	err := os.MkdirAll(path, os.FileMode(0777))
 	if err != nil {
 		if !os.IsExist(err) {
 			return err

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -58,7 +58,7 @@ func TestE2E(t *testing.T) {
 		// Create the directory if it doesn't already exists
 		// NOTE: junit report can be created with new --junit-report flag
 		// https://github.com/kubernetes/kubernetes/blob/4569e646ef161c0262d433aed324fec97a525572/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
-		if err := os.MkdirAll(framework.TestContext.ReportDir, 0755); err != nil {
+		if err := os.MkdirAll(framework.TestContext.ReportDir, 0777); err != nil {
 			log.Fatalf("Failed creating report directory: %v", err)
 		}
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bugfix

**What is this PR about? / Why do we need it?**
The storage plugin used by the application is changed from lvm to ebs, and an error is reported that there is no write permission. logs as below:
![image-20241105](https://github.com/user-attachments/assets/e794dbd9-d142-423c-bf81-483365a94fc7)
We found out that the mount point for the lvm plugin on the host machine had 777 permissions,  code: https://github.com/metal-stack/csi-driver-lvm/blob/master/pkg/lvm/lvm.go#L214 ,  while the ebs plugin's mount point had 755 permissions. After manually executing chmod 777,  the service running normally.


**What testing is done?** 
