### PR TITLE
wip: Retry IMDS calls on driver startup

### DIFF
--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -119,7 +119,7 @@ func TestNewMetadataService(t *testing.T) {
 			}
 
 			if tc.ec2MetadataError == nil && !tc.imdsDisabled {
-				mockEC2Metadata.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				mockEC2Metadata.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -172,14 +172,14 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Error getting instance identity document",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(nil, errors.New("failed to get instance identity document"))
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(nil, errors.New("failed to get instance identity document"))
 			},
 			expectedError: errors.New("could not get EC2 instance identity metadata: failed to get instance identity document"),
 		},
 		{
 			name: "TestEC2MetadataInstanceInfo: Empty instance ID",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID: "",
 					},
@@ -190,7 +190,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Empty instance type",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:   "i-1234567890abcdef0",
 						InstanceType: "",
@@ -202,7 +202,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Empty region and invalid region from session",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:   "i-1234567890abcdef0",
 						InstanceType: "c5.xlarge",
@@ -215,7 +215,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Empty availability zone and invalid region from session",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -229,7 +229,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Error getting ENIs metadata",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -244,7 +244,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Error reading ENIs metadata content",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -261,7 +261,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Error getting block device mappings metadata",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -279,7 +279,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Error reading block device mappings metadata content",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -299,7 +299,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Valid metadata with outpost ARN",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -336,7 +336,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 		{
 			name: "TestEC2MetadataInstanceInfo: Valid metadata without outpost ARN",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",
@@ -366,7 +366,7 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 			name:              "TestEC2MetadataInstanceInfo: Valid metadata retrieving snow region/AZ from session",
 			regionFromSession: "snow",
 			mockEC2Metadata: func(m *MockEC2Metadata) {
-				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}).Return(&imds.GetInstanceIdentityDocumentOutput{
+				m.EXPECT().GetInstanceIdentityDocument(gomock.Any(), &imds.GetInstanceIdentityDocumentInput{}, gomock.Any()).Return(&imds.GetInstanceIdentityDocumentOutput{
 					InstanceIdentityDocument: imds.InstanceIdentityDocument{
 						InstanceID:       "i-1234567890abcdef0",
 						InstanceType:     "c5.xlarge",


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

TODO

Shorter term solution for #2249

(See [install.md: metadata](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md#metadata) for context)

Longer term we should solve race for ebs-plugin starting before IMDS is ready on node, or add a doNotFallbackToK8s parameter option so that we can retry indefinately. 

Note: This PR is stacked on top of #2342 (Don't call IMDS if disabled via environment variable), because we want to avoid wasting time calling IMDS if we know customer disabled it. 

#### How was this change tested?

Ran karpenter [ebs-scale-tests](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/hack/ebs-scale-test) to reproduce #2249. Before PR, one third of instances were falling back to Kubernetes metadata, leading to incorrect node allocatable count. 

After PR, I was not able to find an instance that fell back to K8s metadata (Looking at 100+ nodes across multiple tests). 

TODOs:

1. Calculate how long this PR changes retry period (will update PR description)
2. More manual testing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Retry IMDS timeouts on driver startup
```
