### PR TITLE
Fixup trivy workflows

### DIFF
--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -14,9 +14,6 @@
 
 name: Trivy Scanner - Container Images
 on:
-  push:
-    branches:
-      - master
   schedule:
     - cron: '0 */24 * * *'
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,9 +14,6 @@
 
 name: Trivy Scanner
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 permissions:


### PR DESCRIPTION
#### What is this PR about? / Why do we need it?

This PR removes trivy scans that run on push to master. Since we're already scanning all PRs before they get merged, running the scan on master push is redundant.

Similar change for the container image scan workflow, it is desirable to run them only once, daily.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
