### PR TITLE
Fix a1compat makefile target and fix fips CI jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,8 @@ e2e/external: bin/helm bin/kubetest2
 	COLLECT_METRICS="true" \
 	./hack/e2e/run.sh
 
-.PHONY: e2e/external-a1
-e2e/external-a1: bin/helm bin/kubetest2
+.PHONY: e2e/external-a1-eks
+e2e/external-a1-eks: bin/helm bin/kubetest2
 	HELM_EXTRA_FLAGS="--set=a1CompatibilityDaemonSet=true" \
 	./hack/e2e/run.sh
 
@@ -167,7 +167,7 @@ e2e/external-windows-fips: bin/helm bin/kubetest2
 	GINKGO_SKIP=$(GINKGO_WINDOWS_SKIP) \
 	GINKGO_PARALLEL=15 \
 	EBS_INSTALL_SNAPSHOT="false" \
-	HELM_EXTRA_FLAGS="--set=fips=true"
+	HELM_EXTRA_FLAGS="--set=fips=true" \
 	./hack/e2e/run.sh
 
 .PHONY: e2e/external-windows-hostprocess

--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -67,7 +67,18 @@ function build_and_push() {
     export ALL_OS="linux"
     export ALL_ARCH_linux="${IMAGE_ARCH}"
   fi
-  make -j $(nproc) sub-push
+
+  PUSH_TYPE="sub-push"
+
+  if [[ "$INSTANCE_TYPE" == "a1.large" ]]; then
+    # In the case of a1compat image we need both controller image and a1 compat node image
+    PUSH_TYPE="sub-push sub-push-a1compat"
+  fi
+  if [[ "${FIPS_TEST}" == "true" ]]; then
+    PUSH_TYPE="sub-push-fips"
+  fi
+
+  make -j $(nproc) ${PUSH_TYPE}
 
   loudecho "Image pushed to ${IMAGE_NAME}:${IMAGE_TAG}"
 }

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -31,6 +31,7 @@ WINDOWS=${WINDOWS:-"false"}
 WINDOWS_HOSTPROCESS=${WINDOWS_HOSTPROCESS:-"false"}
 OUTPOST_ARN=${OUTPOST_ARN:-}
 OUTPOST_INSTANCE_TYPE=${OUTPOST_INSTANCE_TYPE:-${INSTANCE_TYPE}}
+FIPS_TEST=${FIPS_TEST:-"false"}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -32,12 +32,9 @@ test-e2e-multi-az)
 test-e2e-external)
   TEST="external"
   ;;
-test-e2e-external-a1)
-  TEST="external-a1"
-  export INSTANCE_TYPE="a1.large"
-  ;;
 test-e2e-external-fips)
   TEST="external-fips"
+  export FIPS_TEST="true"
   ;;
 test-e2e-external-arm64)
   TEST="external"
@@ -49,6 +46,13 @@ test-e2e-external-eks)
   TEST="external"
   export CLUSTER_TYPE="eksctl"
   ;;
+test-e2e-external-a1-eks)
+  TEST="external-a1-eks"
+  export K8S_VERSION_EKSCTL="1.30"
+  export INSTANCE_TYPE="a1.large"
+  export IMAGE_ARCH="arm64"
+  export CLUSTER_TYPE="eksctl"
+  ;;
 test-e2e-external-eks-windows)
   TEST="external-windows"
   export CLUSTER_TYPE="eksctl"
@@ -56,6 +60,7 @@ test-e2e-external-eks-windows)
   ;;
 test-e2e-external-eks-windows-fips)
   TEST="external-windows-fips"
+  export FIPS_TEST="true"
   export CLUSTER_TYPE="eksctl"
   export WINDOWS="true"
   ;;


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind cleanup
#### What is this PR about? / Why do we need it?
This CR removes the a1 compat CI job and fixes the fips CI jobs
#### How was this change tested?
Ran CI test and confirmed with this fix errors subside.


Windows 
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/2417/pull-aws-ebs-csi-driver-test-e2e-external-eks-windows-fips/1904537879137226752

Linux
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/2417/pull-aws-ebs-csi-driver-external-test-fips/1904537816684040192


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
