### PR TITLE
[WIP] Scope down IAM policy

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -4,19 +4,41 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateSnapshot",
-        "ec2:AttachVolume",
-        "ec2:DetachVolume",
-        "ec2:ModifyVolume",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications",
-        "ec2:EnableFastSnapshotRestores"
+        "ec2:DescribeVolumesModifications"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:ModifyVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:DetachVolume"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:instance/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:EnableFastSnapshotRestores"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*"
     },
     {
       "Effect": "Allow",
@@ -24,26 +46,43 @@
         "ec2:CreateTags"
       ],
       "Resource": [
-        "arn:*:ec2:*:*:volume/*",
-        "arn:*:ec2:*:*:snapshot/*"
-      ]
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot"
+          ]
+        }
+      }
     },
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:CreateTags",
         "ec2:DeleteTags"
       ],
       "Resource": [
-        "arn:*:ec2:*:*:volume/*",
-        "arn:*:ec2:*:*:snapshot/*"
-      ]
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringNotLike": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "*",
+          "aws:RequestTag/CSIVolumeName": "*",
+          "aws:RequestTag/CSIVolumeSnapshotName": "*",
+          "aws:RequestTag/kubernetes.io/created-for/pvc/name": "*"
+        }
+      }
     },
     {
       "Effect": "Allow",
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:*:ec2:*:*:volume/*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
@@ -55,7 +94,7 @@
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:*:ec2:*:*:volume/*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "aws:RequestTag/CSIVolumeName": "*"
@@ -65,16 +104,9 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateVolume"
-      ],
-      "Resource": "arn:*:ec2:*:*:snapshot/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "ec2:DeleteVolume"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
@@ -86,7 +118,7 @@
       "Action": [
         "ec2:DeleteVolume"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/CSIVolumeName": "*"
@@ -98,7 +130,7 @@
       "Action": [
         "ec2:DeleteVolume"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
@@ -108,9 +140,33 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/CSIVolumeSnapshotName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:DeleteSnapshot"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
@@ -122,7 +178,7 @@
       "Action": [
         "ec2:DeleteSnapshot"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -30,19 +30,41 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "ec2:CreateSnapshot",
-            "ec2:AttachVolume",
-            "ec2:DetachVolume",
-            "ec2:ModifyVolume",
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeInstances",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",
             "ec2:DescribeVolumes",
-            "ec2:DescribeVolumesModifications",
-            "ec2:EnableFastSnapshotRestores"
+            "ec2:DescribeVolumesModifications"
           ],
           "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateSnapshot",
+            "ec2:ModifyVolume"
+          ],
+          "Resource": "arn:aws:ec2:*:*:volume/*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:AttachVolume",
+            "ec2:DetachVolume"
+          ],
+          "Resource": [
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:instance/*"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateVolume",
+            "ec2:EnableFastSnapshotRestores"
+          ],
+          "Resource": "arn:aws:ec2:*:*:snapshot/*"
         },
         {
           "Effect": "Allow",
@@ -50,26 +72,43 @@ spec:
             "ec2:CreateTags"
           ],
           "Resource": [
-            "arn:*:ec2:*:*:volume/*",
-            "arn:*:ec2:*:*:snapshot/*"
-          ]
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "ec2:CreateAction": [
+                "CreateVolume",
+                "CreateSnapshot"
+              ]
+            }
+          }
         },
         {
           "Effect": "Allow",
           "Action": [
+            "ec2:CreateTags",
             "ec2:DeleteTags"
           ],
           "Resource": [
-            "arn:*:ec2:*:*:volume/*",
-            "arn:*:ec2:*:*:snapshot/*"
-          ]
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
+          ],
+          "Condition": {
+            "StringNotLike": {
+              "aws:RequestTag/ebs.csi.aws.com/cluster": "*",
+              "aws:RequestTag/CSIVolumeName": "*",
+              "aws:RequestTag/CSIVolumeSnapshotName": "*",
+              "aws:RequestTag/kubernetes.io/created-for/pvc/name": "*"
+            }
+          }
         },
         {
           "Effect": "Allow",
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:*:ec2:*:*:volume/*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
@@ -81,7 +120,7 @@ spec:
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:*:ec2:*:*:volume/*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "aws:RequestTag/CSIVolumeName": "*"
@@ -91,16 +130,9 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "ec2:CreateVolume"
-          ],
-          "Resource": "arn:*:ec2:*:*:snapshot/*"
-        },
-        {
-          "Effect": "Allow",
-          "Action": [
             "ec2:DeleteVolume"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
@@ -112,7 +144,7 @@ spec:
           "Action": [
             "ec2:DeleteVolume"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/CSIVolumeName": "*"
@@ -124,7 +156,7 @@ spec:
           "Action": [
             "ec2:DeleteVolume"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
@@ -134,9 +166,33 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
+            "ec2:CreateSnapshot"
+          ],
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/CSIVolumeSnapshotName": "*"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateSnapshot"
+          ],
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
             "ec2:DeleteSnapshot"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
@@ -148,7 +204,7 @@ spec:
           "Action": [
             "ec2:DeleteSnapshot"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What is this PR about? / Why do we need it?

Updates the example IAM policy with the following changes:
- Reverts from `*` partition to `aws` partition for consistency with the managed policy (TODO: Add documentation about this - will be done in a future revision of the PR)
- Moves mutating actions from `*` resource to more specific resources
- Consolidates some statements that can be combined with `ForAnyValue`
- Restricts modification of tags to only allow adding managed tags during volume/snapshot creation

#### How was this change tested?

Manually + CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
TODO - WIP
```
