### PR TITLE
Fix make all-push a1 instance image support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ sub-push-fips:
 	$(MAKE) FIPS=true TAG=$(TAG)-fips sub-push
 
 .PHONY: sub-push-a1compat
-sub-push-a1-compat: sub-image-linux-arm64-al2
+sub-push-a1compat: sub-image-linux-arm64-al2
 
 .PHONY: all-push
 all-push: sub-push sub-push-fips sub-push-a1compat


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Fix make all-push a1 instance image support

Today `make all-push` does not create and push an a1 instance compatible image, which is blocking v1.39.x release. 

This PR fixes the Makefile typo. 

#### How was this change tested?

```
❯ export DOCKER_CLI_EXPERIMENTAL=enabled
trap "docker buildx rm multiarchimage-buildertest" EXIT
docker buildx create --driver-opt=image=moby/buildkit:v0.12.5 --bootstrap --use --name multiarchimage-buildertest

loudecho "Set up QEMU"
# See https://github.com/docker/setup-qemu-action
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

loudecho "Push manifest list containing amazon linux and windows based images to GCR"
export IMAGE=208536326202.dkr.ecr.us-west-2.amazonaws.com/test
export TAG=v1.39.0
export VERSION=$PULL_BASE_REF
make -j $(nproc) all-push
```

All expected images appeared

```
❯ crane ls 208536326202.dkr.ecr.us-west-2.amazonaws.com/test | grep "v1.39"
v1.39.0-linux-arm64-al2
v1.39.0-windows-amd64-ltsc2019
v1.39.0-fips-windows-amd64-ltsc2019
v1.39.0-fips
v1.39.0-fips-linux-arm64-al2023
v1.39.0-fips-windows-amd64-ltsc2022
v1.39.0-linux-amd64-al2023
v1.39.0
v1.39.0-fips-linux-amd64-al2023
v1.39.0-linux-arm64-al2023
v1.39.0-windows-amd64-ltsc2022
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
