### PR TITLE
cleanup: `make verify` should ignore copyright year

### DIFF
--- a/hack/verify-update.sh
+++ b/hack/verify-update.sh
@@ -30,7 +30,9 @@ if ! make -C "${TEST_DIR}" update >/dev/null; then
   exit 1
 fi
 
-if ! diff -x bin -r "${TEST_DIR}" "${ROOT}"; then
+# Ignore copyright year changes
+COPYRIGHT_REGEX="Copyright [0-9]\{4\} The Kubernetes Authors.$"
+if ! diff -x bin -I "${COPYRIGHT_REGEX}" -r "${TEST_DIR}" "${ROOT}"; then
   echo "Auto-generation/formatting needs to run!"
   echo "Run \`make update\` to fix!"
   exit 1


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

At the beginning of each calendar year, `make verify` fails because the copyright year changes on mock code generated by `make update` (`pkg/mounter/mock_mount.go` for example). This is because mock files are generated by `./hack/update-mockgen.sh` without the header, and then `./hack/generate-license-header.sh` adds the headers back with the current year.

This means at the beginning of each year, contributors with open PR's are blocked by the verify job until someone commits a `make update` change to each release branch to update headers on generated files. It's a minor thing, but it's still wasted time and cpu cycles each January.

This PR adds a regex to `./hack/verify-update.sh` to ignore copyright year changes so the verify job will not fail if that is the only change generated by `make update`.

#### How was this change tested?

Change the copyright year in `pkg/mounter/mock_mount.go`, and `make verify` passes. Change anything else in `pkg/mounter/mock_mount.go` and `make verify` fails.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
