### PR TITLE
Add helm chart configuration to add init containers to the node daemonset 

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -57,6 +57,10 @@ spec:
           hostProcess: true
           runAsUserName: "NT AUTHORITY\\SYSTEM"
       hostNetwork: true
+      {{- with .Values.node.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: ebs-plugin

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -60,6 +60,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.node.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: ebs-plugin
           image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -435,6 +435,14 @@ node:
   containerSecurityContext:
     readOnlyRootFilesystem: true
     privileged: true
+  initContainers: []
+  # containers to be run before the csi-node's container starts.
+  #
+  # Example:
+  #
+  # - name: wait
+  #   image: busybox
+  #   command: [ 'sh', '-c', "sleep 20" ]
   # Enable opentelemetry tracing for the plugin running on the daemonset
   otelTracing: {}
   #  otelServiceName: ebs-csi-node


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
Adding a new feature

**What is this PR about? / Why do we need it?**
Adds the ability to add init containers to the node daemonset with the helm chart. 

The controller has this configuration. We have a use case where we would like to use an init container on the node to set the hop limit on each node in our cluster that uses the csi driver. 


**What testing is done?** 
I was only able to test this on a Linux cluster, I do not have any windows nodes. 

Using the following values file
```yaml
node:
  initContainers:
  - name: wait
    image: busybox
    command: ['sh', '-c', "sleep 20"]
```

Generates the following manifest for the node-daemonset

```yaml
# Source: aws-ebs-csi-driver/templates/node.yaml
kind: DaemonSet
apiVersion: apps/v1
metadata:
  name: ebs-csi-node
  namespace: default
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: release-name
    helm.sh/chart: aws-ebs-csi-driver-2.36.0
    app.kubernetes.io/version: "1.36.0"
    app.kubernetes.io/component: csi-driver
    app.kubernetes.io/managed-by: Helm
spec:
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: ebs-csi-node
      app.kubernetes.io/name: aws-ebs-csi-driver
      app.kubernetes.io/instance: release-name
  updateStrategy:
    rollingUpdate:
      maxUnavailable: 10%
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: ebs-csi-node
        app.kubernetes.io/name: aws-ebs-csi-driver
        app.kubernetes.io/instance: release-name
        helm.sh/chart: aws-ebs-csi-driver-2.36.0
        app.kubernetes.io/version: "1.36.0"
        app.kubernetes.io/component: csi-driver
        app.kubernetes.io/managed-by: Helm
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: eks.amazonaws.com/compute-type
                operator: NotIn
                values:
                - fargate
              - key: node.kubernetes.io/instance-type
                operator: NotIn
                values:
                - a1.medium
                - a1.large
                - a1.xlarge
                - a1.2xlarge
                - a1.4xlarge
      nodeSelector:
        kubernetes.io/os: linux
      serviceAccountName: ebs-csi-node-sa
      terminationGracePeriodSeconds: 30
      priorityClassName: system-node-critical
      tolerations:
        - operator: Exists
      hostNetwork: false
      securityContext:
        fsGroup: 0
        runAsGroup: 0
        runAsNonRoot: false
        runAsUser: 0
      initContainers:
        - command:
          - sh
          - -c
          - sleep 20
          image: busybox
          name: wait
      containers:
        - name: ebs-plugin
          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.36.0
          imagePullPolicy: IfNotPresent
          args:
            - node
            - --endpoint=$(CSI_ENDPOINT)
            - --logging-format=text
            - --v=2
          env:
            - name: CSI_ENDPOINT
              value: unix:/csi/csi.sock
            - name: CSI_NODE_NAME
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
          volumeMounts:
            - name: kubelet-dir
              mountPath: /var/lib/kubelet
              mountPropagation: "Bidirectional"
            - name: plugin-dir
              mountPath: /csi
            - name: device-dir
              mountPath: /dev
          ports:
            - name: healthz
              containerPort: 9808
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /healthz
              port: healthz
            initialDelaySeconds: 10
            timeoutSeconds: 3
            periodSeconds: 10
            failureThreshold: 5
          resources:
            limits:
              memory: 256Mi
            requests:
              cpu: 10m
              memory: 40Mi
          securityContext:
            privileged: true
            readOnlyRootFilesystem: true
          lifecycle:
            preStop:
              exec:
                command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
        - name: node-driver-registrar
          image: public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.12.0-eks-1-31-5
          imagePullPolicy: IfNotPresent
          args:
            - --csi-address=$(ADDRESS)
            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
            - --v=2
          env:
            - name: ADDRESS
              value: /csi/csi.sock
            - name: DRIVER_REG_SOCK_PATH
              value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
          livenessProbe:
            exec:
              command:
              - /csi-node-driver-registrar
              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
              - --mode=kubelet-registration-probe
            initialDelaySeconds: 30
            periodSeconds: 90
            timeoutSeconds: 15
          volumeMounts:
            - name: plugin-dir
              mountPath: /csi
            - name: registration-dir
              mountPath: /registration
            - name: probe-dir
              mountPath: /var/lib/kubelet/plugins/ebs.csi.aws.com/
          resources:
            limits:
              memory: 256Mi
            requests:
              cpu: 10m
              memory: 40Mi
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
        - name: liveness-probe
          image: public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.14.0-eks-1-31-5
          imagePullPolicy: IfNotPresent
          args:
            - --csi-address=/csi/csi.sock
          volumeMounts:
            - name: plugin-dir
              mountPath: /csi
          resources:
            limits:
              memory: 256Mi
            requests:
              cpu: 10m
              memory: 40Mi
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
      volumes:
        - name: kubelet-dir
          hostPath:
            path: /var/lib/kubelet
            type: Directory
        - name: plugin-dir
          hostPath:
            path: /var/lib/kubelet/plugins/ebs.csi.aws.com/
            type: DirectoryOrCreate
        - name: registration-dir
          hostPath:
            path: /var/lib/kubelet/plugins_registry/
            type: Directory
        - name: device-dir
          hostPath:
            path: /dev
            type: Directory
        - name: probe-dir
          emptyDir: {}
```

Which when deployed creates a daemonset with a busybox init container.

Solves #2214 