### PR TITLE
[Helm] Fix issue with enabled flag handling when used as a subchart

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Helm chart
 
+## v2.40.1
+
+### Urgent Upgrade Notes
+
+Please upgrade from v2.39.3 directly to v2.40.1 to prevent potential issues when using the enabled flag with AWS EBS CSI Driver as a subchart.
+
+### Bug or Regression
+
+Fix issue with enabled flag handling when used as a subchart ([#2286](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2359), [@sm43](https://github.com/sm43))
+
 ## v2.40.0
 
 #### Default for enable windows changed

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.40.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.40.0
+version: 2.40.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -4,6 +4,10 @@
   "additionalProperties": false,
   "description": "Configurable parameters of the AWS EBS CSI Driver",
   "properties": {
+    "enabled": {
+      "description": "Usually used when using AWS EBS CSI Driver as a subchart.",
+      "type": "boolean"
+    },
     "global": {
       "type": "object",
       "additionalProperties": true,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

This PR fixes an issue where the enabled flag was not being correctly processed when the AWS EBS CSI Driver was used as a subchart.

Error during upgrade

```
Helm upgrade failed for release <> with chart <>: values don't meet the specifications of the schema(s) in the following chart(s): 
aws-ebs-csi-driver: - (root): Additional property enabled is not allowed Last Helm logs:
```

we reference the chart as 

```
  - name: aws-ebs-csi-driver
    condition: aws-ebs-csi-driver.enabled
    repository: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
    version: "~> 2.39.0"
```

For example: 
Open Telemetry Helm chart handles it similar way
https://github.com/open-telemetry/opentelemetry-helm-charts/blob/a20fc37bb9cc96dbd146c2d5ab442982ae24a4c0/charts/opentelemetry-collector/values.schema.json#L19

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note

```
