### PR TITLE
Add enabled flag to schema for sub-charting

### DIFF
--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -9,6 +9,10 @@
       "additionalProperties": true,
       "description": "Allowing global parameters for sub-charting"
     },
+    "enabled": {
+      "type": ["boolean", "null"],
+      "description": "No effect - reserved for use in sub-charting"
+    },
     "a1CompatibilityDaemonSet": {
       "type": "boolean",
       "description": "Enable compatibility for the A1 instance family via use of an AL2-based image in a separate DaemonSet",


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Supersedes #2359 without updating the changelog or immediately performing a chart release

Using a fake `enabled` parameter when sub-charting to act as a condition is a common pattern (e.g. https://stackoverflow.com/questions/55338147/disabling-subcharts-in-custom-helm-chart), add `enabled` to the schema for this purpose but explicitly document it has no effect.

#### How was this change tested?

Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add `enabled` flag to schema for use in sub-charting 
```
