### PR TITLE
Selinux Mount Option

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -127,6 +127,12 @@ spec:
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
+            {{- if .Values.node.selinux }}
+            - name: selinux-sysfs
+              mountPath: /sys/fs/selinux
+            - name: selinux-config
+              mountPath: /etc/selinux/config
+            {{- end }}
           {{- with .Values.node.volumeMounts }}
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -244,6 +250,18 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        {{- if .Values.node.selinux }}
+        - name: selinux-sysfs
+          hostPath:
+            path: /sys/fs/selinux
+            type: Directory
+            readOnly: true
+        - name: selinux-config
+          hostPath:
+            path: /etc/selinux/config
+            type: File
+            readOnly: true
+        {{- end }}
         - name: probe-dir
           {{- if .Values.node.probeDirVolume }}
           {{- toYaml .Values.node.probeDirVolume | nindent 10 }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -342,6 +342,9 @@ controller:
   # Enable dnsConfig for the controller and node pods
   dnsConfig: {}
 node:
+  # Enable SELinux-only optimizations on the EBS CSI Driver node pods
+  # Must only be set true if all linux nodes in the DaemonSet have SELinux enabled
+  selinux: false
   env: []
   envFrom: []
   kubeletPath: /var/lib/kubelet


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Adds a new helm parameter, `node.selinux`, that mounts the relevant directories to allow the selinux-aware `mount` binary to perform selinux-specific optimizations. (This parameter can also be used in the future for any other selinux optimizations on the node).

This must be a parameter that is default-disabled, because `/sys/fs/selinux` will not exist unless SELinux is actually enabled on the nodes.

#### How was this change tested?

CI/Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add Helm parameter `node.selinux` to enable SELinux-specific mounts on the node DaemonSet
```
