### PR TITLE
Remove outdated TODOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,13 +82,6 @@ test/coverage:
 	go tool cover -html=filtered_cover.out -o coverage.html
 	rm cover.out filtered_cover.out
 
-# TODO: Re-enable sanity tests
-# sanity tests have been disabled with the removal of NewFakeDriver, which was previously created to instantiate a fake driver utilized for testing. 
-# to re-enable tests, implement sanity tests creating a new driver instance by injecting mocked dependencies.
-#.PHONY: test-sanity
-#test-sanity:
-#	go test -v -race ./tests/sanity/...
-
 .PHONY: tools
 tools: bin/aws bin/ct bin/eksctl bin/ginkgo bin/golangci-lint bin/gomplate bin/helm bin/kops bin/kubetest2 bin/mockgen bin/shfmt
 

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -18,7 +18,6 @@
 # cleaning up (regardless of test success/failure), and passing out the result
 
 # Prevent race conditions by frontloading tool download
-# TODO: Find a way to lock pip installs to prevent pip concurrency bugs from hurting us
 make bin/aws
 
 case ${1} in


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Remove Makefile todo about removal of sanity tests because they are re-added in #2254 

Remove pip locking comment because that concern was addressed by #2012 

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
