### PR TITLE
Update metrics to align with Prometheus best practices

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -344,6 +344,7 @@ controller:
 node:
   env: []
   envFrom: []
+  enableMetrics: false
   kubeletPath: /var/lib/kubelet
   loggingFormat: text
   logLevel: 2

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -173,7 +173,7 @@ func main() {
 		region = md.GetRegion()
 	}
 
-	cloud, err := cloud.NewCloud(region, options.AwsSdkDebugLog, options.UserAgentExtra, options.Batching)
+	cloud, err := cloud.NewCloud(region, options.AwsSdkDebugLog, options.UserAgentExtra, options.Batching, options.DeprecatedMetrics)
 	if err != nil {
 		klog.ErrorS(err, "failed to create cloud service")
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,7 +8,7 @@ $ helm repo add prometheus-community https://prometheus-community.github.io/helm
 $ helm repo update
 $ helm install prometheus prometheus-community/kube-prometheus-stack
 ```
-2. Enable metrics by setting `enableMetrics: true` in [values.yaml](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.yaml).
+2. Enable metrics by configuring `controller.enableMetrics` and `node.enableMetrics`.
 
 3. Deploy EBS CSI Driver:
 ```sh
@@ -21,26 +21,24 @@ Installing the Prometheus Operator and enabling metrics will deploy a [Service](
 
 ## AWS API Metrics
 
-The EBS CSI Driver will emit [AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/OperationList-query.html) metrics to the following TCP endpoint: `0.0.0.0:3301/metrics` if `enableMetrics: true` has been configured in the Helm chart.
+The EBS CSI Driver will emit [AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/OperationList-query.html) metrics to the following TCP endpoint: `0.0.0.0:3301/metrics` if `controller.enableMetrics: true` has been configured in the Helm chart.
 
 The metrics will appear in the following format: 
 ```sh
-# HELP cloudprovider_aws_api_request_duration_seconds [ALPHA] Latency of AWS API calls
-# TYPE cloudprovider_aws_api_request_duration_seconds histogram
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.005"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.01"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.025"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.05"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.1"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.25"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.5"} 0
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="1"} 1
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="2.5"} 1
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="5"} 1
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="10"} 1
-cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="+Inf"} 1
-cloudprovider_aws_api_request_duration_seconds_sum{request="AttachVolume"} 0.547694574
-cloudprovider_aws_api_request_duration_seconds_count{request="AttachVolume"} 1
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.005"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.01"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.025"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.05"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.1"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.25"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.5"} 0
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="1"} 1
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="2.5"} 1
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="5"} 1
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="10"} 1
+aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="+Inf"} 1
+aws_ebs_csi_api_request_duration_seconds_sum{request="AttachVolume"} 0.547694574
+aws_ebs_csi_api_request_duration_seconds_count{request="AttachVolume"} 1
 ...
 ```
 

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -334,12 +334,12 @@ var _ Cloud = &cloud{}
 
 // NewCloud returns a new instance of AWS cloud
 // It panics if session is invalid.
-func NewCloud(region string, awsSdkDebugLog bool, userAgentExtra string, batching bool) (Cloud, error) {
-	c := newEC2Cloud(region, awsSdkDebugLog, userAgentExtra, batching)
+func NewCloud(region string, awsSdkDebugLog bool, userAgentExtra string, batching bool, deprecatedMetrics bool) (Cloud, error) {
+	c := newEC2Cloud(region, awsSdkDebugLog, userAgentExtra, batching, deprecatedMetrics)
 	return c, nil
 }
 
-func newEC2Cloud(region string, awsSdkDebugLog bool, userAgentExtra string, batchingEnabled bool) Cloud {
+func newEC2Cloud(region string, awsSdkDebugLog bool, userAgentExtra string, batchingEnabled bool, deprecatedMetrics bool) Cloud {
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
 	if err != nil {
 		panic(err)
@@ -358,7 +358,7 @@ func newEC2Cloud(region string, awsSdkDebugLog bool, userAgentExtra string, batc
 
 	svc := ec2.NewFromConfig(cfg, func(o *ec2.Options) {
 		o.APIOptions = append(o.APIOptions,
-			RecordRequestsMiddleware(),
+			RecordRequestsMiddleware(deprecatedMetrics),
 			LogServerErrorsMiddleware(), // This middlware should always be last so it sees an unmangled error
 		)
 

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -82,11 +82,12 @@ func extractVolumeIdentifiers(volumes []types.Volume) (volumeIDs []string, volum
 
 func TestNewCloud(t *testing.T) {
 	testCases := []struct {
-		name            string
-		region          string
-		awsSdkDebugLog  bool
-		userAgentExtra  string
-		batchingEnabled bool
+		name              string
+		region            string
+		awsSdkDebugLog    bool
+		userAgentExtra    string
+		batchingEnabled   bool
+		deprecatedMetrics bool
 	}{
 		{
 			name:            "success: with awsSdkDebugLog, userAgentExtra, and batchingEnabled",
@@ -107,7 +108,7 @@ func TestNewCloud(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		ec2Cloud, err := NewCloud(tc.region, tc.awsSdkDebugLog, tc.userAgentExtra, tc.batchingEnabled)
+		ec2Cloud, err := NewCloud(tc.region, tc.awsSdkDebugLog, tc.userAgentExtra, tc.batchingEnabled, tc.deprecatedMetrics)
 		if err != nil {
 			t.Fatalf("error %v", err)
 		}

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -30,7 +30,7 @@ import (
 )
 
 // RecordRequestsHandler is added to the Complete chain; called after any request.
-func RecordRequestsMiddleware() func(*middleware.Stack) error {
+func RecordRequestsMiddleware(deprecatedMetrics bool) func(*middleware.Stack) error {
 	return func(stack *middleware.Stack) error {
 		return stack.Finalize.Add(middleware.FinalizeMiddlewareFunc("RecordRequestsMiddleware", func(ctx context.Context, input middleware.FinalizeInput, next middleware.FinalizeHandler) (output middleware.FinalizeOutput, metadata middleware.Metadata, err error) {
 			start := time.Now()
@@ -44,14 +44,23 @@ func RecordRequestsMiddleware() func(*middleware.Stack) error {
 						labels = map[string]string{
 							"operation_name": operationName,
 						}
-						metrics.Recorder().IncreaseCount("cloudprovider_aws_api_throttled_requests_total", labels)
+						metrics.Recorder().IncreaseCount("aws_ebs_csi_api_request_throttles_total", labels)
+						if deprecatedMetrics {
+							metrics.Recorder().IncreaseCount("cloudprovider_aws_api_throttled_requests_total", labels)
+						}
 					} else {
-						metrics.Recorder().IncreaseCount("cloudprovider_aws_api_request_errors", labels)
+						metrics.Recorder().IncreaseCount("aws_ebs_csi_api_request_errors_total", labels)
+						if deprecatedMetrics {
+							metrics.Recorder().IncreaseCount("cloudprovider_aws_api_request_errors", labels)
+						}
 					}
 				}
 			} else {
 				duration := time.Since(start).Seconds()
-				metrics.Recorder().ObserveHistogram("cloudprovider_aws_api_request_duration_seconds", duration, labels, nil)
+				metrics.Recorder().ObserveHistogram("aws_ebs_csi_api_request_duration_seconds_total", duration, labels, nil)
+				if deprecatedMetrics {
+					metrics.Recorder().ObserveHistogram("cloudprovider_aws_api_request_duration_seconds", duration, labels, nil)
+				}
 			}
 			return output, metadata, err
 		}), middleware.After)

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -57,7 +57,7 @@ func RecordRequestsMiddleware(deprecatedMetrics bool) func(*middleware.Stack) er
 				}
 			} else {
 				duration := time.Since(start).Seconds()
-				metrics.Recorder().ObserveHistogram("aws_ebs_csi_api_request_duration_seconds_total", duration, labels, nil)
+				metrics.Recorder().ObserveHistogram("aws_ebs_csi_api_request_duration_seconds", duration, labels, nil)
 				if deprecatedMetrics {
 					metrics.Recorder().ObserveHistogram("cloudprovider_aws_api_request_duration_seconds", duration, labels, nil)
 				}

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -67,6 +67,8 @@ type Options struct {
 	// flag to set the timeout for volume modification requests to be coalesced into a single
 	// volume modification call to AWS.
 	ModifyVolumeRequestHandlerTimeout time.Duration
+	// flag to enable deprecated metrics
+	DeprecatedMetrics bool
 
 	// #### Node options #####
 
@@ -113,6 +115,7 @@ func (o *Options) AddFlags(f *flag.FlagSet) {
 		f.StringVar(&o.UserAgentExtra, "user-agent-extra", "", "Extra string appended to user agent.")
 		f.BoolVar(&o.Batching, "batching", false, "To enable batching of API calls. This is especially helpful for improving performance in workloads that are sensitive to EC2 rate limits.")
 		f.DurationVar(&o.ModifyVolumeRequestHandlerTimeout, "modify-volume-request-handler-timeout", DefaultModifyVolumeRequestHandlerTimeout, "Timeout for the window in which volume modification calls must be received in order for them to coalesce into a single volume modification call to AWS. This must be lower than the csi-resizer and volumemodifier timeouts")
+		f.BoolVar(&o.DeprecatedMetrics, "deprecated-metrics", true, "DEPRECATED: To enable deprecated metrics. This parameter is only for backward compatibility and may be removed in a future release.")
 	}
 	// Node options
 	if o.Mode == AllMode || o.Mode == NodeMode {

--- a/pkg/driver/options_test.go
+++ b/pkg/driver/options_test.go
@@ -52,6 +52,9 @@ func TestAddFlags(t *testing.T) {
 	if err := f.Set("aws-sdk-debug-log", "true"); err != nil {
 		t.Errorf("error setting aws-sdk-debug-log: %v", err)
 	}
+	if err := f.Set("deprecated-metrics", "true"); err != nil {
+		t.Errorf("error setting deprecated-metrics: %v", err)
+	}
 	if err := f.Set("warn-on-invalid-tag", "true"); err != nil {
 		t.Errorf("error setting warn-on-invalid-tag: %v", err)
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	namespace = "aws_ebs_csi_"
+)
+
 var (
 	r    *metricRecorder // singleton instance of metricRecorder
 	once sync.Once

--- a/pkg/metrics/nvme_test.go
+++ b/pkg/metrics/nvme_test.go
@@ -46,19 +46,19 @@ func TestNewNVMECollector(t *testing.T) {
 	}
 
 	expectedMetrics := []string{
-		"total_read_ops",
-		"total_write_ops",
-		"total_read_bytes",
-		"total_write_bytes",
-		"total_read_time",
-		"total_write_time",
-		"ebs_volume_performance_exceeded_iops",
-		"ebs_volume_performance_exceeded_tp",
-		"ec2_instance_ebs_performance_exceeded_iops",
-		"ec2_instance_ebs_performance_exceeded_tp",
-		"volume_queue_length",
-		"read_io_latency_histogram",
-		"write_io_latency_histogram",
+		metricReadOps,
+		metricWriteOps,
+		metricReadBytes,
+		metricWriteBytes,
+		metricReadOpsSeconds,
+		metricWriteOpsSeconds,
+		metricExceededIOPS,
+		metricExceededTP,
+		metricExceededIOPS,
+		metricExceededTP,
+		metricVolumeQueueLength,
+		metricReadLatency,
+		metricWriteLatency,
 	}
 
 	for _, metricName := range expectedMetrics {

--- a/pkg/metrics/nvme_test.go
+++ b/pkg/metrics/nvme_test.go
@@ -87,9 +87,9 @@ func TestConvertHistogram(t *testing.T) {
 			},
 			wantCount: 10,
 			wantBuckets: map[float64]uint64{
-				100: 5,
-				200: 8,
-				300: 10,
+				100 / 1e6: 5,
+				200 / 1e6: 8,
+				300 / 1e6: 10,
 			},
 		},
 	}

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -621,7 +621,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
-		cloud, err := awscloud.NewCloud(region, false, "", true)
+		cloud, err := awscloud.NewCloud(region, false, "", true, false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}

--- a/tests/e2e/nvme_metrics.go
+++ b/tests/e2e/nvme_metrics.go
@@ -114,19 +114,22 @@ var _ = Describe("[ebs-csi-e2e] [single-az] NVMe Metrics", func() {
 		By("Verifying NVMe metrics")
 
 		expectedMetrics := []string{
-			"total_read_ops",
-			"total_write_ops",
-			"total_read_bytes",
-			"total_write_bytes",
-			"total_read_time",
-			"total_write_time",
-			"ebs_volume_performance_exceeded_iops",
-			"ebs_volume_performance_exceeded_tp",
-			"ec2_instance_ebs_performance_exceeded_iops",
-			"ec2_instance_ebs_performance_exceeded_tp",
-			"volume_queue_length",
-			"read_io_latency_histogram",
-			"write_io_latency_histogram",
+			"aws_ebs_csi_read_ops_total",
+			"aws_ebs_csi_write_ops_total",
+			"aws_ebs_csi_read_bytes_total",
+			"aws_ebs_csi_write_bytes_total",
+			"aws_ebs_csi_read_seconds_total",
+			"aws_ebs_csi_write_seconds_total",
+			"aws_ebs_csi_exceeded_iops_seconds_total",
+			"aws_ebs_csi_exceeded_tp_seconds_total",
+			"aws_ebs_csi_ec2_exceeded_iops_seconds_total",
+			"aws_ebs_csi_ec2_exceeded_tp_seconds_total",
+			"aws_ebs_csi_nvme_collector_scrapes_total",
+			"aws_ebs_csi_nvme_collector_errors_total",
+			"aws_ebs_csi_volume_queue_length",
+			"aws_ebs_csi_read_io_latency_seconds",
+			"aws_ebs_csi_write_io_latency_seconds",
+			"aws_ebs_csi_nvme_collector_duration_seconds",
 		}
 
 		for _, metric := range expectedMetrics {

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -87,7 +87,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region, false, "", true)
+		cloud, err = awscloud.NewCloud(region, false, "", true, false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}
@@ -260,7 +260,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 			Tags:               map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region, false, "", true)
+		cloud, err = awscloud.NewCloud(region, false, "", true, false)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

This PR updates the metrics registered by the node plugin to align with Prometheus best practices by:
- Adding a `aws_ebs_csi` namespace prefix.
- Following Prometheus conventions such as adding `_total` suffix for counter metrics.
- Using base units (seconds) instead of microseconds.

It also introduces a new parameter `controller.deprecatedMetrics` to disable registering the existing controller metrics that use an outdated namespace, such as:

```
cloudprovider_aws_api_request_duration_seconds_bucket{request="AttachVolume",le="0.005"} 0
```

Metrics using the new namespace will be registered by default if `controller.enableMetrics` is configured:
```
aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.005"} 0
```
#### How was this change tested?

- `make verify && make test`
- Manually
- CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
BREAKING CHANGE: Node plugin metrics have been renamed to follow Prometheus best practices:
- Added "aws_ebs_csi_" prefix.
- Added "_total" suffix for counters.
- Changed time units from microseconds to seconds for all counters.

Controller plugin metrics now use the "aws_ebs_csi_" prefix instead of "cloudprovider_aws_".
Old metric names can be disabled via the controller.deprecatedMetrics parameter.
```

#### Note for reviewers:

Please note that time units have been changed from microseconds to seconds for all counters. The read/write IO latency histograms is observed in microseconds (the buckets for these histograms are retrieved directly from the log page which record the data in microseconds).