### PR TITLE
Auto-detect AWS Region from Config

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -22,8 +22,11 @@ mkdir -p "${TEST_DIR}"
 CLUSTER_FILE=${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.yaml
 KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig"}
 
-export AWS_REGION=${AWS_REGION:-us-west-2}
-ZONES=${AWS_AVAILABILITY_ZONES:-us-west-2a,us-west-2b,us-west-2c}
+# Use AWS_REGION as priority, fallback to region from awscli config, fallback to us-west-2
+REGION_FROM_CONFIG="$(aws configure get region)"
+export AWS_REGION=${AWS_REGION:-${REGION_FROM_CONFIG:-us-west-2}}
+# If zones are not provided, auto-detect the first 3 AZs that are not opt in
+ZONES=${AWS_AVAILABILITY_ZONES:-$(aws ec2 describe-availability-zones | jq -r '[.AvailabilityZones[] | select(.OptInStatus == "opt-in-not-required") | .ZoneName][:3] | join(",")')}
 FIRST_ZONE=$(echo "${ZONES}" | cut -d, -f1)
 NODE_COUNT=${NODE_COUNT:-3}
 INSTANCE_TYPE=${INSTANCE_TYPE:-c5.large}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Automatically use the local user's region from their awscli config if `AWS_REGION` is not present. To make this work consistently, use `aws ec2 describe-availability-zones` to auto-choose AZs instead of hardcoding `us-west-2a` through `us-west-2c`

#### How was this change tested?

```
$ aws configure
<set region to us-east-1>

$ make cluster/create
./hack/e2e/create-cluster.sh
Error: cluster not found "ebs-csi-e2e.k8s.local"
###
## Creating cluster ebs-csi-e2e.k8s.local with /home/conncatl/aws-ebs-csi-driver/hack/e2e/csi-test-artifacts/ebs-csi-e2e.k8s.local.kops.yaml (dry run)
#
W0328 21:13:24.186810   69189 new_cluster.go:1444] Gossip is deprecated, using None DNS instead
I0328 21:13:24.186873   69189 new_cluster.go:1463] Cloud Provider ID: "aws"
I0328 21:13:25.515392   69189 subnets.go:224] Assigned CIDR 172.20.0.0/18 to subnet us-east-1a
I0328 21:13:25.515420   69189 subnets.go:224] Assigned CIDR 172.20.64.0/18 to subnet us-east-1b
I0328 21:13:25.515427   69189 subnets.go:224] Assigned CIDR 172.20.128.0/18 to subnet us-east-1c
......
<cluster creates, see region was correctly detected>
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
