### PR TITLE
Add Prometheus Annotations to the Node Service

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -47,6 +47,9 @@ kind: Service
 metadata:
   name: ebs-csi-node
   namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "3302"
   labels:
     app: ebs-csi-node
 spec:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What is this PR about? / Why do we need it?

Customer requested to be able to scrape the metrics from the drivers into CloudWatch Agent. 

This PR Adds Prometheus annotations to the Node Service, this way metrics can be automatically discovered and scraped by Prometheus, enabling monitoring and observability of the node-level metrics through the CloudWatch agent.

#### How was this change tested?

Deploying driver with changes and ensuring that annotations were set by running `kubectl describe service ebs-csi-node -n kube-system`

#### Does this PR introduce a user-facing change?

```
NONE
```
