### PR TITLE
Fix Trivy TOOMANYREQUESTS errors

### DIFF
--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Scan container image
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           image-ref: '${{ matrix.image }}'
           output: 'results.sarif'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -15,6 +15,8 @@
 name: Trivy Scanner
 on:
   pull_request:
+    branches:
+      - 'release-*'
 
 permissions:
   contents: read
@@ -30,6 +32,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

This should eliminate or greatly reduce the number of `TOOMANYREQUESTS` errors hit by the Trivy action via:
- Only running the PR scanner on PRs to release branches (which is where we care about avoiding vulnerabilities in our dependencies)
- Adds ECR Public as a fallback to both Trivy actions

#### How was this change tested?
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
