### PR TITLE
Set internalTrafficPolicy to local on node metric service

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -59,5 +59,6 @@ spec:
     - name: metrics
       port: 3302
       targetPort: 3302
+  internalTrafficPolicy: Local
   type: ClusterIP
 {{- end }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature
#### What is this PR about? / Why do we need it?
This PR sets interenalTrafficPolicy to true on the node pods metrics service
#### How was this change tested?
Confirmed change does not break current metrics flow.
https://gist.github.com/ElijahQuinones/62d7d8f5d37d237ac86cb10bc38d77ab
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
