### PR TITLE
Ignore ECR login failure in make cluster/image

### DIFF
--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -42,7 +42,10 @@ function build_and_push() {
   fi
 
   loudecho "Building and pushing test driver image to ${IMAGE_NAME}:${IMAGE_TAG}"
-  aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+  # Ignore login failures, could be caused by having https://github.com/awslabs/amazon-ecr-credential-helper installed or other similar special cases
+  # We're about to try to push the image, so any credential issue will be revealed at that time
+  aws ecr get-login-password --region "${REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com" ||
+    echo "Ignoring ECR login failure, image push may fail if this is unexpected"
 
   # Only setup buildx builder on Prow, allow local users to use docker cache
   if [ -n "${PROW_JOB_ID:-}" ]; then


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

In some cases, logging in to ECR doesn't work but isn't necessary, such as if the user has a login helper installed. Instead of failing out on this step, explicitly ignore failures as any issues will show up shortly after in the push anyways.

#### How was this change tested?

Manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
