### PR TITLE
Fix command in dep bump document

### DIFF
--- a/docs/updating-dependencies.md
+++ b/docs/updating-dependencies.md
@@ -35,7 +35,7 @@ For a full list of commands see [Managing pull requests for dependency updates |
 
 #### Dependabot PR failing CI due to breaking changes?
 
-1. Take-over the PR with something like `gh repo checkout pr some_number` or `git pull upstream/dependabot/rest_of_path`
+1. Take-over the PR with something like `gh pr checkout {pr_number}` or `git pull upstream/dependabot/{rest_of_path}`
 2. Make the necessary repository changes. 
 3. Commit and add the string `[dependabot-skip]` to the message so Dependabot can keep rebasing the PR. Push!
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/cleanup

#### What is this PR about? / Why do we need it?
Fix command listed in `docs/updating-dependencies.md`
#### How was this change tested?

```
gh repo checkout pr 2320
unknown command "checkout" for "gh repo"

Usage:  gh repo <command> [flags]

Available commands:
  archive
  autolink
  clone
  create
  delete
  deploy-key
  edit
  fork
  gitignore
  license
  list
  rename
  set-default
  sync
  unarchive
  view
```

```
❯ gh pr checkout 2320
branch 'dependabot/go_modules/misc-dependencies-9f91678858' set up to track 'origin/dependabot/go_modules/misc-dependencies-9f91678858'.
Switched to a new branch 'dependabot/go_modules/misc-dependencies-9f91678858'
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
