### PR TITLE
Fix helm regression with a1CompatibilityDaemonSet & release chart v2.39.2

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Helm chart
 
+## v2.39.2
+
+### Urgent Upgrade Notes
+
+Please upgrade from v2.38.1 directly to v2.39.2 to avoid upgrade failures if you are relying on `a1CompatibilityDaemonSet`. 
+
+### Bug or Regression
+- Fix helm regression when `a1CompatibilityDaemonSet=true` ([#2316](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2316), [@AndrewSirenko](https://github.com/AndrewSirenko))
+
 ## v2.39.1
 
 ### Bug or Regression

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.39.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.39.1
+version: 2.39.2
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -12,7 +12,9 @@
 {{- include "node" (deepCopy $ | mustMerge $args) -}}
 {{- end }}
 {{- if .Values.a1CompatibilityDaemonSet }}
-{{- not .Values.fips | required "FIPS mode not supported for A1 instance family compatibility image" -}}
+{{- if .Values.fips -}}
+{{- fail "FIPS mode not supported for A1 instance family compatibility image" -}}
+{{- end -}}
 {{$args := dict
   "NodeName" "ebs-csi-node-a1compat"
   "Values" (dict


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fix helm regression with a1CompatibilityDaemonSet.

Fixes #2315 

#### How was this change tested?

Setting a1 true should render helm template:

```
> helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set a1CompatibilityDaemonSet=true
...
  volumes:
    - name: config-vol
      configMap:
        name: ebs-csi-driver-test
  restartPolicy: Never
```

Setting a1 and fips both on should fail:

```
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set a1CompatibilityDaemonSet=true --set fips=true --debug
install.go:200: [debug] Original chart version: ""
install.go:217: [debug] CHART PATH: /home/andsirey/workplace/aws-ebs-csi-driver/charts/aws-ebs-csi-driver


Error: execution error at (aws-ebs-csi-driver/templates/node.yaml:16:4): FIPS mode not supported for A1 instance family compatibility image
helm.go:84: [debug] execution error at (aws-ebs-csi-driver/templates/node.yaml:16:4): FIPS mode not supported for A1 instance family compatibility image
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Fix helm regression with a1CompatibilityDaemonSet=true
```
