### PR TITLE
Fix node.selinux configuration parameter & release Helm Chart v2.39.1

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Helm chart
 
+## v2.39.1
+
+### Bug or Regression
+- Fix `node.selinux` to properly set SELinux-specific mounts as ReadOnly ([#2311](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2311), [@AndrewSirenko](https://github.com/AndrewSirenko))
+
 ## v2.39.0
 
 ### Feature

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.39.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.39.0
+version: 2.39.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -134,8 +134,10 @@ spec:
             {{- if .Values.node.selinux }}
             - name: selinux-sysfs
               mountPath: /sys/fs/selinux
+              readOnly: true
             - name: selinux-config
               mountPath: /etc/selinux/config
+              readOnly: true
             {{- end }}
           {{- with .Values.node.volumeMounts }}
           {{- toYaml . | nindent 12 }}
@@ -259,12 +261,10 @@ spec:
           hostPath:
             path: /sys/fs/selinux
             type: Directory
-            readOnly: true
         - name: selinux-config
           hostPath:
             path: /etc/selinux/config
             type: File
-            readOnly: true
         {{- end }}
         - name: probe-dir
           {{- if .Values.node.probeDirVolume }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fix node.selinux configuration parameter because Pod spec.volumes.hostpath does not have a `readOnly`. That belongs in pod.spec.containers.volumeMounts.

When you install via helm this readOnly is dropped with a warning. However this breaks add-on. 

```
❯ helm upgrade --install aws-ebs-csi-driver \
    --namespace kube-system --set "node.selinux=true" \
    aws-ebs-csi-driver/aws-ebs-csi-driver
Release "aws-ebs-csi-driver" does not exist. Installing it now.
W0124 19:27:54.986662   29648 warnings.go:70] unknown field "spec.template.spec.volumes[4].hostPath.readOnly"
W0124 19:27:54.986683   29648 warnings.go:70] unknown field "spec.template.spec.volumes[5].hostPath.readOnly"
```

#### How was this change tested?

```
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver > pre.yml
helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set node.selinux=true > post.yml

diff pre.yml post.yml -C 5
*** pre.yml	2025-01-24 21:04:48.509855690 +0000
--- post.yml	2025-01-24 21:04:48.599854884 +0000
***************
*** 480,489 ****
--- 480,495 ----
                mountPropagation: "Bidirectional"
              - name: plugin-dir
                mountPath: /csi
              - name: device-dir
                mountPath: /dev
+             - name: selinux-sysfs
+               mountPath: /sys/fs/selinux
+               readOnly: true
+             - name: selinux-config
+               mountPath: /etc/selinux/config
+               readOnly: true
            ports:
              - name: healthz
                containerPort: 9808
                protocol: TCP
            livenessProbe:
***************
*** 576,585 ****
--- 582,599 ----
              type: Directory
          - name: device-dir
            hostPath:
              path: /dev
              type: Directory
+         - name: selinux-sysfs
+           hostPath:
+             path: /sys/fs/selinux
+             type: Directory
+         - name: selinux-config
+           hostPath:
+             path: /etc/selinux/config
+             type: File
          - name: probe-dir
            emptyDir: {}
  ---
  # Source: aws-ebs-csi-driver/templates/controller.yaml
  # Controller Service
```

```
❯ helm upgrade --install aws-ebs-csi-driver \
    --namespace kube-system --set "node.selinux=true" \
    charts/aws-ebs-csi-driver
Release "aws-ebs-csi-driver" does not exist. Installing it now.
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Fri Jan 24 21:05:37 2025
NAMESPACE: kube-system
STATUS: deployed

❯ k get daemonset ebs-csi-node -o yaml -n kube-system | grep selinux -C 5
          name: kubelet-dir
        - mountPath: /csi
          name: plugin-dir
        - mountPath: /dev
          name: device-dir
        - mountPath: /sys/fs/selinux
          name: selinux-sysfs
          readOnly: true
        - mountPath: /etc/selinux/config
          name: selinux-config
          readOnly: true
      - args:
        - --csi-address=$(ADDRESS)
        - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
        - --v=2
--
      - hostPath:
          path: /dev
          type: Directory
        name: device-dir
      - hostPath:
          path: /sys/fs/selinux
          type: Directory
        name: selinux-sysfs
      - hostPath:
          path: /etc/selinux/config
          type: File
        name: selinux-config
      - emptyDir: {}
        name: probe-dir

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
