### PR TITLE
Change stub NVMECollector from windows to non-linux platforms

### DIFF
--- a/pkg/metrics/nvme_unsupported.go
+++ b/pkg/metrics/nvme_unsupported.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build windows
-// +build windows
+//go:build !linux
 
 package metrics
 
 import "k8s.io/klog/v2"
 
 func registerNVMECollector(_ *metricRecorder, _, _ string) {
-	klog.InfoS("NVMe metric collection is not supported on windows")
+	klog.InfoS("NVMe metric collection is not supported on this platform")
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR changes our stub NVMECollector implementations from Windows only to non-linux, so that ebs-csi-controller is buildable and unit-testable on MacOS. 

See #1556 for more context on why being able to build and run tests on MacOS / darwin is helpful.

#### How was this change tested?

Today: 

```
❯ make test
go test -v -race ./cmd/... ./pkg/... ./tests/sanity/...
# github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/metrics
pkg/metrics/metrics.go:78:2: undefined: registerNVMECollector
FAIL	github.com/kubernetes-sigs/aws-ebs-csi-driver/cmd [build failed]
FAIL	github.com/kubernetes-sigs/aws-ebs-csi-driver/cmd/hooks [build failed]
...
```

After PR:

```
❯ make test
go test -v -race ./cmd/... ./pkg/... ./tests/sanity/...
# github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/metrics.test
...
PASS
ok  	github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util/template	(cached)
?   	github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/sanity	[no test files]
❯ echo $?
0
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
