### PR TITLE
Remove all examples/references to Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # See
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # for info on BUILDPLATFORM, TARGETOS, TARGETARCH, etc.
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.24 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 RUN go env -w GOCACHE=/gocache GOMODCACHE=/gomodcache
 COPY go.* .

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -337,7 +337,7 @@ controller:
   # Example:
   #
   # - name: wait
-  #   image: busybox
+  #   image: public.ecr.aws/amazonlinux/amazonlinux
   #   command: [ 'sh', '-c', "sleep 20" ]
   # Enable opentelemetry tracing for the plugin running on the daemonset
   otelTracing: {}
@@ -454,7 +454,7 @@ node:
   # Example:
   #
   # - name: wait
-  #   image: busybox
+  #   image: public.ecr.aws/amazonlinux/amazonlinux
   #   command: [ 'sh', '-c', "sleep 20" ]
   # Enable opentelemetry tracing for the plugin running on the daemonset
   otelTracing: {}

--- a/examples/kubernetes/block-volume/manifests/pod.yaml
+++ b/examples/kubernetes/block-volume/manifests/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app 
-    image: busybox 
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh", "-c"]
     args: ["tail -f /dev/null"]
     volumeDevices:

--- a/examples/kubernetes/dynamic-provisioning/manifests/pod.yaml
+++ b/examples/kubernetes/dynamic-provisioning/manifests/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/ephemeral-volume/manifests/pod.yaml
+++ b/examples/kubernetes/ephemeral-volume/manifests/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
     - name: app
-      image: centos
+      image: public.ecr.aws/amazonlinux/amazonlinux
       command: ["/bin/sh"]
       args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
       volumeMounts:

--- a/examples/kubernetes/modify-volume/manifests/pod-with-volume.yaml
+++ b/examples/kubernetes/modify-volume/manifests/pod-with-volume.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) | tee /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/resizing/manifests/pod.yaml
+++ b/examples/kubernetes/resizing/manifests/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/snapshot/manifests/app/pod.yaml
+++ b/examples/kubernetes/snapshot/manifests/app/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/snapshot/manifests/snapshot-import/app/pod.yaml
+++ b/examples/kubernetes/snapshot/manifests/snapshot-import/app/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/snapshot/manifests/snapshot-restore/pod.yaml
+++ b/examples/kubernetes/snapshot/manifests/snapshot-restore/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/static-provisioning/manifests/pod.yaml
+++ b/examples/kubernetes/static-provisioning/manifests/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:

--- a/examples/kubernetes/storageclass/manifests/pod.yaml
+++ b/examples/kubernetes/storageclass/manifests/pod.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   containers:
   - name: app
-    image: centos
+    image: public.ecr.aws/amazonlinux/amazonlinux
     command: ["/bin/sh"]
     args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
     volumeMounts:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind documentation

#### What is this PR about? / Why do we need it?

Pulling images from Docker Hub is a poor experience, due to Docker Hub rate limiting. Additionally, the images we reference are extremely outdated. Replace all Docker Hub images with `public.ecr.aws/amazonlinux/amazonlinux`.

#### How was this change tested?

Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
