### PR TITLE
Fix to only initialize controller metrics in controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -158,6 +158,9 @@ func main() {
 		r := metrics.InitializeRecorder(options.DeprecatedMetrics)
 		r.InitializeMetricsHandler(options.HTTPEndpoint, "/metrics", options.MetricsCertFile, options.MetricsKeyFile)
 
+		if options.Mode == driver.ControllerMode || options.Mode == driver.AllMode {
+			r.InitializeAPIMetrics(options.DeprecatedMetrics)
+		}
 		if options.Mode == driver.NodeMode || options.Mode == driver.AllMode {
 			metrics.InitializeNVME(r, options.CsiMountPointPath, md.GetInstanceID())
 		}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -69,7 +69,6 @@ func InitializeRecorder(deprecatedMetrics bool) *metricRecorder {
 			registry: prometheus.NewRegistry(),
 			metrics:  make(map[string]interface{}),
 		}
-		r.initializeAPIMetrics(deprecatedMetrics)
 	})
 	return r
 }
@@ -210,7 +209,8 @@ func (m *metricRecorder) initializeMetricWithOperations(name, help string, label
 	}
 }
 
-func (m *metricRecorder) initializeAPIMetrics(deprecatedMetrics bool) {
+// InitializeAPIMetrics registers and initializes any `aws_ebs_csi` metric that has known label values on driver startup. Setting deprecatedMetrics to true also initializes deprecated metrics.
+func (m *metricRecorder) InitializeAPIMetrics(deprecatedMetrics bool) {
 	labelNames := []string{"request"}
 	help := HelpText
 	m.initializeMetricWithOperations(


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What is this PR about? / Why do we need it?
This PR ensures that controller Prometheus metrics do not also populate on the node metrics.

#### How was this change tested?
Installed driver on cluster with three different configurations and confirmed that the metric outputs were as expected. The configurations were:

1. `--set="node.enableMetrics=true" --set="controller.enableMetrics=true"`
2. `--set="node.enableMetrics=true" --set="controller.enableMetrics=false"`
3. `--set="node.enableMetrics=false" --set="controller.enableMetrics=true"`

This what node metrics look like now: 
```# HELP aws_ebs_csi_nvme_collector_duration_seconds Histogram of NVMe collector scrape duration in seconds.
# TYPE aws_ebs_csi_nvme_collector_duration_seconds histogram
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.001"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.0025"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.005"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.01"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.025"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.05"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.1"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.25"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="0.5"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="1"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="2.5"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="5"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="10"} 1
aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="i-0e2bb1585c491000c",le="+Inf"} 1
aws_ebs_csi_nvme_collector_duration_seconds_sum{instance_id="i-0e2bb1585c491000c"} 0.000218889
aws_ebs_csi_nvme_collector_duration_seconds_count{instance_id="i-0e2bb1585c491000c"} 1
# HELP aws_ebs_csi_nvme_collector_errors_total Total number of NVMe collector scrape errors.
# TYPE aws_ebs_csi_nvme_collector_errors_total counter
aws_ebs_csi_nvme_collector_errors_total{instance_id="i-0e2bb1585c491000c"} 0
# HELP aws_ebs_csi_nvme_collector_scrapes_total Total number of NVMe collector scrapes.
# TYPE aws_ebs_csi_nvme_collector_scrapes_total counter
aws_ebs_csi_nvme_collector_scrapes_total{instance_id="i-0e2bb1585c491000c"} 1 
```

#### Does this PR introduce a user-facing change?
```
Customers will no longer see controller metrics when scraping only node metrics
```
