### PR TITLE
enabling node metrics causes helm apply failure on malformed yaml

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -41,7 +41,7 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if .Values.node.enableMetrics -}}
+{{- if .Values.node.enableMetrics }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -347,6 +347,7 @@ node:
   kubeletPath: /var/lib/kubelet
   loggingFormat: text
   logLevel: 2
+  enableMetrics: false
   priorityClassName:
   additionalArgs: []
   affinity:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
#### What is this PR about? / Why do we need it?
Enabling node metrics causes helm apply failure on malformed yaml. 
The flag for enabling the it is missing from `values.yaml`.

#### How was this change tested?
By installing and upgrading the chart - 
```
helm -n kube-system diff upgrade aws-ebs-csi-driver helm-charts/aws-ebs-csi-driver --reset-then-reuse-values --set node.enableMetrics=true
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Helm chart failed to install/upgrade if `node.enableMetrics=true` was set.
```
