### PR TITLE
Fix incorrect schema entry for controller.podDisruptionBudget.unhealthyPodEvictionPolicy value

### DIFF
--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -285,7 +285,7 @@
               "default": true
             },
             "unhealthyPodEvictionPolicy": {
-              "type": ["object", "null"],
+              "type": ["string", "null"],
               "description": "Unhealthy pod eviction policy for the EBS CSI Controller Pod's PodDisruptionBudget",
               "default": null
             }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What is this PR about? / Why do we need it?
#2388 

#### How was this change tested?
Ran the failing command post change
```
helm template ebs ./aws-ebs-csi-driver --set controller.podDisruptionBudget.unhealthyPodEvictionPolicy="AlwaysAllow"
```
#### Does this PR introduce a user-facing change?
Yes, schema will now allow use of podDisruptionBudget

```release-note

```
