### PR TITLE
feat: Add error `code` label to EBS CSI API request error metrics

### DIFF
--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -49,6 +49,7 @@ func RecordRequestsMiddleware(deprecatedMetrics bool) func(*middleware.Stack) er
 							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestThrottles, labels)
 						}
 					} else {
+						labels["code"] = apiErr.ErrorCode()
 						metrics.Recorder().IncreaseCount(metrics.APIRequestErrors, labels)
 						if deprecatedMetrics {
 							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestErrors, labels)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature
#### What is this PR about? / Why do we need it?

**Description**:
This PR enhances the `aws_ebs_csi_api_request_errors_total` metric by adding an `error_code` label to provide more granular visibility into the specific types of API errors encountered.

**Changes**:
- Added `code` as a new label to `aws_ebs_csi_api_request_errors_total` metric
- Error code is extracted from the AWS API error response

This additional dimension allows operators to:
- Better understand the nature of API failures
- Set up more specific alerting rules
- Troubleshoot issues more effectively by filtering on specific error types

#### How was this change tested?
- Verified metric exposition format
- Tested with common error scenarios

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Error `code` label is now supported EBS CSI API request error metrics
```
