### PR TITLE
Upgrade Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,22 @@
-**Is this a bug fix or adding new feature?**
+#### What type of PR is this?
 
-**What is this PR about? / Why do we need it?**
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+-->
 
-**What testing is done?** 
+#### What is this PR about? / Why do we need it?
+
+#### How was this change tested?
+
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, enter your extended release note in the block below.
+-->
+```release-note
+
+```


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Add release-note to pull request template so that we can think about release-notes at PR time and use [Kubernetes release-notes generator](https://github.com/kubernetes/release/blob/master/cmd/release-notes/README.md) instead of hand-crafting release notes at the end of each release. 

Also switches first question to suggesting to add a GitHub label. Hopefully one-day we can add an `area/helm` label as well. 

**Impact**: Saves ~25 minutes crafting release notes (if you aren't using [OSS-Repo-Management-Tools/get_pull_requests_since_last_version](https://github.com/AndrewSirenko/OSS-Repo-Management-Tools/blob/main/get_pull_requests_since_last_version)), and a team check-in about what note goes where. 

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```