### PR TITLE
Enable VAC feature gate for Kustomize deployments

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -147,6 +147,7 @@ spec:
             - --kube-api-burst=100
             - --worker-threads=100
             - --retry-interval-max=30m
+            - --feature-gates=VolumeAttributesClass=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -235,6 +236,7 @@ spec:
             - --kube-api-burst=100
             - --workers=100
             - --retry-interval-max=30m
+            - --feature-gates=VolumeAttributesClass=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/hack/update-kustomize.sh
+++ b/hack/update-kustomize.sh
@@ -24,7 +24,7 @@ TEMP_DIR=$(mktemp -d)
 trap "rm -rf \"${TEMP_DIR}\"" EXIT
 cp "deploy/kubernetes/base/kustomization.yaml" "${TEMP_DIR}/kustomization.yaml"
 
-"${BIN}/helm" template --output-dir "${TEMP_DIR}" --skip-tests --api-versions 'snapshot.storage.k8s.io/v1' --api-versions 'policy/v1/PodDisruptionBudget' --set 'controller.userAgentExtra=kustomize' kustomize charts/aws-ebs-csi-driver >/dev/null
+"${BIN}/helm" template --output-dir "${TEMP_DIR}" --skip-tests --api-versions 'storage.k8s.io/v1beta1/VolumeAttributesClass' --api-versions 'snapshot.storage.k8s.io/v1' --api-versions 'policy/v1/PodDisruptionBudget' --set 'controller.userAgentExtra=kustomize' kustomize charts/aws-ebs-csi-driver >/dev/null
 rm -rf "deploy/kubernetes/base"
 mv "${TEMP_DIR}/aws-ebs-csi-driver/templates" "deploy/kubernetes/base"
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Fixes #2238 

After discussion, we decided for a consistent experience and because the downsides are significant if a user attempts to use it while disabled on the sidecars, we will enable the VAC feature gate for the Kustomize deployment. 

#### How was this change tested?

Manually tested + CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
[TODO AFTER GENERATING RELEASE NOTES: Move to "Urgent Upgrade Notes" section] Enables the `VolumeAttributesClass` by default for the Kustomize deployment. If you are deploying using the Kustomize manifests on a cluster that does not have the `VolumeAttributesClass` feature gate enabled on the control plane, you may see harmless extra failures related to the feature in the csi-provisioner and/or csi-resizer logs.
```
