### PR TITLE
Add `go fix` to `make update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test/coverage:
 tools: bin/aws bin/ct bin/eksctl bin/ginkgo bin/golangci-lint bin/gomplate bin/helm bin/kops bin/kubetest2 bin/mockgen bin/shfmt
 
 .PHONY: update
-update: update/gofmt update/kustomize update/mockgen update/gomod update/shfmt update/generate-license-header
+update: update/gofix update/gofmt update/kustomize update/mockgen update/gomod update/shfmt update/generate-license-header
 	@echo "All updates succeeded!"
 
 .PHONY: verify
@@ -287,6 +287,10 @@ bin/%: hack/tools/install.sh hack/tools/python-runner.sh
 
 ## Updaters
 # Automatic generators/formatters for code
+
+.PHONY: update/gofix
+update/gofix:
+	go fix ./...
 
 .PHONY: update/gofmt
 update/gofmt:

--- a/pkg/metrics/nvme.go
+++ b/pkg/metrics/nvme.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright 2024 The Kubernetes Authors.
 //

--- a/pkg/metrics/nvme_test.go
+++ b/pkg/metrics/nvme_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build linux
-// +build linux
 
 package metrics
 

--- a/pkg/mounter/mount_linux.go
+++ b/pkg/mounter/mount_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/pkg/mounter/mount_linux_test.go
+++ b/pkg/mounter/mount_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/mounter/mount_unsupported.go
+++ b/pkg/mounter/mount_unsupported.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/pkg/mounter/mount_windows.go
+++ b/pkg/mounter/mount_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/pkg/mounter/mount_windows_proxyV1.go
+++ b/pkg/mounter/mount_windows_proxyV1.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2024 The Kubernetes Authors.

--- a/pkg/mounter/mount_windows_proxyV2.go
+++ b/pkg/mounter/mount_windows_proxyV2.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
 Copyright 2024 The Kubernetes Authors.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 /*
 Copyright 2019 The Kubernetes Authors.

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build linux
-// +build linux
 
 package sanity
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

`go fix` is a command built into go that automatically rewrites code using deprecated golang APIs to new APIs ([reference 1](https://pkg.go.dev/cmd/fix), [reference 2](https://go.dev/blog/introducing-gofix). We have a few instances of this in our codebase, notably using `+build` where `go:build` is standard.

This PR adds `go fix` to `make update`, so that our codebase will be automatically updated to fixup any deprecated APIs that `go fix` handles when we bump the go version.

#### How was this change tested?

```
$ make update         
go fix ./...
gofmt -s -w .
./hack/update-kustomize.sh
./hack/update-mockgen.sh
go mod tidy
./bin/shfmt -w -i 2 -d ./hack/
./hack/generate-license-header.sh
Adding license header...
All updates succeeded!
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
