### PR TITLE
Update patch-cluster.yaml to v1beta1 for Vac

### DIFF
--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -17,7 +17,7 @@ spec:
     featureGates:
       VolumeAttributesClass: "true"
     runtimeConfig:
-      storage.k8s.io/v1alpha1: "true"
+      storage.k8s.io/v1beta1: "true"
   kubeControllerManager:
     featureGates:
       VolumeAttributesClass: "true"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

/kind cleanup

**What is this PR about? / Why do we need it?**

Update patch-cluster.yaml to v1beta1 for Vac so we can use our own VAC example in CI for Kops clusters.  

**What testing is done?** 
