### PR TITLE
Add make cluster/helm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,10 +51,14 @@ eval "$(make cluster/kubeconfig)"
 To test a change, build the driver image and then install it:
 ```bash
 make cluster/image
-# If testing a Helm-based change, you can use HELM_EXTRA_FLAGS
-# to set your new paremeters for testing, for example:
-# export HELM_EXTRA_FLAGS="--set=controller.newParameter=true"
 make cluster/install
+```
+
+If you are testing a Helm-only change, `make cluster/helm` installs using the default (release) image:
+```bash
+# Use HELM_EXTRA_FLAGS for testing parameters, for example:
+# export HELM_EXTRA_FLAGS="--set=controller.newParameter=true"
+make cluster/helm
 ```
 
 When you are finished manually testing, uninstall the driver:

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,11 @@ cluster/delete: bin/kops bin/eksctl
 cluster/install: bin/helm bin/aws
 	./hack/e2e/install.sh
 
+.PHONY: cluster/helm
+cluster/helm: bin/helm bin/aws
+	HELM_USE_DEFAULT_IMAGE="true" \
+	./hack/e2e/install.sh
+
 .PHONY: cluster/uninstall
 cluster/uninstall: bin/helm bin/aws
 	./hack/e2e/uninstall.sh

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -158,7 +158,18 @@ Install the EBS CSI Driver to the cluster via Helm. You must have already run `m
 #### Example: Install the EBS CSI Driver to a cluster for testing
 
 ```bash
+make cluster/image
 make cluster/install
+```
+
+### `make cluster/install`
+
+Install the EBS CSI Driver to the cluster via Helm using the default (release) image. This is useful for testing Helm-only changes.
+
+#### Example: Install the EBS CSI Driver to a cluster for testing a Helm-only change
+
+```bash
+make cluster/helm
 ```
 
 ### `make cluster/uninstall`

--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -27,8 +27,6 @@ function install_driver() {
     HELM_ARGS=(upgrade --install aws-ebs-csi-driver
       "${BASE_DIR}/../../charts/aws-ebs-csi-driver"
       --namespace kube-system
-      --set image.repository="${IMAGE_NAME}"
-      --set image.tag="${IMAGE_TAG}"
       --set node.enableWindows="${WINDOWS}"
       --set node.windowsHostProcess="${WINDOWS_HOSTPROCESS}"
       --set controller.k8sTagClusterId="${CLUSTER_NAME}"
@@ -38,6 +36,10 @@ function install_driver() {
       --kubeconfig "${KUBECONFIG}")
     if [ -n "${HELM_VALUES_FILE:-}" ]; then
       HELM_ARGS+=(-f "${HELM_VALUES_FILE}")
+    fi
+    if [ -z "${HELM_USE_DEFAULT_IMAGE+x}" ]; then
+      HELM_ARGS+=(--set image.repository="${IMAGE_NAME}")
+      HELM_ARGS+=(--set image.tag="${IMAGE_TAG}")
     fi
     eval "EXPANDED_HELM_EXTRA_FLAGS=$HELM_EXTRA_FLAGS"
     if [[ -n "$EXPANDED_HELM_EXTRA_FLAGS" ]]; then


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

While the existing `Makefile` works great for testing changes to the Go driver code, it requires building the image to install and cannot be easily modified to use the default (released) image. This means that to test a Helm-only change you have to waste your time building the image, and if you explicitly want to install the released image (such as to test something with the released version of the driver) you can't (easily) use `make cluster/install`.

This PR adds a new command, `make cluster/helm` that installs the default image. This command is primarily intended for (and documented as) a way to test Helm-only changes without needing to build the image. It uses the same function as the normal installation, so it will automatically respect the existing environment variables.

Technically this could be installed as just an environment variable, but I feel like this is such a common operation that giving it a top-level make target is sufficiently useful over making people remember something like `HELM_USE_DEFAULT_IMAGE=true make cluster/install`. Open to feedback if others disagree though.

#### How was this change tested?

Manually, CI will not exercise this target.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
