### PR TITLE
Initialize metrics at 0 on startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -155,7 +155,7 @@ func main() {
 	}
 
 	if options.HTTPEndpoint != "" {
-		r := metrics.InitializeRecorder()
+		r := metrics.InitializeRecorder(options.DeprecatedMetrics)
 		r.InitializeMetricsHandler(options.HTTPEndpoint, "/metrics", options.MetricsCertFile, options.MetricsKeyFile)
 
 		if options.Mode == driver.NodeMode || options.Mode == driver.AllMode {

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -44,22 +44,22 @@ func RecordRequestsMiddleware(deprecatedMetrics bool) func(*middleware.Stack) er
 						labels = map[string]string{
 							"operation_name": operationName,
 						}
-						metrics.Recorder().IncreaseCount("aws_ebs_csi_api_request_throttles_total", labels)
+						metrics.Recorder().IncreaseCount(metrics.APIRequestThrottles, labels)
 						if deprecatedMetrics {
-							metrics.Recorder().IncreaseCount("cloudprovider_aws_api_throttled_requests_total", labels)
+							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestThrottles, labels)
 						}
 					} else {
-						metrics.Recorder().IncreaseCount("aws_ebs_csi_api_request_errors_total", labels)
+						metrics.Recorder().IncreaseCount(metrics.APIRequestErrors, labels)
 						if deprecatedMetrics {
-							metrics.Recorder().IncreaseCount("cloudprovider_aws_api_request_errors", labels)
+							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestErrors, labels)
 						}
 					}
 				}
 			} else {
 				duration := time.Since(start).Seconds()
-				metrics.Recorder().ObserveHistogram("aws_ebs_csi_api_request_duration_seconds", duration, labels, nil)
+				metrics.Recorder().ObserveHistogram(metrics.APIRequestDuration, duration, labels, nil)
 				if deprecatedMetrics {
-					metrics.Recorder().ObserveHistogram("cloudprovider_aws_api_request_duration_seconds", duration, labels, nil)
+					metrics.Recorder().ObserveHistogram(metrics.DeprecatedAPIRequestDuration, duration, labels, nil)
 				}
 			}
 			return output, metadata, err

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// constants for prometheus metrics use.
+const (
+	APIRequestDuration            = "aws_ebs_csi_api_request_duration_seconds"
+	APIRequestErrors              = "aws_ebs_csi_api_request_errors_total"
+	APIRequestThrottles           = "aws_ebs_csi_api_request_throttles_total"
+	HelpText                      = "ebs_csi_aws_com metric"
+	DeprecatedHelpText            = "cloudprovider_aws_api metric"
+	DeprecatedAPIRequestDuration  = "cloudprovider_aws_api_request_duration_seconds"
+	DeprecatedAPIRequestErrors    = "cloudprovider_aws_api_request_errors"
+	DeprecatedAPIRequestThrottles = "cloudprovider_aws_api_throttled_requests_total"
+)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -78,7 +78,7 @@ test_re_register_total{key="value2"} 1
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.recorder {
-				InitializeRecorder()
+				InitializeRecorder(false)
 			}
 			m := Recorder()
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What is this PR about? / Why do we need it?

Currently the driver does not initialize metrics until there is some EBS activity, which can cause issues on customer dashboards/alerts due to missing data points. This PR modifies this behavior, and it allows for all registered metrics to be initialized to 0 on startup and published on the metrics endpoint even if no EBS activity has been recorded yet.

closes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2312

#### How was this change tested?
I tested these changes by doing the following:

1. Made cluster by running `make cluster/create`
2. Set controller replica count to 1
3. Built driver image with my changes by running `make cluster/image`
4. Installed image with changes on my cluster by running `make cluster/install`
5. Run `export ebs_csi_controller=ebs-csi-controller-<controller ID>`
6. Run `kubectl port-forward $ebs_csi_controller 3301:3301 -n kube-system `
7. Run `curl 127.0.0.1:3301/metrics` and verify that the metrics are initialized to 0 before any operation.
8.  Go through the [Dynamic Volume Provisioning Example](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/examples/kubernetes/dynamic-provisioning#dynamic-volume-provisioning:~:text=Dynamic%20Volume%20Provisioning)
9. Run `curl 127.0.0.1:3301/metrics` and ensure that metrics of operations conducted were recorded and the unused operation metrics remain at 0. 

#### Does this PR introduce a user-facing change?

N/A
