### PR TITLE
Fix incorrect properties validation in Helm schema

### DIFF
--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -16,6 +16,7 @@
     },
     "additionalDaemonSets": {
       "type": ["object", "null"],
+      "additionalProperties": false,
       "description": "Additional DaemonSets of the node pod",
       "default": null,
       "patternProperties": {
@@ -38,6 +39,7 @@
     },
     "helmTester": {
       "type": "object",
+      "additionalProperties": false,
       "description": "Supply a custom image to the ebs-csi-driver-test pod in helm-tester.yaml",
       "properties": {
         "enabled": {
@@ -60,6 +62,7 @@
     },
     "awsAccessSecret": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
@@ -77,6 +80,7 @@
     },
     "image": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "pullPolicy": {
           "type": "string",
@@ -227,25 +231,7 @@
         },
         "securityContext": {
           "type": "object",
-          "description": "SecurityContext on the controller pod",
-          "properties": {
-            "runAsNonRoot": {
-              "type": "boolean",
-              "default": true
-            },
-            "runAsUser": {
-              "type": "integer",
-              "default": 1000
-            },
-            "runAsGroup": {
-              "type": "integer",
-              "default": 1000
-            },
-            "fsGroup": {
-              "type": "integer",
-              "default": 1000
-            }
-          }
+          "description": "SecurityContext on the controller pod"
         },
         "httpEndpoint": {
           "type": ["string", "null"],
@@ -332,6 +318,7 @@
         },
         "serviceAccount": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "create": {
               "type": "boolean",
@@ -381,7 +368,16 @@
         },
         "otelTracing": {
           "type": ["object", "null"],
+          "additionalProperties": false,
           "description": "Enable opentelemetry tracing for the plugin running on the daemonset",
+          "properties": {
+            "otelServiceName": {
+              "type": "string"
+            },
+            "otelExporterEndpoint": {
+              "type": "string"
+            }
+          },
           "default": null
         },
         "volumes": {
@@ -396,29 +392,11 @@
         },
         "containerSecurityContext": {
           "type": "object",
-          "description": "SecurityContext on the controller container (see sidecars for securityContext on sidecar containers)",
-          "properties": {
-            "seccompProfile": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "default": "RuntimeDefault"
-                }
-              }
-            },
-            "readOnlyRootFilesystem": {
-              "type": "boolean",
-              "default": true
-            },
-            "privileged": {
-              "type": "boolean",
-              "default": true
-            }
-          }
+          "description": "SecurityContext on the controller container (see sidecars for securityContext on sidecar containers)"
         },
         "serviceMonitor": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "forceEnable": {
               "type": "boolean",
@@ -426,13 +404,7 @@
             },
             "labels": {
               "type": "object",
-              "description": "Additional labels for ServiceMonitor object",
-              "properties": {
-                "release": {
-                  "type": "string",
-                  "default": "prometheus"
-                }
-              }
+              "description": "Additional labels for ServiceMonitor object"
             },
             "interval": {
               "type": "string",
@@ -441,22 +413,7 @@
           }
         },
         "updateStrategy": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "default": "RollingUpdate"
-            },
-            "rollingUpdate": {
-              "type": "object",
-              "properties": {
-                "maxUnavailable": {
-                  "type": "integer",
-                  "default": 1
-                }
-              }
-            }
-          }
+          "type": "object"
         },
         "initContainers": {
           "type": "array",
@@ -464,13 +421,7 @@
           "default": []
         },
         "socketDirVolume": {
-          "type": "object",
-          "properties": {
-            "emptyDir": {
-              "type": ["object", "null"],
-              "default": null
-            }
-          }
+          "type": "object"
         },
         "nameOverride": {
           "type": ["string", "null"],
@@ -558,13 +509,7 @@
           "default": []
         },
         "probeDirVolume": {
-          "type": "object",
-          "properties": {
-            "emptyDir": {
-              "type": "object",
-              "default": null
-            }
-          }
+          "type": "object"
         },
         "namespaceOverride": {
           "type": ["string", "null"],
@@ -639,25 +584,7 @@
         },
         "securityContext": {
           "type": "object",
-          "description": "SecurityContext on the node pod",
-          "properties": {
-            "runAsNonRoot": {
-              "type": "boolean",
-              "default": false
-            },
-            "runAsUser": {
-              "type": "integer",
-              "default": 0
-            },
-            "runAsGroup": {
-              "type": "integer",
-              "default": 0
-            },
-            "fsGroup": {
-              "type": "integer",
-              "default": 0
-            }
-          }
+          "description": "SecurityContext on the node pod"
         },
         "priorityClassName": {
           "description": "Priority class for the Node Daemonset",
@@ -690,6 +617,7 @@
         },
         "serviceAccount": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "create": {
               "type": "boolean",
@@ -748,35 +676,10 @@
         },
         "containerSecurityContext": {
           "type": "object",
-          "description": "securityContext on the node container (see sidecars for securityContext on sidecar containers). Privileged containers always run as `Unconfined`, which means that they are not restricted by a seccomp profile.",
-          "properties": {
-            "readOnlyRootFilesystem": {
-              "type": "boolean",
-              "default": true
-            },
-            "privileged": {
-              "type": "boolean",
-              "default": true
-            }
-          }
+          "description": "securityContext on the node container (see sidecars for securityContext on sidecar containers). Privileged containers always run as `Unconfined`, which means that they are not restricted by a seccomp profile."
         },
         "updateStrategy": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "default": "RollingUpdate"
-            },
-            "rollingUpdate": {
-              "type": "object",
-              "properties": {
-                "maxUnavailable": {
-                  "type": "string",
-                  "default": "10%"
-                }
-              }
-            }
-          }
+          "type": "object"
         },
         "daemonSetAnnotations": {
           "type": ["object", "null"],
@@ -784,6 +687,15 @@
         },
         "otelTracing": {
           "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "otelServiceName": {
+              "type": "string"
+            },
+            "otelExporterEndpoint": {
+              "type": "string"
+            }
+          },
           "description": "Enable opentelemetry tracing for the plugin running on the daemonset",
           "default": null
         }
@@ -841,6 +753,7 @@
             },
             "leaderElection": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "enabled": {
                   "type": "boolean",
@@ -849,29 +762,11 @@
               }
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "seccompProfile": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "default": "RuntimeDefault"
-                    }
-                  }
-                },
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             },
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -915,6 +810,7 @@
             },
             "leaderElection": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "enabled": {
                   "type": "boolean",
@@ -923,26 +819,7 @@
               }
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "seccompProfile": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "default": "RuntimeDefault"
-                    }
-                  }
-                },
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             },
             "additionalClusterRoleRules": {
               "type": ["array", "null"],
@@ -951,6 +828,7 @@
             },
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -1004,6 +882,7 @@
             },
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -1019,26 +898,7 @@
               }
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "seccompProfile": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "default": "RuntimeDefault"
-                    }
-                  }
-                },
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             }
           }
         },
@@ -1065,6 +925,7 @@
             },
             "leaderElection": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "enabled": {
                   "type": "boolean",
@@ -1083,6 +944,7 @@
             },
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -1098,26 +960,7 @@
               }
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "seccompProfile": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "default": "RuntimeDefault"
-                    }
-                  }
-                },
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             }
           }
         },
@@ -1127,6 +970,7 @@
           "properties": {
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -1150,17 +994,7 @@
               "default": null
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             }
           }
         },
@@ -1187,6 +1021,7 @@
             },
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -1206,32 +1041,15 @@
               "default": null
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "seccompProfile": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "default": "RuntimeDefault"
-                    }
-                  }
-                },
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             },
             "livenessProbe": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "exec": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "command": {
                       "type": "array",
@@ -1282,6 +1100,7 @@
             },
             "leaderElection": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "enabled": {
                   "type": "boolean",
@@ -1295,6 +1114,7 @@
             },
             "image": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "pullPolicy": {
                   "type": "string",
@@ -1310,26 +1130,7 @@
               }
             },
             "securityContext": {
-              "type": "object",
-              "properties": {
-                "seccompProfile": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "default": "RuntimeDefault"
-                    }
-                  }
-                },
-                "readOnlyRootFilesystem": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "allowPrivilegeEscalation": {
-                  "type": "boolean",
-                  "default": false
-                }
-              }
+              "type": "object"
             }
           }
         }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes schema validation in several places:
- Adds missing `additionalProperties: false` in several places
- Adds missing properties validation to `otelTracing`
- Removes properties validation in several places where the data is directly passed through into Kubernetes (We should not validate Kubernetes objects and instead just directly pass them through to k8s, as what is valid changes between k8s versions and is already validated by Kubernetes itself on installation)

#### How was this change tested?

Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
