### PR TITLE
Enable useTesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,9 @@ linters-settings:
     dot-import-whitelist:
       - "github.com/onsi/gomega"
       - "github.com/onsi/ginkgo/v2"
+  usetesting:
+    # Turning check for os.MkdirTemp() off as t.TempDir() is not sufficient for mounter and sanity tests in their current state.
+    os-mkdir-temp: false 
 linters:
   enable-all: true
   disable:
@@ -68,4 +71,3 @@ linters:
     - godox # Do not allow TODOs
     - nonamedreturns # Need to nolint/refactor a few places our code
     - paralleltest # There are many tests that aren't parallelized
-    - usetesting # TODO consider adding usetesting linter

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -689,7 +689,7 @@ func TestCheckDesiredState(t *testing.T) {
 				},
 			},
 		}, nil)
-		_, err := cloudInstance.checkDesiredState(context.Background(), tc.volumeID, tc.desiredSizeGiB, tc.options)
+		_, err := cloudInstance.checkDesiredState(t.Context(), tc.volumeID, tc.desiredSizeGiB, tc.options)
 		if err != nil {
 			if tc.expErr == nil {
 				t.Fatalf("Did not expect to get an error but got %q", err)
@@ -1385,7 +1385,7 @@ func TestCreateDisk(t *testing.T) {
 				VolumeId:   aws.String("snap-test-volume"),
 				State:      types.SnapshotStateCompleted,
 			}
-			ctx, ctxCancel := context.WithDeadline(context.Background(), time.Now().Add(defaultCreateDiskDeadline))
+			ctx, ctxCancel := context.WithDeadline(t.Context(), time.Now().Add(defaultCreateDiskDeadline))
 			defer ctxCancel()
 
 			if tc.expCreateVolumeInput != nil {
@@ -1506,7 +1506,7 @@ func TestCreateDiskClientToken(t *testing.T) {
 		}, nil).AnyTimes(),
 	)
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(defaultCreateDiskDeadline))
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(defaultCreateDiskDeadline))
 	defer cancel()
 	for i := range 3 {
 		_, err := c.CreateDisk(ctx, volumeName, diskOptions)
@@ -1551,7 +1551,7 @@ func TestDeleteDisk(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			mockEC2.EXPECT().DeleteVolume(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ec2.DeleteVolumeOutput{}, tc.expErr)
 
 			ok, err := c.DeleteDisk(ctx, tc.volumeID)
@@ -1759,7 +1759,7 @@ func TestAttachDisk(t *testing.T) {
 				t.Fatalf("could not assert c as type cloud, %v", c)
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			deviceManager := cloudInstance.dm
 
 			tc.mockFunc(mockEC2, ctx, tc.volumeID, tc.nodeID, tc.nodeID2, tc.path, deviceManager)
@@ -1848,7 +1848,7 @@ func TestDetachDisk(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			tc.mockFunc(mockEC2, ctx, tc.volumeID, tc.nodeID)
 
 			err := c.DetachDisk(ctx, tc.volumeID, tc.nodeID)
@@ -1916,7 +1916,7 @@ func TestGetDiskByName(t *testing.T) {
 				},
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			mockEC2.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(&ec2.DescribeVolumesOutput{Volumes: []types.Volume{vol}}, tc.expErr)
 
 			disk, err := c.GetDiskByName(ctx, tc.volumeName, tc.volumeCapacity)
@@ -2010,7 +2010,7 @@ func TestGetDiskByID(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mockEC2.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(
 				&ec2.DescribeVolumesOutput{
@@ -2110,7 +2110,7 @@ func TestCreateSnapshot(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mockEC2.EXPECT().CreateSnapshot(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, input *ec2.CreateSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.CreateSnapshotOutput, error) {
@@ -2227,7 +2227,7 @@ func TestEnableFastSnapshotRestores(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			mockEC2.EXPECT().EnableFastSnapshotRestores(gomock.Any(), gomock.Any(), gomock.Any()).Return(tc.expOutput, tc.expErr).AnyTimes()
 
 			response, err := c.EnableFastSnapshotRestores(ctx, tc.availabilityZones, tc.snapshotID)
@@ -2290,7 +2290,7 @@ func TestAvailabilityZones(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			mockEC2.EXPECT().DescribeAvailabilityZones(gomock.Any(), gomock.Any()).Return(tc.expOutput, tc.expErr).AnyTimes()
 
 			az, err := c.AvailabilityZones(ctx)
@@ -2344,7 +2344,7 @@ func TestDeleteSnapshot(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			mockEC2.EXPECT().DeleteSnapshot(gomock.Any(), gomock.Any(), gomock.Any()).Return(&ec2.DeleteSnapshotOutput{}, tc.expErr)
 
 			_, err := c.DeleteSnapshot(ctx, tc.snapshotName)
@@ -2633,7 +2633,7 @@ func TestResizeOrModifyDisk(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.existingVolume != nil || tc.existingVolumeError != nil {
 				mockEC2.EXPECT().DescribeVolumes(gomock.Any(), gomock.Any()).Return(
 					&ec2.DescribeVolumesOutput{
@@ -2767,7 +2767,7 @@ func TestModifyTags(t *testing.T) {
 			mockEC2 := NewMockEC2API(mockCtrl)
 			c := newCloud(mockEC2)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			if len(tc.modifyTagsOptions.TagsToAdd) > 0 {
 				if tc.negativeCase {
@@ -2857,7 +2857,7 @@ func TestGetSnapshotByName(t *testing.T) {
 				},
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{Snapshots: []types.Snapshot{ec2snapshot}}, nil)
 
@@ -2930,7 +2930,7 @@ func TestGetSnapshotByID(t *testing.T) {
 				State:      types.SnapshotStateCompleted,
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{Snapshots: []types.Snapshot{ec2snapshot}}, nil)
 
@@ -3014,7 +3014,7 @@ func TestListSnapshots(t *testing.T) {
 				mockEC2 := NewMockEC2API(mockCtl)
 				c := newCloud(mockEC2)
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{Snapshots: ec2Snapshots}, nil)
 
@@ -3089,7 +3089,7 @@ func TestListSnapshots(t *testing.T) {
 				mockEC2 := NewMockEC2API(mockCtl)
 				c := newCloud(mockEC2)
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{Snapshots: ec2Snapshots}, nil)
 
@@ -3153,7 +3153,7 @@ func TestListSnapshots(t *testing.T) {
 				mockEC2 := NewMockEC2API(mockCtl)
 				c := newCloud(mockEC2)
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				firstCall := mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{
 					Snapshots: ec2Snapshots[:maxResults],
@@ -3203,7 +3203,7 @@ func TestListSnapshots(t *testing.T) {
 				mockEC2 := NewMockEC2API(mockCtl)
 				c := newCloud(mockEC2)
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(nil, errors.New("test error"))
 
@@ -3221,7 +3221,7 @@ func TestListSnapshots(t *testing.T) {
 				mockEC2 := NewMockEC2API(mockCtl)
 				c := newCloud(mockEC2)
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockEC2.EXPECT().DescribeSnapshots(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSnapshotsOutput{}, nil)
 
@@ -3371,7 +3371,7 @@ func TestWaitForAttachmentState(t *testing.T) {
 				MultiAttachEnabled: aws.Bool(false),
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			switch tc.name {

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -108,7 +108,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         nil,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -178,7 +178,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -246,7 +246,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -303,7 +303,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -360,7 +360,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -389,7 +389,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         stdParams,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -437,7 +437,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeContext: map[string]string{},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -520,7 +520,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         stdParams,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -583,7 +583,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeContext: map[string]string{},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -645,7 +645,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeContext: map[string]string{},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -702,7 +702,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -745,7 +745,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -788,7 +788,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -831,7 +831,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -874,7 +874,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -916,7 +916,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -958,7 +958,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1000,7 +1000,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1043,7 +1043,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1091,7 +1091,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1137,7 +1137,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1178,7 +1178,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1219,7 +1219,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1287,7 +1287,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1360,7 +1360,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         nil,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1424,7 +1424,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         nil,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1491,7 +1491,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1547,7 +1547,7 @@ func TestCreateVolume(t *testing.T) {
 					},
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1585,7 +1585,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         nil,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1617,7 +1617,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeCapabilities: stdVolCap,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1646,7 +1646,7 @@ func TestCreateVolume(t *testing.T) {
 					Parameters:         nil,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockDisk := &cloud.Disk{
 					VolumeID:         req.GetName(),
@@ -1685,7 +1685,7 @@ func TestCreateVolume(t *testing.T) {
 					VolumeCapabilities: invalidMultiAttachVolCap,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -1849,7 +1849,7 @@ func TestCreateVolumeWithFormattingParameters(t *testing.T) {
 				Parameters:         tc.formattingOptionParameters,
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mockDisk := &cloud.Disk{
 				VolumeID:         req.GetName(),
@@ -1910,7 +1910,7 @@ func TestDeleteVolume(t *testing.T) {
 				}
 				expResp := &csi.DeleteVolumeResponse{}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -1943,7 +1943,7 @@ func TestDeleteVolume(t *testing.T) {
 				}
 				expResp := &csi.DeleteVolumeResponse{}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -1975,7 +1975,7 @@ func TestDeleteVolume(t *testing.T) {
 					VolumeId: "test-vol",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -2012,7 +2012,7 @@ func TestDeleteVolume(t *testing.T) {
 					VolumeId: "vol-test",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -2281,7 +2281,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2300,7 +2300,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2325,7 +2325,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2344,7 +2344,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2375,7 +2375,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2404,7 +2404,7 @@ func TestCreateSnapshot(t *testing.T) {
 						KubernetesClusterID: clusterID,
 					},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2432,7 +2432,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2462,7 +2462,7 @@ func TestCreateSnapshot(t *testing.T) {
 						},
 					},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2491,7 +2491,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				if _, err := awsDriver.CreateSnapshot(context.Background(), req); err != nil {
+				if _, err := awsDriver.CreateSnapshot(t.Context(), req); err != nil {
 					srvErr, ok := status.FromError(err)
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
@@ -2516,7 +2516,7 @@ func TestCreateSnapshot(t *testing.T) {
 					SourceVolumeId: "vol-test",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -2529,7 +2529,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				_, err := awsDriver.CreateSnapshot(context.Background(), req)
+				_, err := awsDriver.CreateSnapshot(t.Context(), req)
 				checkExpectedErrorCode(t, err, codes.InvalidArgument)
 			},
 		},
@@ -2551,7 +2551,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2570,7 +2570,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					srvErr, ok := status.FromError(err)
 					if !ok {
@@ -2619,7 +2619,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2638,7 +2638,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2678,7 +2678,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: inFlight,
 					options:  &Options{},
 				}
-				_, err := awsDriver.CreateSnapshot(context.Background(), req)
+				_, err := awsDriver.CreateSnapshot(t.Context(), req)
 
 				checkExpectedErrorCode(t, err, codes.Aborted)
 			},
@@ -2704,7 +2704,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2731,7 +2731,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2762,7 +2762,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2790,7 +2790,7 @@ func TestCreateSnapshot(t *testing.T) {
 					inFlight: internal.NewInFlight(),
 					options:  &Options{KubernetesClusterID: clusterID},
 				}
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2819,7 +2819,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2856,7 +2856,7 @@ func TestCreateSnapshot(t *testing.T) {
 					options:  &Options{},
 				}
 
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2885,7 +2885,7 @@ func TestCreateSnapshot(t *testing.T) {
 					ReadyToUse: true,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2921,7 +2921,7 @@ func TestCreateSnapshot(t *testing.T) {
 					options:  &Options{},
 				}
 
-				resp, err := awsDriver.CreateSnapshot(context.Background(), req)
+				resp, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -2947,7 +2947,7 @@ func TestCreateSnapshot(t *testing.T) {
 					SourceVolumeId: "vol-test",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -2991,7 +2991,7 @@ func TestCreateSnapshot(t *testing.T) {
 					options:  &Options{},
 				}
 
-				_, err := awsDriver.CreateSnapshot(context.Background(), req)
+				_, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err == nil {
 					t.Fatalf("Expected error, got nil")
 				}
@@ -3013,7 +3013,7 @@ func TestCreateSnapshot(t *testing.T) {
 					SourceVolumeId: "vol-test",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -3028,7 +3028,7 @@ func TestCreateSnapshot(t *testing.T) {
 					options:  &Options{},
 				}
 
-				_, err := awsDriver.CreateSnapshot(context.Background(), req)
+				_, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err == nil {
 					t.Fatalf("Expected error, got nil")
 				}
@@ -3050,7 +3050,7 @@ func TestCreateSnapshot(t *testing.T) {
 					SourceVolumeId: "vol-test",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockSnapshot := &cloud.Snapshot{
 					SnapshotID:     fmt.Sprintf("snapshot-%d", rand.New(rand.NewSource(time.Now().UnixNano())).Uint64()),
 					SourceVolumeID: req.GetSourceVolumeId(),
@@ -3082,7 +3082,7 @@ func TestCreateSnapshot(t *testing.T) {
 					options:  &Options{},
 				}
 
-				_, err := awsDriver.CreateSnapshot(context.Background(), req)
+				_, err := awsDriver.CreateSnapshot(t.Context(), req)
 				if err == nil {
 					t.Fatalf("Expected error, got nil")
 				}
@@ -3104,7 +3104,7 @@ func TestDeleteSnapshot(t *testing.T) {
 			name: "success normal",
 			testFunc: func(t *testing.T) {
 				t.Helper()
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -3130,7 +3130,7 @@ func TestDeleteSnapshot(t *testing.T) {
 			name: "success not found",
 			testFunc: func(t *testing.T) {
 				t.Helper()
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -3156,7 +3156,7 @@ func TestDeleteSnapshot(t *testing.T) {
 			name: "fail with another request in-flight",
 			testFunc: func(t *testing.T) {
 				t.Helper()
-				ctx := context.Background()
+				ctx := t.Context()
 
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
@@ -3216,7 +3216,7 @@ func TestListSnapshots(t *testing.T) {
 					NextToken: "",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -3229,7 +3229,7 @@ func TestListSnapshots(t *testing.T) {
 					options:  &Options{},
 				}
 
-				resp, err := awsDriver.ListSnapshots(context.Background(), req)
+				resp, err := awsDriver.ListSnapshots(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -3244,7 +3244,7 @@ func TestListSnapshots(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				t.Helper()
 				req := &csi.ListSnapshotsRequest{}
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -3257,7 +3257,7 @@ func TestListSnapshots(t *testing.T) {
 					options:  &Options{},
 				}
 
-				resp, err := awsDriver.ListSnapshots(context.Background(), req)
+				resp, err := awsDriver.ListSnapshots(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -3281,7 +3281,7 @@ func TestListSnapshots(t *testing.T) {
 					CreationTime:   time.Now(),
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -3294,7 +3294,7 @@ func TestListSnapshots(t *testing.T) {
 					options:  &Options{},
 				}
 
-				resp, err := awsDriver.ListSnapshots(context.Background(), req)
+				resp, err := awsDriver.ListSnapshots(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -3312,7 +3312,7 @@ func TestListSnapshots(t *testing.T) {
 					SnapshotId: "snapshot-1",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -3325,7 +3325,7 @@ func TestListSnapshots(t *testing.T) {
 					options:  &Options{},
 				}
 
-				resp, err := awsDriver.ListSnapshots(context.Background(), req)
+				resp, err := awsDriver.ListSnapshots(t.Context(), req)
 				if err != nil {
 					t.Fatalf("Unexpected error: %v", err)
 				}
@@ -3343,7 +3343,7 @@ func TestListSnapshots(t *testing.T) {
 					SnapshotId: "snapshot-1",
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 
@@ -3356,7 +3356,7 @@ func TestListSnapshots(t *testing.T) {
 					options:  &Options{},
 				}
 
-				if _, err := awsDriver.ListSnapshots(context.Background(), req); err != nil {
+				if _, err := awsDriver.ListSnapshots(t.Context(), req); err != nil {
 					srvErr, ok := status.FromError(err)
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
@@ -3377,7 +3377,7 @@ func TestListSnapshots(t *testing.T) {
 					MaxEntries: 4,
 				}
 
-				ctx := context.Background()
+				ctx := t.Context()
 				mockCtl := gomock.NewController(t)
 				defer mockCtl.Finish()
 				mockCloud := cloud.NewMockCloud(mockCtl)
@@ -3389,7 +3389,7 @@ func TestListSnapshots(t *testing.T) {
 					options:  &Options{},
 				}
 
-				if _, err := awsDriver.ListSnapshots(context.Background(), req); err != nil {
+				if _, err := awsDriver.ListSnapshots(t.Context(), req); err != nil {
 					srvErr, ok := status.FromError(err)
 					if !ok {
 						t.Fatalf("Could not get error status code from error: %v", srvErr)
@@ -3538,7 +3538,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				VolumeCapability: tc.volumeCapability,
 				VolumeId:         tc.volumeID,
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 
 			awsDriver, mockCtl, mockCloud := createControllerService(t)
 			defer mockCtl.Finish()
@@ -3633,7 +3633,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 				VolumeId: tc.volumeID,
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			awsDriver, mockCtl, mockCloud := createControllerService(t)
 			defer mockCtl.Finish()
@@ -3699,7 +3699,7 @@ func TestControllerExpandVolume(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package driver
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -1034,7 +1033,7 @@ func TestNodeStageVolume(t *testing.T) {
 				driver.inFlight.Insert("vol-test")
 			}
 
-			_, err := driver.NodeStageVolume(context.Background(), tc.req)
+			_, err := driver.NodeStageVolume(t.Context(), tc.req)
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("Expected error '%v' but got '%v'", tc.expectedErr, err)
 			}
@@ -1771,7 +1770,7 @@ func TestNodePublishVolume(t *testing.T) {
 				driver.inFlight.Insert("vol-test")
 			}
 
-			_, err := driver.NodePublishVolume(context.Background(), tc.req)
+			_, err := driver.NodePublishVolume(t.Context(), tc.req)
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("Expected error '%v' but got '%v'", tc.expectedErr, err)
 			}
@@ -1896,7 +1895,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 				driver.inFlight.Insert("vol-test")
 			}
 
-			_, err := driver.NodeUnstageVolume(context.Background(), tc.req)
+			_, err := driver.NodeUnstageVolume(t.Context(), tc.req)
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("Expected error '%v' but got '%v'", tc.expectedErr, err)
 			}
@@ -1932,7 +1931,7 @@ func TestNodeGetCapabilities(t *testing.T) {
 
 	driver := &NodeService{}
 
-	resp, err := driver.NodeGetCapabilities(context.Background(), req)
+	resp, err := driver.NodeGetCapabilities(t.Context(), req)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2021,7 +2020,7 @@ func TestNodeGetInfo(t *testing.T) {
 				options:  &Options{},
 			}
 
-			resp, err := driver.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{})
+			resp, err := driver.NodeGetInfo(t.Context(), &csi.NodeGetInfoRequest{})
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -2110,7 +2109,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 				driver.inFlight.Insert("vol-test")
 			}
 
-			_, err := driver.NodeUnpublishVolume(context.Background(), tc.req)
+			_, err := driver.NodeUnpublishVolume(t.Context(), tc.req)
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("Expected error '%v' but got '%v'", tc.expectedErr, err)
 			}
@@ -2340,7 +2339,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				metadata: metadata,
 			}
 
-			resp, err := driver.NodeExpandVolume(context.Background(), tc.req)
+			resp, err := driver.NodeExpandVolume(t.Context(), tc.req)
 			if !reflect.DeepEqual(err, tc.expectedErr) {
 				t.Fatalf("Expected error '%v' but got '%v'", tc.expectedErr, err)
 			}
@@ -2491,7 +2490,7 @@ func TestNodeGetVolumeStats(t *testing.T) {
 				req.VolumePath = "fake-path"
 			}
 
-			_, err := driver.NodeGetVolumeStats(context.TODO(), req)
+			_, err := driver.NodeGetVolumeStats(t.Context(), req)
 
 			if !reflect.DeepEqual(err, tc.expectedErr(dir)) {
 				t.Fatalf("Expected error '%v' but got '%v'", tc.expectedErr(dir), err)

--- a/pkg/driver/request_coalescing_test.go
+++ b/pkg/driver/request_coalescing_test.go
@@ -130,7 +130,7 @@ func testBasicRequestCoalescingSuccess(t *testing.T, executor modifyVolumeExecut
 	wg.Add(2)
 
 	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
-		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		_, err := awsDriver.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
 			VolumeId: volumeID,
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: NewSize,
@@ -143,7 +143,7 @@ func testBasicRequestCoalescingSuccess(t *testing.T, executor modifyVolumeExecut
 		wg.Done()
 	})
 	go wrapTimeout(t, "Modify timed out", func() {
-		err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+		err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 			ModificationKeyVolumeType: NewVolumeType,
 		})
 
@@ -186,7 +186,7 @@ func testRequestFail(t *testing.T, executor modifyVolumeExecutor) {
 	wg.Add(2)
 
 	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
-		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		_, err := awsDriver.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
 			VolumeId: volumeID,
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: NewSize,
@@ -199,7 +199,7 @@ func testRequestFail(t *testing.T, executor modifyVolumeExecutor) {
 		wg.Done()
 	})
 	go wrapTimeout(t, "Modify timed out", func() {
-		err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+		err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 			ModificationKeyVolumeType: NewVolumeType,
 		})
 
@@ -259,7 +259,7 @@ func testPartialFail(t *testing.T, executor modifyVolumeExecutor) {
 	volumeType1Err, volumeType2Error := false, false
 
 	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
-		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		_, err := awsDriver.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
 			VolumeId: volumeID,
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: NewSize,
@@ -272,14 +272,14 @@ func testPartialFail(t *testing.T, executor modifyVolumeExecutor) {
 		wg.Done()
 	})
 	go wrapTimeout(t, "Modify timed out", func() {
-		err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+		err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 			ModificationKeyVolumeType: NewVolumeType1, // gp3
 		})
 		volumeType1Err = err != nil
 		wg.Done()
 	})
 	go wrapTimeout(t, "Modify timed out", func() {
-		err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+		err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 			ModificationKeyVolumeType: NewVolumeType2, // io2
 		})
 		if err != nil {
@@ -340,7 +340,7 @@ func testSequentialRequests(t *testing.T, executor modifyVolumeExecutor) {
 	wg.Add(2)
 
 	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
-		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		_, err := awsDriver.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
 			VolumeId: volumeID,
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: NewSize,
@@ -357,7 +357,7 @@ func testSequentialRequests(t *testing.T, executor modifyVolumeExecutor) {
 	time.Sleep(5 * time.Second)
 
 	go wrapTimeout(t, "Modify timed out", func() {
-		err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+		err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 			ModificationKeyVolumeType: NewVolumeType,
 		})
 
@@ -401,7 +401,7 @@ func testDuplicateRequest(t *testing.T, executor modifyVolumeExecutor) {
 
 	for range num {
 		go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
-			_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+			_, err := awsDriver.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
 				VolumeId: volumeID,
 				CapacityRange: &csi.CapacityRange{
 					RequiredBytes: NewSize,
@@ -413,7 +413,7 @@ func testDuplicateRequest(t *testing.T, executor modifyVolumeExecutor) {
 			wg.Done()
 		})
 		go wrapTimeout(t, "Modify timed out", func() {
-			err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+			err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 				ModificationKeyVolumeType: "io2",
 			})
 			if err != nil {
@@ -462,7 +462,7 @@ func testResponseReturnTiming(t *testing.T, executor modifyVolumeExecutor) {
 	wg.Add(2)
 
 	go wrapTimeout(t, "ControllerExpandVolume timed out", func() {
-		_, err := awsDriver.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+		_, err := awsDriver.ControllerExpandVolume(t.Context(), &csi.ControllerExpandVolumeRequest{
 			VolumeId: volumeID,
 			CapacityRange: &csi.CapacityRange{
 				RequiredBytes: NewSize,
@@ -478,7 +478,7 @@ func testResponseReturnTiming(t *testing.T, executor modifyVolumeExecutor) {
 		wg.Done()
 	})
 	go wrapTimeout(t, "Modify timed out", func() {
-		err := executor(context.Background(), awsDriver, volumeID, map[string]string{
+		err := executor(t.Context(), awsDriver, volumeID, map[string]string{
 			ModificationKeyVolumeType: NewVolumeType,
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind cleanup

#### What is this PR about? / Why do we need it?
This PR enables the `usetesing` linter which ensures that wherever we are using test methods in our unit tests.
#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
