### PR TITLE
Adding Logs On How We Calculate CSINode.allocatables in NodeGetInfo

### DIFF
--- a/pkg/cloud/metadata/ec2.go
+++ b/pkg/cloud/metadata/ec2.go
@@ -90,7 +90,6 @@ func EC2MetadataInstanceInfo(svc EC2Metadata, regionFromSession string) (*Metada
 		return nil, fmt.Errorf("could not read ENIs metadata content: %w", err)
 	}
 	attachedENIs := util.CountMACAddresses(string(enis))
-	klog.V(4).InfoS("Number of attached ENIs", "attachedENIs", attachedENIs)
 
 	blockDevMappings := 0
 	if !util.IsSBE(doc.Region) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

Today we log number of attached ENIs upon driver start if IMDS is our metadata source. However, we accidentally log it even if driver is in controller mode, which is an confusing experience for customers (Why should ebs-csi-controller care about the ENI count of the node it is on?) 

This PR removes logging of ENIs when in controller mode and also adds logging of some of the information used to calculate CSI Node Allocatable, this way customers can have a better understanding of how this final node allocatable count was calculated.

#### How was this change tested?

Manually by spinning up a cluster and checking logs for nodes. 

Logs output looks like this: 
```
node.go:777] "getVolumesLimit:" instanceType="c5.large"
node.go:781] "getVolumesLimit:" maxAttachments=28
node.go:786] "getVolumesLimit:" numBlockDevices=0
node.go:789] "getVolumesLimit:" reservedVolumeAttachments=1
node.go:802] "getVolumesLimit:" numeENIs=1
node.go:804] "getVolumesLimit:" reservedSlots=0
node.go:597] "NodeGetInfo:" Node Allocatables=26
```

#### Does this PR introduce a user-facing change?

```
Log CSINode.allocatables calculation in Node Service
```
