### PR TITLE
Update tags in cloudbuild.sh/Makefile to match promoted images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,8 @@ sub-push-fips:
 	$(MAKE) FIPS=true TAG=$(TAG)-fips sub-push
 
 .PHONY: sub-push-a1compat
-sub-push-a1compat: sub-image-linux-arm64-al2
+sub-push-a1compat:
+	$(MAKE) DOCKER_EXTRA_ARGS="-t=$(IMAGE):$(TAG)-a1compat" sub-image-linux-arm64-al2
 
 .PHONY: all-push
 all-push: sub-push sub-push-fips sub-push-a1compat
@@ -234,6 +235,7 @@ image:
 		--build-arg=VERSION=$(VERSION) \
 		$(FIPS_DOCKER_ARGS) \
 		`./hack/provenance.sh` \
+		$(DOCKER_EXTRA_ARGS) \
 		.
 
 .PHONY: create-manifest

--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -40,6 +40,7 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 loudecho "Push manifest list containing amazon linux and windows based images to GCR"
 export IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
-export TAG=$GIT_TAG
+# Prow passes GIT_TAG like "v20250306-v1.40.1" - strip first 10 characters to get real tag
+export TAG=${GIT_TAG:10}
 export VERSION=$PULL_BASE_REF
 IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Changes `cloudbuild.sh` and `make sub-push-a1compat` to use the tags from the promoted versions of images for consistency.

#### How was this change tested?

Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
