### PR TITLE
Add FIPS image and Helm option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY . .
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION
+ARG GOEXPERIMENT
 RUN --mount=type=cache,target=/gomodcache --mount=type=cache,target=/gocache OS=$TARGETOS ARCH=$TARGETARCH make
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al23 AS linux-al2023

--- a/charts/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Determine image
+*/}}
+{{- define "aws-ebs-csi-driver.fullImagePath" -}}
+{{ printf "%s%s:%s%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) (.Values.fips | ternary "-fips" "") }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "aws-ebs-csi-driver.labels" -}}

--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -64,7 +64,7 @@ spec:
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ include "aws-ebs-csi-driver.fullImagePath" $ }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.node.windowsHostProcess }}
           command:
@@ -111,6 +111,10 @@ spec:
               value: {{ .otelServiceName }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otelExporterEndpoint }}
+            {{- if .Values.fips }}
+            - name: AWS_USE_FIPS_ENDPOINT
+              value: "true"
+            {{- end }}
             {{- end }}
             {{- with .Values.node.env }}
             {{- . | toYaml | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -66,7 +66,7 @@ spec:
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (toString .Values.image.tag)) }}
+          image: {{ include "aws-ebs-csi-driver.fullImagePath" $ }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - node
@@ -111,6 +111,10 @@ spec:
               value: {{ .otelServiceName }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otelExporterEndpoint }}
+            {{- end }}
+            {{- if .Values.fips }}
+            - name: AWS_USE_FIPS_ENDPOINT
+              value: "true"
             {{- end }}
             {{- with .Values.node.env }}
             {{- . | toYaml | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -71,7 +71,7 @@ spec:
       {{- end }}
       containers:
         - name: ebs-plugin
-          image: {{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
+          image: {{ include "aws-ebs-csi-driver.fullImagePath" $ }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - controller
@@ -149,6 +149,10 @@ spec:
               value: {{ .otelServiceName }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otelExporterEndpoint }}
+            {{- end }}
+            {{- if .Values.fips }}
+            - name: AWS_USE_FIPS_ENDPOINT
+              value: "true"
             {{- end }}
           {{- with .Values.controller.envFrom }}
           envFrom:

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -12,6 +12,7 @@
 {{- include "node" (deepCopy $ | mustMerge $args) -}}
 {{- end }}
 {{- if .Values.a1CompatibilityDaemonSet }}
+{{- not .Values.fips | required "FIPS mode not supported for A1 instance family compatibility image" -}}
 {{$args := dict
   "NodeName" "ebs-csi-node-a1compat"
   "Values" (dict

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -11,6 +11,12 @@ image:
 customLabels: {}
 # k8s-app: aws-ebs-csi-driver
 
+# Instruct the AWS SDK to use AWS FIPS endpoints, and deploy container built with BoringCrypto (a FIPS-validated cryptographic library) instead of the Go default
+#
+# The EBS CSI Driver FIPS images have not undergone FIPS certification, and no official guarnatee is made about the compliance of these images under the FIPS standard
+# Users relying on these images for FIPS compliance should perform their own independent evaluation
+fips: false
+
 sidecars:
   provisioner:
     env: []

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,0 +1,15 @@
+# EBS CSI Driver FIPS Support
+
+## Support
+
+The EBS CSI Driver Helm chart can be configured to enable two modifications to better support environments that require FIPS certification. Both of these modifications are activated by changing the Helm parameter `fips` from `false` to `true`.
+
+### FIPS Endpoints
+
+The AWS SDK will be instructed to use FIPS endpoints [via the `AWS_USE_FIPS_ENDPOINT` environment variable](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html). FIPS endpoints are only supported in some regions, and thus the option will only work in regions that have both an STS and EC2 FIPS endpoint available. For a full list of current regions with FIPS endpoints available, see [the FIPS section of the AWS documentation](https://aws.amazon.com/compliance/fips/).
+
+### FIPS Image
+
+The EBS CSI Driver image will be swapped with an image built using BoringCrypto as Go's cryptographic library. BoringCrypto has [an active FIPS 140-3 certification](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735).
+
+The EBS CSI Driver FIPS images have not undergone FIPS certification, and no official guarantee is made about the compliance of these images under the FIPS standard. Users relying on these images for FIPS compliance should perform their own independent evaluation.

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -20,7 +20,11 @@ All other tools are downloaded for you at runtime.
 
 ### `make cluster/image`
 
-Build and push a single image of the driver based on the local platform (the same overrides as `make` apply, as well as `OSVERSION` to override container OS version). In most cases, `make all-push` is more suitable. Environment variables are accepted to override the `REGISTRY`, `IMAGE` name, and image `TAG`.
+Build and push an image of the driver for local development. Environment variables are accepted to override the `REGISTRY`, `IMAGE` name, and image `TAG`. Setting `FIPS` to `true` will build an image using a FIPS-validated cryptographic library.
+
+### `make all-push`
+
+Build and push all image variants of the driver needed for an official release. This target is not intended or designed to be run outside of CI.
 
 ## Local Development
 

--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -42,4 +42,4 @@ loudecho "Push manifest list containing amazon linux and windows based images to
 export IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
 export TAG=$GIT_TAG
 export VERSION=$PULL_BASE_REF
-IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push-with-a1compat
+IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push-for-release


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

This PR adds a FIPS image and helm chart option `fips` that enables that image as well as deplying with the environment variable needed to instruct the AWS SDK to use FIPS endpoints.

#### How was this change tested?

Manually/CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Build additional FIPS image and add Helm FIPS parameter
```
