### PR TITLE
Refresh dynamic instance metadata for NodeGetInfo calls

### DIFF
--- a/pkg/cloud/metadata/interface.go
+++ b/pkg/cloud/metadata/interface.go
@@ -30,6 +30,7 @@ type MetadataService interface {
 	GetNumAttachedENIs() int
 	GetNumBlockDeviceMappings() int
 	GetOutpostArn() arn.ARN
+	UpdateMetadata() error
 }
 
 type EC2Metadata interface {

--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -152,7 +152,13 @@ func TestNewMetadataService(t *testing.T) {
 				require.EqualError(t, err, tc.expectedError.Error())
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedMetadata, metadata)
+				assert.Equal(t, tc.expectedMetadata.InstanceID, metadata.GetInstanceID())
+				assert.Equal(t, tc.expectedMetadata.InstanceType, metadata.GetInstanceType())
+				assert.Equal(t, tc.expectedMetadata.Region, metadata.GetRegion())
+				assert.Equal(t, tc.expectedMetadata.AvailabilityZone, metadata.GetAvailabilityZone())
+				assert.Equal(t, tc.expectedMetadata.NumAttachedENIs, metadata.GetNumAttachedENIs())
+				assert.Equal(t, tc.expectedMetadata.NumBlockDeviceMappings, metadata.GetNumBlockDeviceMappings())
+				assert.Equal(t, tc.expectedMetadata.OutpostArn, metadata.GetOutpostArn())
 			}
 		})
 	}
@@ -406,7 +412,13 @@ func TestEC2MetadataInstanceInfo(t *testing.T) {
 				require.Nil(t, metadata)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedMetadata, metadata)
+				assert.Equal(t, tc.expectedMetadata.InstanceID, metadata.GetInstanceID())
+				assert.Equal(t, tc.expectedMetadata.InstanceType, metadata.GetInstanceType())
+				assert.Equal(t, tc.expectedMetadata.Region, metadata.GetRegion())
+				assert.Equal(t, tc.expectedMetadata.AvailabilityZone, metadata.GetAvailabilityZone())
+				assert.Equal(t, tc.expectedMetadata.NumAttachedENIs, metadata.GetNumAttachedENIs())
+				assert.Equal(t, tc.expectedMetadata.NumBlockDeviceMappings, metadata.GetNumBlockDeviceMappings())
+				assert.Equal(t, tc.expectedMetadata.OutpostArn, metadata.GetOutpostArn())
 			}
 		})
 	}

--- a/pkg/cloud/metadata/mock_metadata.go
+++ b/pkg/cloud/metadata/mock_metadata.go
@@ -134,6 +134,20 @@ func (mr *MockMetadataServiceMockRecorder) GetRegion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockMetadataService)(nil).GetRegion))
 }
 
+// UpdateMetadata mocks base method.
+func (m *MockMetadataService) UpdateMetadata() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMetadata")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMetadata indicates an expected call of UpdateMetadata.
+func (mr *MockMetadataServiceMockRecorder) UpdateMetadata() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockMetadataService)(nil).UpdateMetadata))
+}
+
 // MockEC2Metadata is a mock of EC2Metadata interface.
 type MockEC2Metadata struct {
 	ctrl     *gomock.Controller

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -573,6 +573,10 @@ func (d *NodeService) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 func (d *NodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	klog.V(4).InfoS("NodeGetInfo: called", "args", req)
 
+	if err := d.metadata.UpdateMetadata(); err != nil {
+		klog.ErrorS(err, "Failed to update metadata, using cached values")
+	}
+
 	zone := d.metadata.GetAvailabilityZone()
 	osType := runtime.GOOS
 

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1959,6 +1959,29 @@ func TestNodeGetInfo(t *testing.T) {
 				m := metadata.NewMockMetadataService(ctrl)
 				m.EXPECT().GetInstanceID().Return("i-1234567890abcdef0")
 				m.EXPECT().GetAvailabilityZone().Return("us-west-2a")
+				m.EXPECT().UpdateMetadata().Return(nil)
+				m.EXPECT().GetOutpostArn().Return(arn.ARN{})
+				return m
+			},
+			expectedResp: &csi.NodeGetInfoResponse{
+				NodeId: "i-1234567890abcdef0",
+				AccessibleTopology: &csi.Topology{
+					Segments: map[string]string{
+						ZoneTopologyKey:          "us-west-2a",
+						WellKnownZoneTopologyKey: "us-west-2a",
+						OSTopologyKey:            runtime.GOOS,
+					},
+				},
+			},
+		},
+		{
+			name: "update_metadata_error",
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				// When UpdateMedata returns an error, NodeGetInfo should continue execution.
+				m.EXPECT().UpdateMetadata().Return(errors.New("metadata update failed"))
+				m.EXPECT().GetInstanceID().Return("i-1234567890abcdef0")
+				m.EXPECT().GetAvailabilityZone().Return("us-west-2a")
 				m.EXPECT().GetOutpostArn().Return(arn.ARN{})
 				return m
 			},
@@ -1979,6 +2002,7 @@ func TestNodeGetInfo(t *testing.T) {
 				m := metadata.NewMockMetadataService(ctrl)
 				m.EXPECT().GetInstanceID().Return("i-1234567890abcdef0")
 				m.EXPECT().GetAvailabilityZone().Return("us-west-2a")
+				m.EXPECT().UpdateMetadata().Return(nil)
 				m.EXPECT().GetOutpostArn().Return(arn.ARN{
 					Partition: "aws",
 					Service:   "outposts",

--- a/tests/sanity/fake_sanity_metadata_service.go
+++ b/tests/sanity/fake_sanity_metadata_service.go
@@ -33,6 +33,11 @@ func newFakeMetadataService(id string, r string, az string, oa arn.ARN) *fakeMet
 		outpostArn:       oa,
 	}
 }
+
+func (m *fakeMetadataService) UpdateMetadata() error {
+	return nil
+}
+
 func (m *fakeMetadataService) GetInstanceID() string {
 	return m.instanceID
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

When Kubernetes periodically calls NodeGetInfo, the driver should return updated information about the maximum number of attachable volumes. This commit modifies the driver to refresh dynamic metadata (ENI count) when calculating volume limits, rather than using cached values from driver initialization.

#### How was this change tested?

Attaching one additional ENI after driver startup and observing driver logs / CSINode object.

- Node plugin logs:

```
I0409 15:36:55.336607       1 node.go:574] "NodeGetInfo: called" args=""
I0409 15:36:55.338301       1 metadata.go:93] "Updated metadata" numAttachedENIs=1 numBlockDeviceMappings=0
I0409 15:36:55.338335       1 node.go:781] "getVolumesLimit:" instanceType="c5.large"
I0409 15:36:55.338344       1 node.go:785] "getVolumesLimit:" availableAttachments=28
I0409 15:36:55.338352       1 node.go:790] "getVolumesLimit:" numBlockDevices=0
I0409 15:36:55.338358       1 node.go:792] "getVolumesLimit:" reservedVolumeAttachments=1
I0409 15:36:55.338459       1 node.go:806] "getVolumesLimit:" ENIs=1
I0409 15:36:55.338513       1 node.go:808] "getVolumesLimit:" reservedSlots=0
I0409 15:36:55.338525       1 node.go:601] "NodeGetInfo:" maxVolumesPerNode=26
I0409 15:37:01.930657       1 identity.go:61] "Probe: called" args=""
I0409 15:37:06.338244       1 node.go:574] "NodeGetInfo: called" args=""
I0409 15:37:06.341084       1 metadata.go:93] "Updated metadata" numAttachedENIs=2 numBlockDeviceMappings=0
I0409 15:37:06.341253       1 node.go:781] "getVolumesLimit:" instanceType="c5.large"
I0409 15:37:06.341347       1 node.go:785] "getVolumesLimit:" availableAttachments=28
I0409 15:37:06.341438       1 node.go:790] "getVolumesLimit:" numBlockDevices=0
I0409 15:37:06.341509       1 node.go:792] "getVolumesLimit:" reservedVolumeAttachments=1
I0409 15:37:06.341659       1 node.go:806] "getVolumesLimit:" ENIs=2
I0409 15:37:06.341749       1 node.go:808] "getVolumesLimit:" reservedSlots=0
I0409 15:37:06.341832       1 node.go:601] "NodeGetInfo:" maxVolumesPerNode=25
```

- CSINode object before additional ENI is attached:
```
Name:               i-036afc1e0189c56ad
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins:
                      kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-v...
CreationTimestamp:  Wed, 09 Apr 2025 14:57:07 +0000
Spec:
  Drivers:
    ebs.csi.aws.com:
      Node ID:  i-036afc1e0189c56ad
      Allocatables:
        Count:        26
      Topology Keys:  [kubernetes.io/os topology.ebs.csi.aws.com/zone topology.kubernetes.io/zone]
Events:               <none>
```

- CSINode object after additional ENI is attached:
```
Name:               i-036afc1e0189c56ad
Labels:             <none>
Annotations:        storage.alpha.kubernetes.io/migrated-plugins:
                      kubernetes.io/aws-ebs,kubernetes.io/azure-disk,kubernetes.io/azure-file,kubernetes.io/cinder,kubernetes.io/gce-pd,kubernetes.io/portworx-v...
CreationTimestamp:  Wed, 09 Apr 2025 14:57:07 +0000
Spec:
  Drivers:
    ebs.csi.aws.com:
      Node ID:  i-036afc1e0189c56ad
      Allocatables:
        Count:        25
      Topology Keys:  [kubernetes.io/os topology.ebs.csi.aws.com/zone topology.kubernetes.io/zone]
Events:               <none>
```

- CSI Driver manifest used for testing:
```
kubectl get csidriver -o yaml                          
apiVersion: v1
items:
- apiVersion: storage.k8s.io/v1
  kind: CSIDriver
  metadata:
    annotations:
      meta.helm.sh/release-name: aws-ebs-csi-driver
      meta.helm.sh/release-namespace: kube-system
    creationTimestamp: "2025-04-09T15:33:11Z"
    labels:
      app.kubernetes.io/component: csi-driver
      app.kubernetes.io/instance: aws-ebs-csi-driver
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: aws-ebs-csi-driver
      app.kubernetes.io/version: 1.41.0
      helm.sh/chart: aws-ebs-csi-driver-2.41.0
    name: ebs.csi.aws.com
    resourceVersion: "7647"
    uid: 152bcd6e-b3c7-41ec-9af5-dfe4898c2e9b
  spec:
    attachRequired: true
    fsGroupPolicy: File
    nodeAllocatableUpdatePeriodSeconds: 11
    podInfoOnMount: false
    requiresRepublish: false
    seLinuxMount: false
    storageCapacity: false
    volumeLifecycleModes:
    - Persistent
kind: List
metadata:
  resourceVersion: ""
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
