### PR TITLE
Fixup FIPS Makefile/E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ sub-push: all-image-registry push-manifest
 
 .PHONY: sub-push-fips
 sub-push-fips:
-	$(MAKE) FIPS=true sub-push
+	$(MAKE) FIPS=true TAG=$(TAG)-fips sub-push
 
 .PHONY: sub-push-a1compat
 sub-push-a1-compat: sub-image-linux-arm64-al2

--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -64,7 +64,7 @@ function build_and_push() {
     export ALL_OS="linux"
     export ALL_ARCH_linux="${IMAGE_ARCH}"
   fi
-  make -j $(nproc) all-push
+  make -j $(nproc) sub-push
 
   loudecho "Image pushed to ${IMAGE_NAME}:${IMAGE_TAG}"
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Fixes two issues currently flaking our CI left and right:

- Use a different tag when pushing the FIPS image in `sub-push-fips`
- Switch `make cluster/image` from `all-push` to `sub-push` so it doesn't waste time building the a1compat and FIPS images

#### How was this change tested?

Manual/CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
