### PR TITLE
Add e2e tests for fips and a1compat images

### DIFF
--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -32,6 +32,13 @@ test-e2e-multi-az)
 test-e2e-external)
   TEST="external"
   ;;
+test-e2e-external-a1)
+  TEST="external-a1"
+  export INSTANCE_TYPE="a1.large"
+  ;;
+test-e2e-external-fips)
+  TEST="external-fips"
+  ;;
 test-e2e-external-arm64)
   TEST="external"
   export IMAGE_ARCH="arm64"
@@ -44,6 +51,11 @@ test-e2e-external-eks)
   ;;
 test-e2e-external-eks-windows)
   TEST="external-windows"
+  export CLUSTER_TYPE="eksctl"
+  export WINDOWS="true"
+  ;;
+test-e2e-external-eks-windows-fips)
+  TEST="external-windows-fips"
   export CLUSTER_TYPE="eksctl"
   export WINDOWS="true"
   ;;


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature
#### What is this PR about? / Why do we need it?
This PR adds the necessary changes in the driver repo to add a1compat and fips image e2e tests
#### How was this change tested?
Tested locally by running make file targets
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
