### PR TITLE
Output junit report for `tests/e2e/...` E2E jobs

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 
 BASE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 TEST_DIR="${BASE_DIR}/csi-test-artifacts"
+# On Prow, $ARTIFACTS indicates where to put the artifacts for skylens upload
+REPORT_DIR="${ARTIFACTS:-${TEST_DIR}/artifacts}"
 mkdir -p "${TEST_DIR}"
 CLUSTER_FILE=${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.yaml
 KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig"}

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -152,10 +152,10 @@ else
     "${BIN}/ginkgo" -p -nodes="${GINKGO_PARALLEL}" -v \
       --focus="${GINKGO_FOCUS}" \
       --skip="${GINKGO_SKIP}" \
+      --junit-report="${REPORT_DIR}/junit.xml" \
       "${TEST_PATH}" \
       -- \
       -kubeconfig="${KUBECONFIG}" \
-      -report-dir="${TEST_DIR}/artifacts" \
       -gce-zone="${FIRST_ZONE}"
     TEST_PASSED=$?
     set -e


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Adds a junit report for the "local" E2E jobs (those in `tests/e2e/...`). Automatically outputs this report to the `ARTIFACTS` environment variable if present (this is how Prow tells the job where to put artifacts). Also removes an unused and incorrect `-report-dir` CLI flag that appears to be a previous attempt at this.

#### How was this change tested?
Click single-az / multi-az jobs down below after they finish running, see that they now show which tests passed/failed/were skipped

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
