### PR TITLE
Update example policy and documentation

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -4,19 +4,41 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateSnapshot",
-        "ec2:AttachVolume",
-        "ec2:DetachVolume",
-        "ec2:ModifyVolume",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications",
-        "ec2:EnableFastSnapshotRestores"
+        "ec2:DescribeVolumesModifications"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:ModifyVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:DetachVolume"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:instance/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:EnableFastSnapshotRestores"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*"
     },
     {
       "Effect": "Allow",
@@ -24,9 +46,17 @@
         "ec2:CreateTags"
       ],
       "Resource": [
-        "arn:*:ec2:*:*:volume/*",
-        "arn:*:ec2:*:*:snapshot/*"
-      ]
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot"
+          ]
+        }
+      }
     },
     {
       "Effect": "Allow",
@@ -34,8 +64,8 @@
         "ec2:DeleteTags"
       ],
       "Resource": [
-        "arn:*:ec2:*:*:volume/*",
-        "arn:*:ec2:*:*:snapshot/*"
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
       ]
     },
     {
@@ -43,7 +73,7 @@
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:*:ec2:*:*:volume/*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
@@ -55,7 +85,7 @@
       "Action": [
         "ec2:CreateVolume"
       ],
-      "Resource": "arn:*:ec2:*:*:volume/*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "aws:RequestTag/CSIVolumeName": "*"
@@ -65,16 +95,9 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateVolume"
-      ],
-      "Resource": "arn:*:ec2:*:*:snapshot/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "ec2:DeleteVolume"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
@@ -86,7 +109,7 @@
       "Action": [
         "ec2:DeleteVolume"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/CSIVolumeName": "*"
@@ -98,7 +121,7 @@
       "Action": [
         "ec2:DeleteVolume"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
@@ -108,9 +131,33 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/CSIVolumeSnapshotName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:DeleteSnapshot"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
@@ -122,7 +169,7 @@
       "Action": [
         "ec2:DeleteSnapshot"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {
         "StringLike": {
           "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -30,19 +30,41 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "ec2:CreateSnapshot",
-            "ec2:AttachVolume",
-            "ec2:DetachVolume",
-            "ec2:ModifyVolume",
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeInstances",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",
             "ec2:DescribeVolumes",
-            "ec2:DescribeVolumesModifications",
-            "ec2:EnableFastSnapshotRestores"
+            "ec2:DescribeVolumesModifications"
           ],
           "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateSnapshot",
+            "ec2:ModifyVolume"
+          ],
+          "Resource": "arn:aws:ec2:*:*:volume/*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:AttachVolume",
+            "ec2:DetachVolume"
+          ],
+          "Resource": [
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:instance/*"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateVolume",
+            "ec2:EnableFastSnapshotRestores"
+          ],
+          "Resource": "arn:aws:ec2:*:*:snapshot/*"
         },
         {
           "Effect": "Allow",
@@ -50,9 +72,17 @@ spec:
             "ec2:CreateTags"
           ],
           "Resource": [
-            "arn:*:ec2:*:*:volume/*",
-            "arn:*:ec2:*:*:snapshot/*"
-          ]
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "ec2:CreateAction": [
+                "CreateVolume",
+                "CreateSnapshot"
+              ]
+            }
+          }
         },
         {
           "Effect": "Allow",
@@ -60,8 +90,8 @@ spec:
             "ec2:DeleteTags"
           ],
           "Resource": [
-            "arn:*:ec2:*:*:volume/*",
-            "arn:*:ec2:*:*:snapshot/*"
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
           ]
         },
         {
@@ -69,7 +99,7 @@ spec:
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:*:ec2:*:*:volume/*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
@@ -81,7 +111,7 @@ spec:
           "Action": [
             "ec2:CreateVolume"
           ],
-          "Resource": "arn:*:ec2:*:*:volume/*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "aws:RequestTag/CSIVolumeName": "*"
@@ -91,16 +121,9 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
-            "ec2:CreateVolume"
-          ],
-          "Resource": "arn:*:ec2:*:*:snapshot/*"
-        },
-        {
-          "Effect": "Allow",
-          "Action": [
             "ec2:DeleteVolume"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
@@ -112,7 +135,7 @@ spec:
           "Action": [
             "ec2:DeleteVolume"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/CSIVolumeName": "*"
@@ -124,7 +147,7 @@ spec:
           "Action": [
             "ec2:DeleteVolume"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:volume/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
@@ -134,9 +157,33 @@ spec:
         {
           "Effect": "Allow",
           "Action": [
+            "ec2:CreateSnapshot"
+          ],
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/CSIVolumeSnapshotName": "*"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateSnapshot"
+          ],
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
+          "Condition": {
+            "StringLike": {
+              "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
             "ec2:DeleteSnapshot"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
@@ -148,12 +195,23 @@ spec:
           "Action": [
             "ec2:DeleteSnapshot"
           ],
-          "Resource": "*",
+          "Resource": "arn:aws:ec2:*:*:snapshot/*",
           "Condition": {
             "StringLike": {
               "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
             }
           }
+        },
+        {
+          "Sid": "ExtraStatementOnTopOfExampleToAllowTaggingTests",
+          "Effect": "Allow",
+          "Action": [
+            "ec2:CreateTags"
+          ],
+          "Resource": [
+            "arn:aws:ec2:*:*:volume/*",
+            "arn:aws:ec2:*:*:snapshot/*"
+          ]
         }
       ]
   cloudConfig:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind documentation

#### What is this PR about? / Why do we need it?

This PR updates the example policy and associated documentation to be in sync with the upcoming managed policy revision.

In particular; it:

- Scopes down several permissions (notably changing `*` resources to specific types such as `volume/*` and `snapshot/*`)
- Adds necessary permission change for the upcoming `CreateVolume` IAM handling change
- Adds the `EnableFSRs` permission
- Reverts the previous change to use the `*` partition, instead choosing to document the partition name in `install.md` to be consistent with the managed policy
- Adds documentation around permissions for modifying tags (and cleans up the IAM section of `install.md`)

#### How was this change tested?

Manually/CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Update the example IAM policy to be in sync with the AWS managed policy
```