### PR TITLE
Fix cloudbuild.sh target

### DIFF
--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -42,4 +42,4 @@ loudecho "Push manifest list containing amazon linux and windows based images to
 export IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
 export TAG=$GIT_TAG
 export VERSION=$PULL_BASE_REF
-IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push-for-release
+IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

`hack/cloudbuild.sh` references invalid makefile target `all-push-for-release`, it should be `all-push` - this causes all of our commits to `master` to fail to build (and would break building images for release as well).

#### How was this change tested?

Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
