### PR TITLE
Add snapshot-volume-scale to scalability test suite

### DIFF
--- a/hack/ebs-scale-test/README.md
+++ b/hack/ebs-scale-test/README.md
@@ -44,7 +44,7 @@ Note: The environment variables set when you run `scale-test setup` must remain 
 # Affect test
 CLUSTER_TYPE              # Type of scalability cluster to create.
 TEST_TYPE                 # Type of scale test to run.
-REPLICAS                  # Number of StatefulSet replicas to create.
+REPLICAS                  # Number of StatefulSet replicas or snapshots to create.
 DRIVER_VALUES_FILEPATH    # Custom values file passed to EBS CSI Driver Helm chart.
 
 # Names
@@ -52,6 +52,9 @@ CLUSTER_NAME              # Base name used by `eksctl` to create AWS resources.
 EXPORT_DIR                # Where to export scale test metrics/logs locally.
 S3_BUCKET                 # Name of S3 bucket used for holding scalability run results.
 SCALABILITY_TEST_RUN_NAME # Name of test run. Used as name of directory for adding run results in $S3_BUCKET.
+
+# Snapshot
+SNAPSHOTS_PER_VOLUME # How many snapshots per volume
 
 # Find default values at top of `scale-test` script. 
 ```
@@ -66,6 +69,7 @@ Set the `CLUSTER_TYPE` and `TEST_TYPE` environment variables to set up and run d
 - `TEST_TYPE` dictates what type of scalability test we want to run. Options include: 
   - 'scale-sts': Scales a StatefulSet to `$REPLICAS`. Waits for all pods to be ready. Delete Sts. Waits for all PVs to be deleted. Exercises the complete dynamic provisioning lifecycle for block volumes.
   - 'expand-and-modify': Creates `$REPLICAS` block volumes. Patches PVC capacity and VACName at rate of 5 PVCs per second. Ensures PVCs are expanded and modified before deleting them. Exercises ControllerExpandVolume & ControllerModifyVolume. Set `MODIFY_ONLY` or `EXPAND_ONLY` to 'true' to test solely volume modification/expansion.
+  - 'snapshot-volume-scale': Creates `$REPLICAS` number of volumes. Takes `$SNAPSHOTS_PER_VOLUME` snapshots of each volume.
 
 You can mix and match `CLUSTER_TYPE` and `TEST_TYPE`.
 

--- a/hack/ebs-scale-test/helpers/cluster-setup/scale-driver-values.yaml
+++ b/hack/ebs-scale-test/helpers/cluster-setup/scale-driver-values.yaml
@@ -27,3 +27,6 @@ sidecars:
     additionalArgs: ["--http-endpoint=:8082"]
   attacher:
     additionalArgs: ["--http-endpoint=:8084"]
+  snapshotter:
+    additionalArgs: ["--http-endpoint=:8085"]
+  

--- a/hack/ebs-scale-test/helpers/scale-test/collect-and-export-metrics.sh
+++ b/hack/ebs-scale-test/helpers/scale-test/collect-and-export-metrics.sh
@@ -48,9 +48,11 @@ collect_metrics() {
   PID_8082=$!
   kubectl port-forward "$CONTROLLER_POD_NAME" 8084:8084 -n kube-system &
   PID_8084=$!
+  kubectl port-forward "$CONTROLLER_POD_NAME" 8085:8085 -n kube-system &
+  PID_8085=$!
 
   echo "Collecting metrics"
-  for port in 3301 8081 8082 8084; do
+  for port in 3301 8081 8082 8084 8085; do
     curl "http://localhost:${port}/metrics" >>"$METRICS_FILEPATH" && continue
     echo "Failed to collect metrics from port ${port}, retrying after 5s..."
     sleep 5
@@ -63,7 +65,7 @@ collect_metrics() {
     echo "WARNING: Could not collect metrics from port ${port}. Something may be wrong in cluster."
   done
   # Stop forwarding ports after metrics collected.
-  kill $PID_3301 $PID_8081 $PID_8082 $PID_8084
+  kill $PID_3301 $PID_8081 $PID_8082 $PID_8084 $PID_8085
 }
 
 clean_metrics() {

--- a/hack/ebs-scale-test/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.sh
+++ b/hack/ebs-scale-test/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We expect this helper script is sourced from hack/ebs-scale-test
+path_to_snapshot_test_dir="${BASE_DIR}/helpers/scale-test/snapshot-volume-scale-test"
+
+export SNAPSHOTS_PER_VOLUME=${SNAPSHOTS_PER_VOLUME:=1}
+
+snapshot_scale_test() {
+  manifest_path="$path_to_snapshot_test_dir/snapshot-volume-scale.yaml"
+  export_manifest_path="$EXPORT_DIR/snapshot-manifest.yaml"
+
+  echo "Applying $manifest_path. Exported to $export_manifest_path"
+  gomplate -f "$manifest_path" -o "$export_manifest_path"
+  kubectl apply -f "$export_manifest_path"
+
+  trap 'echo "Test interrupted! Deleting test resources to prevent leak"; cleanup_snapshot_resources' EXIT
+
+  echo "Waiting for all PVCs to be bound"
+  wait_for_pvcs_bound
+
+  echo "Creating $REPLICAS volume snapshots ($SNAPSHOTS_PER_VOLUME per volume)"
+  create_snapshots
+
+  echo "Waiting for snapshots to be ready"
+  wait_for_snapshots_ready
+
+  echo "Restoring volumes from snapshots"
+  restore_volumes_from_snapshots
+
+  echo "Waiting for restored PVCs to be bound"
+  wait_for_restored_pvcs_bound
+
+  echo "Deleting snapshots"
+  delete_snapshots
+
+  echo "Waiting for VolumeSnapshotContents to be deleted"
+  wait_for_volume_snapshot_contents_deleted
+
+  echo "Deleting PVCs"
+  delete_pvcs
+
+  echo "Waiting for PVs to be deleted"
+  wait_for_pvs_deleted
+
+  echo "Cleaning up snapshot resources"
+  cleanup_snapshot_resources
+
+  trap - EXIT
+}
+
+wait_for_pvcs_bound() {
+  while true; do
+    bound_pvc_count=$(kubectl get pvc -l app=snapshot-scale-test -o json | jq '.items | map(select(.status.phase == "Bound")) | length')
+    if [[ "$bound_pvc_count" -ge "$REPLICAS" ]]; then
+      echo "All PVCs bound, proceeding..."
+      break
+    else
+      echo "Only $bound_pvc_count PVCs are bound, waiting for a total of $REPLICAS..."
+      sleep 5
+    fi
+  done
+}
+
+create_snapshots() {
+  for i in {0..$(($REPLICAS - 1))}; do
+    for j in {1..$SNAPSHOTS_PER_VOLUME}; do
+      cat <<EOF | kubectl apply -f -
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: snapshot-volume-$i-$j
+  labels:
+    app: snapshot-scale-test
+spec:
+  volumeSnapshotClassName: csi-aws-vsc
+  source:
+    persistentVolumeClaimName: snapshot-pvc-$i
+EOF
+    done
+  done
+}
+
+wait_for_snapshots_ready() {
+  expected_REPLICAS=$((REPLICAS * SNAPSHOTS_PER_VOLUME))
+  while true; do
+    ready_REPLICAS=$(kubectl get volumesnapshot -l app=snapshot-scale-test -o json | jq '.items | map(select(.status.readyToUse == true)) | length')
+    if [[ "$ready_REPLICAS" -ge "$expected_REPLICAS" ]]; then
+      echo "All snapshots ready to use, proceeding..."
+      break
+    else
+      echo "$ready_REPLICAS/$expected_REPLICAS snapshots ready to use, waiting..."
+      sleep 5
+    fi
+  done
+}
+
+restore_volumes_from_snapshots() {
+  for i in $(seq 0 $(($REPLICAS - 1))); do
+    cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: restored-pvc-$i
+  labels:
+    app: snapshot-scale-test
+    type: restored
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-snapshot-test
+  resources:
+    requests:
+      storage: 1Gi
+  dataSource:
+    name: snapshot-volume-$i-1
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+EOF
+  done
+}
+
+wait_for_restored_pvcs_bound() {
+  while true; do
+    bound_pvc_count=$(kubectl get pvc -l app=snapshot-scale-test,type=restored -o json | jq '.items | map(select(.status.phase == "Bound")) | length')
+    if [[ "$bound_pvc_count" -ge "$REPLICAS" ]]; then
+      echo "All restored PVCs bound, proceeding..."
+      break
+    else
+      echo "Only $bound_pvc_count restored PVCs are bound, waiting for a total of $REPLICAS..."
+      sleep 5
+    fi
+  done
+}
+
+delete_snapshots() {
+  kubectl delete volumesnapshot -l app=snapshot-scale-test
+}
+
+wait_for_volume_snapshot_contents_deleted() {
+  while true; do
+    snapshot_content_count=$(kubectl get volumesnapshotcontent -o json | jq '.items | map(select(.spec.volumeSnapshotRef.name | startswith("snapshot-volume-"))) | length')
+    if [[ "$snapshot_content_count" -eq 0 ]]; then
+      echo "All VolumeSnapshotContents deleted, proceeding..."
+      break
+    else
+      echo "$snapshot_content_count VolumeSnapshotContents still exist, waiting..."
+      sleep 5
+    fi
+  done
+}
+
+delete_pvcs() {
+  kubectl delete pvc -l app=snapshot-scale-test
+}
+
+wait_for_pvs_deleted() {
+  while true; do
+    pv_count=$(kubectl get pv -o json | jq '.items | map(select(.spec.claimRef.name | startswith("snapshot-pvc-") or startswith("restored-pvc-"))) | length')
+    if [[ "$pv_count" -eq 0 ]]; then
+      echo "All PVs deleted, proceeding..."
+      break
+    else
+      echo "$pv_count PVs still exist, waiting..."
+      sleep 5
+    fi
+  done
+}
+
+cleanup_snapshot_resources() {
+  kubectl delete volumesnapshotclass csi-aws-vsc --ignore-not-found=true
+  kubectl delete sc ebs-snapshot-test --ignore-not-found=true
+  kubectl delete volumesnapshot -l app=snapshot-scale-test --ignore-not-found=true
+  kubectl delete pvc -l app=snapshot-scale-test --ignore-not-found=true
+}
+
+(return 0 2>/dev/null) || (
+  echo "This script is not meant to be run directly, only sourced as a helper!"
+  exit 1
+)

--- a/hack/ebs-scale-test/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.yaml
+++ b/hack/ebs-scale-test/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.yaml
@@ -1,0 +1,50 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-snapshot-test
+provisioner: ebs.csi.aws.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  type: gp2
+  tagSpecification_1: "ebs-scale-test={{ .Env.SCALABILITY_TEST_RUN_NAME }}"
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-aws-vsc
+driver: ebs.csi.aws.com
+deletionPolicy: Delete
+parameters:
+  tagSpecification_1: "ebs-scale-test={{ .Env.SCALABILITY_TEST_RUN_NAME }}"
+---
+{{- range $index := seq 0 (sub .Env.REPLICAS 1) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshot-pvc-{{ $index }}
+  labels:
+    app: snapshot-scale-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-snapshot-test
+  resources:
+    requests:
+      storage: 1Gi
+---
+{{- end }}

--- a/hack/ebs-scale-test/scale-test
+++ b/hack/ebs-scale-test/scale-test
@@ -31,6 +31,7 @@ export SCALABILITY_TEST_RUN_NAME
 CLUSTER_TYPE=${CLUSTER_TYPE:="pre-allocated"}
 TEST_TYPE=${TEST_TYPE:="scale-sts"}
 REPLICAS=${REPLICAS:=1000}
+EBS_INSTALL_SNAPSHOT_VERSION=${EBS_INSTALL_SNAPSHOT_VERSION:-"v8.2.1"}
 DRIVER_VALUES_FILEPATH=${DRIVER_VALUES_FILEPATH:="$BASE_DIR/helpers/cluster-setup/scale-driver-values.yaml"}
 
 CLUSTER_NAME=${CLUSTER_NAME:="ebs-scale-$CLUSTER_TYPE"}
@@ -57,6 +58,7 @@ source "${BASE_DIR}/helpers/scale-test/pre_test_validation.sh"
 
 source "${BASE_DIR}/helpers/scale-test/scale-sts-test/scale-sts.sh"
 source "${BASE_DIR}/helpers/scale-test/expand-and-modify-test/expand-and-modify.sh"
+source "${BASE_DIR}/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.sh"
 
 usage() {
   echo "Usage: $0 [base-cmd]"
@@ -80,6 +82,7 @@ check_dependencies_helper() {
 # Functions sourced from helpers/cluster-setup/manage-cluster.sh
 setup_scale() {
   create_cluster
+  deploy_snapshot_controller
   deploy_ebs_csi_driver
 }
 
@@ -90,8 +93,9 @@ run_scale() {
   case "$TEST_TYPE" in
   *scale-sts*) sts_scale_test ;;
   *expand-and-modify*) expand_and_modify_test ;;
+  *snapshot-volume-scale*) snapshot_scale_test ;;
   *)
-    echo "Invalid TEST_TYPE '$TEST_TYPE'. Please set to 'scale-sts' or 'expand-and-modify'"
+    echo "Invalid TEST_TYPE '$TEST_TYPE'."
     exit 1
     ;;
   esac
@@ -103,6 +107,7 @@ run_scale() {
 clean_scale() {
   cleanup_cluster
   check_lingering_volumes
+  check_lingering_snapshots
 }
 
 main() {


### PR DESCRIPTION
#### What is this PR about? / Why do we need it?

This PR adds a scale test for the CreateSnapshot / restore volume from snapshot code paths.

#### How was this change tested?

Manually:

```
export TEST_TYPE="snapshot-volume-scale"
export REPLICAS=1000
./scale-test run
```

https://gist.github.com/torredil/f1cd9806d013e56115f1ea93f018384d

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
