### PR TITLE
Adding more metric specific HELP texts for controller metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,6 +23,14 @@ Installing the Prometheus Operator and enabling metrics will deploy a [Service](
 
 The EBS CSI Driver will emit [AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/OperationList-query.html) metrics to the following TCP endpoint: `0.0.0.0:3301/metrics` if `controller.enableMetrics: true` has been configured in the Helm chart.
 
+The following metrics are currently supported:
+
+| Metric name | Metric type | Description | Labels |
+|-------------|-------------|-------------|-------------|
+|aws_ebs_csi_api_request_duration_seconds|Histogram|Duration by request type in seconds|request=\<AWS SDK API Request Type\> <br/> le=\<Time In Seconds\>| 
+|aws_ebs_csi_api_request_errors_total|Counter|Total number of errors by error code and request type|request=\<AWS SDK API Request Type\> <br/> error=\<Error Code\>| 
+|aws_ebs_csi_api_request_throttles_total|Counter|Total number of throttled requests per request type|request=\<AWS SDK API Request Type\>|
+
 The metrics will appear in the following format: 
 ```sh
 aws_ebs_csi_api_request_duration_seconds_bucket{request="AttachVolume",le="0.005"} 0

--- a/pkg/cloud/handlers.go
+++ b/pkg/cloud/handlers.go
@@ -44,23 +44,23 @@ func RecordRequestsMiddleware(deprecatedMetrics bool) func(*middleware.Stack) er
 						labels = map[string]string{
 							"operation_name": operationName,
 						}
-						metrics.Recorder().IncreaseCount(metrics.APIRequestThrottles, labels)
+						metrics.Recorder().IncreaseCount(metrics.APIRequestThrottles, metrics.APIRequestThrottlesHelpText, labels)
 						if deprecatedMetrics {
-							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestThrottles, labels)
+							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestThrottles, metrics.DeprecatedAPIRequestThrottlesHelpText, labels)
 						}
 					} else {
 						labels["code"] = apiErr.ErrorCode()
-						metrics.Recorder().IncreaseCount(metrics.APIRequestErrors, labels)
+						metrics.Recorder().IncreaseCount(metrics.APIRequestErrors, metrics.APIRequestErrorsHelpText, labels)
 						if deprecatedMetrics {
-							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestErrors, labels)
+							metrics.Recorder().IncreaseCount(metrics.DeprecatedAPIRequestErrors, metrics.DeprecatedAPIRequestErrorsHelpText, labels)
 						}
 					}
 				}
 			} else {
 				duration := time.Since(start).Seconds()
-				metrics.Recorder().ObserveHistogram(metrics.APIRequestDuration, duration, labels, nil)
+				metrics.Recorder().ObserveHistogram(metrics.APIRequestDuration, metrics.APIRequestDurationHelpText, duration, labels, nil)
 				if deprecatedMetrics {
-					metrics.Recorder().ObserveHistogram(metrics.DeprecatedAPIRequestDuration, duration, labels, nil)
+					metrics.Recorder().ObserveHistogram(metrics.DeprecatedAPIRequestDuration, metrics.DeprecatedAPIRequestDurationHelpText, duration, labels, nil)
 				}
 			}
 			return output, metadata, err

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -16,12 +16,16 @@ package metrics
 
 // constants for prometheus metrics use.
 const (
-	APIRequestDuration            = "aws_ebs_csi_api_request_duration_seconds"
-	APIRequestErrors              = "aws_ebs_csi_api_request_errors_total"
-	APIRequestThrottles           = "aws_ebs_csi_api_request_throttles_total"
-	HelpText                      = "ebs_csi_aws_com metric"
-	DeprecatedHelpText            = "cloudprovider_aws_api metric"
-	DeprecatedAPIRequestDuration  = "cloudprovider_aws_api_request_duration_seconds"
-	DeprecatedAPIRequestErrors    = "cloudprovider_aws_api_request_errors"
-	DeprecatedAPIRequestThrottles = "cloudprovider_aws_api_throttled_requests_total"
+	APIRequestDuration                    = "aws_ebs_csi_api_request_duration_seconds"
+	APIRequestErrors                      = "aws_ebs_csi_api_request_errors_total"
+	APIRequestThrottles                   = "aws_ebs_csi_api_request_throttles_total"
+	APIRequestDurationHelpText            = "AWS SDK API request duration by request type in seconds"
+	APIRequestErrorsHelpText              = "Total number of AWS SDK API errors by error code and request type"
+	APIRequestThrottlesHelpText           = "Total number of throttled AWS SDK API requests per request type"
+	DeprecatedAPIRequestDurationHelpText  = APIRequestDurationHelpText + " (deprecated)"
+	DeprecatedAPIRequestErrorsHelpText    = APIRequestErrorsHelpText + " (deprecated)"
+	DeprecatedAPIRequestThrottlesHelpText = APIRequestThrottlesHelpText + " (deprecated)"
+	DeprecatedAPIRequestDuration          = "cloudprovider_aws_api_request_duration_seconds"
+	DeprecatedAPIRequestErrors            = "cloudprovider_aws_api_request_errors"
+	DeprecatedAPIRequestThrottles         = "cloudprovider_aws_api_throttled_requests_total"
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -79,7 +79,7 @@ func InitializeNVME(r *metricRecorder, csiMountPointPath, instanceID string) {
 }
 
 // IncreaseCount increases the counter metric by 1.
-func (m *metricRecorder) IncreaseCount(name string, labels map[string]string) {
+func (m *metricRecorder) IncreaseCount(name string, helpText string, labels map[string]string) {
 	if m == nil {
 		return // recorder is not initialized
 	}
@@ -88,8 +88,8 @@ func (m *metricRecorder) IncreaseCount(name string, labels map[string]string) {
 
 	if !ok {
 		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
-		m.registerCounterVec(name, "ebs_csi_aws_com metric", getLabelNames(labels))
-		m.IncreaseCount(name, labels)
+		m.registerCounterVec(name, helpText, getLabelNames(labels))
+		m.IncreaseCount(name, helpText, labels)
 		return
 	}
 
@@ -102,7 +102,7 @@ func (m *metricRecorder) IncreaseCount(name string, labels map[string]string) {
 }
 
 // ObserveHistogram records the given value in the histogram metric.
-func (m *metricRecorder) ObserveHistogram(name string, value float64, labels map[string]string, buckets []float64) {
+func (m *metricRecorder) ObserveHistogram(name string, helpText string, value float64, labels map[string]string, buckets []float64) {
 	if m == nil {
 		return // recorder is not initialized
 	}
@@ -110,8 +110,8 @@ func (m *metricRecorder) ObserveHistogram(name string, value float64, labels map
 
 	if !ok {
 		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels, "buckets", buckets)
-		m.registerHistogramVec(name, "ebs_csi_aws_com metric", getLabelNames(labels), buckets)
-		m.ObserveHistogram(name, value, labels, buckets)
+		m.registerHistogramVec(name, helpText, getLabelNames(labels), buckets)
+		m.ObserveHistogram(name, helpText, value, labels, buckets)
 		return
 	}
 
@@ -212,17 +212,15 @@ func (m *metricRecorder) initializeMetricWithOperations(name, help string, label
 // InitializeAPIMetrics registers and initializes any `aws_ebs_csi` metric that has known label values on driver startup. Setting deprecatedMetrics to true also initializes deprecated metrics.
 func (m *metricRecorder) InitializeAPIMetrics(deprecatedMetrics bool) {
 	labelNames := []string{"request"}
-	help := HelpText
 	m.initializeMetricWithOperations(
 		APIRequestDuration,
-		help,
+		APIRequestDurationHelpText,
 		labelNames,
 	)
 	if deprecatedMetrics {
-		help = DeprecatedHelpText
 		m.initializeMetricWithOperations(
 			DeprecatedAPIRequestDuration,
-			help,
+			DeprecatedAPIRequestDurationHelpText,
 			labelNames,
 		)
 	}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -31,10 +31,10 @@ func TestMetricRecorder(t *testing.T) {
 		{
 			name: "TestMetricRecorder: IncreaseCounterMetric",
 			exec: func(m *metricRecorder) {
-				m.IncreaseCount("test_total", map[string]string{"key": "value"})
+				m.IncreaseCount("test_total", "help text", map[string]string{"key": "value"})
 			},
 			expected: `
-# HELP test_total ebs_csi_aws_com metric
+# HELP test_total help text
 # TYPE test_total counter
 test_total{key="value"} 1
 			`,
@@ -43,10 +43,10 @@ test_total{key="value"} 1
 		{
 			name: "TestMetricRecorder: ObserveHistogramMetric",
 			exec: func(m *metricRecorder) {
-				m.ObserveHistogram("test", 1.5, map[string]string{"key": "value"}, []float64{1, 2, 3})
+				m.ObserveHistogram("test", "help text", 1.5, map[string]string{"key": "value"}, []float64{1, 2, 3})
 			},
 			expected: `
-# HELP test ebs_csi_aws_com metric
+# HELP test help text
 # TYPE test histogram
 test{key="value",le="1"} 0
 test{key="value",le="2"} 1
@@ -60,13 +60,13 @@ test_count{key="value"} 1
 		{
 			name: "TestMetricRecorder: Re-register metric",
 			exec: func(m *metricRecorder) {
-				m.IncreaseCount("test_re_register_total", map[string]string{"key": "value1"})
-				m.registerCounterVec("test_re_register_total", "ebs_csi_aws_com metric", []string{"key"})
-				m.IncreaseCount("test_re_register_total", map[string]string{"key": "value1"})
-				m.IncreaseCount("test_re_register_total", map[string]string{"key": "value2"})
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value1"})
+				m.registerCounterVec("test_re_register_total", "help text", []string{"key"})
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value1"})
+				m.IncreaseCount("test_re_register_total", "help text", map[string]string{"key": "value2"})
 			},
 			expected: `
-# HELP test_re_register_total ebs_csi_aws_com metric
+# HELP test_re_register_total help text
 # TYPE test_re_register_total counter
 test_re_register_total{key="value1"} 2
 test_re_register_total{key="value2"} 1


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What is this PR about? / Why do we need it?

This PR adds more descriptive HELP texts to the driver controller metrics

#### How was this change tested?

Deployed driver with controller metrics enabled and checked that HELP texts on top were showing correctly

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```
Add more descriptive Prometheus `HELP` texts to each metric from the controller.
```
