### PR TITLE
Set image.pullPolicy to Always for Makefile installations

### DIFF
--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -31,7 +31,8 @@ function install_driver() {
       --set image.tag="${IMAGE_TAG}"
       --set node.enableWindows="${WINDOWS}"
       --set node.windowsHostProcess="${WINDOWS_HOSTPROCESS}"
-      --set=controller.k8sTagClusterId="${CLUSTER_NAME}"
+      --set controller.k8sTagClusterId="${CLUSTER_NAME}"
+      --set image.pullPolicy="Always"
       --timeout 10m0s
       --wait
       --kubeconfig "${KUBECONFIG}")


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

Makefile/CI change

**What is this PR about? / Why do we need it?**

Because the tag is based on the cluster name, not setting `image.pullPolicy` in dev can lead to stale images. Set it to `Always` so that a fresh image is guaranteed.

**What testing is done?** 

Manually tested + CI
