### PR TITLE
Prevent null deref when enableWindows and otelTracing enabled on node

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -111,10 +111,10 @@ spec:
               value: {{ .otelServiceName }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ .otelExporterEndpoint }}
+            {{- end }}
             {{- if .Values.fips }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
-            {{- end }}
             {{- end }}
             {{- with .Values.node.env }}
             {{- . | toYaml | nindent 12 }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Order of Helm `end` is incorrect in Windows, causing a null pointer deref when windows and otel tracing are enabled at the same time:

```
Error: template: aws-ebs-csi-driver/templates/node-windows.yaml:4:4: executing "aws-ebs-csi-driver/templates/node-windows.yaml" at <include "node-windows" (deepCopy $ | mustMerge $defaultArgs)>: error calling include: template: aws-ebs-csi-driver/templates/_node-windows.tpl:114:26: executing "node-windows" at <.Values.fips>: nil pointer evaluating interface {}.fips
```

#### How was this change tested?

Manually/CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Prevent nil pointer deref in Helm chart when `node.enableWindows` and `node.otelTracing` are both set
```
