### PR TITLE
Fix typo in Makefile a1compat target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ sub-push-fips:
 	$(MAKE) FIPS=true TAG=$(TAG)-fips sub-push
 
 .PHONY: sub-push-a1compat
-sub-push-a1-compat: sub-image-linux-arm64-al2
+sub-push-a1compat: sub-image-linux-arm64-al2
 
 .PHONY: all-push
 all-push: sub-push sub-push-fips sub-push-a1compat


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Makefile a1compat target contains a typo that prevents it from building.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
