### PR TITLE
Adding Proper Handling of VAC and Controller Tags On Volume Creation

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -213,7 +213,7 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		}
 	}
 
-	modifyOptions, err := parseModifyVolumeParameters(req.GetMutableParameters())
+	modifyOptions, err := parseCreateRequestMutableParameters(req.GetMutableParameters(), d.options.ExtraTags, *tProps)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid mutable parameter: %v", err)
 	}
@@ -301,9 +301,6 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		volumeTags[NameTag] = d.options.KubernetesClusterID + "-dynamic-" + volName
 		volumeTags[KubernetesClusterTag] = d.options.KubernetesClusterID
 	}
-	for k, v := range d.options.ExtraTags {
-		volumeTags[k] = v
-	}
 
 	addTags, err := template.Evaluate(scTags, tProps, d.options.WarnOnInvalidTag)
 	if err != nil {
@@ -315,6 +312,10 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 
 	for k, v := range addTags {
+		volumeTags[k] = v
+	}
+
+	for k, v := range modifyOptions.modifyTagsOptions.TagsToAdd {
 		volumeTags[k] = v
 	}
 
@@ -350,6 +351,63 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Errorf(errCode, "Could not create volume %q: %v", volName, err)
 	}
 	return newCreateVolumeResponse(disk, responseCtx), nil
+}
+
+func parseCreateRequestMutableParameters(params map[string]string, extraTags map[string]string, tProps template.PVProps) (*modifyVolumeRequest, error) {
+	options := modifyVolumeRequest{
+		modifyTagsOptions: cloud.ModifyTagsOptions{
+			TagsToAdd:    make(map[string]string),
+			TagsToDelete: make([]string, 0),
+		},
+	}
+
+	rawTagsToAdd := []string{}
+	for key, value := range params {
+		switch key {
+		case ModificationKeyIOPS:
+			iops, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse IOPS: %q", value)
+			}
+			options.modifyDiskOptions.IOPS = int32(iops)
+		case ModificationKeyThroughput:
+			throughput, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse throughput: %q", value)
+			}
+			options.modifyDiskOptions.Throughput = int32(throughput)
+		case DeprecatedModificationKeyVolumeType:
+			if _, ok := params[ModificationKeyVolumeType]; ok {
+				klog.Infof("Ignoring deprecated key `volumeType` because preferred key `type` is present")
+				continue
+			}
+			klog.InfoS("Key `volumeType` is deprecated, please use `type` instead")
+			options.modifyDiskOptions.VolumeType = value
+		case ModificationKeyVolumeType:
+			options.modifyDiskOptions.VolumeType = value
+		default:
+			switch {
+			case strings.HasPrefix(key, ModificationAddTag):
+				rawTagsToAdd = append(rawTagsToAdd, value)
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "Invalid mutable parameter key: %s", key)
+			}
+		}
+	}
+
+	for k, v := range extraTags {
+		rawTagsToAdd = append(rawTagsToAdd, k+"="+v)
+	}
+
+	addTags, err := template.Evaluate(rawTagsToAdd, tProps, false)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Error interpolating the tag value: %v", err)
+	}
+	if err := validateExtraTags(addTags, false); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Invalid tag value: %v", err)
+	}
+	options.modifyTagsOptions.TagsToAdd = addTags
+	return &options, nil
 }
 
 func validateCreateVolumeRequest(req *csi.CreateVolumeRequest) error {


### PR DESCRIPTION
#### What type of PR is this?

kind feature

#### What is this PR about? / Why do we need it?

This PR adds proper handling of volumeAttributesClass tags so that the tags specified in the VAC are templated, validated, and added to the volume on volume creation. It also handles the templating and validation of any `--extra-tags` on the controller on volume creation.

Closes #2442 #2439

#### How was this change tested?

1. Ran make test 
```
> make test 
Ran 76 of 92 Specs in 0.442 seconds
SUCCESS! -- 76 Passed | 0 Failed | 1 Pending | 15 Skipped
```

2. Used/deployed the following resource configurations and then ran `aws ec2 describe-volumes --volume-ids vol-<ID fo provisioned volume>` to make sure that the tags specified in the VAC were added and properly interpolated. 
```
---
apiVersion: storage.k8s.io/v1beta1
kind: VolumeAttributesClass
metadata:
  name: io2-class
driverName: ebs.csi.aws.com
parameters:
  type: io2
  iops: "3000"
  tagSpecification_1: "pvcnamespaceTEST={{ .PVCNamespace }}"
  tagSpecification_2: "pvcnameTEST={{ .PVCName }}"
  tagSpecification_3: "pvnameTEST={{ .PVName }}"
  tagSpecification_4: "location=Seattle"
  tagSpecification_5: "cost-center="
  tagSpecification_6: 'backup={{ .PVCNamespace | contains "prod" }}'
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim
spec:
  volumeAttributesClassName: io2-class
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 4Gi
 ---
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
volumeBindingMode: WaitForFirstConsumer
---
apiVersion: v1
kind: Pod
metadata:
  name: app
spec:
  containers:
  - name: app
    image: public.ecr.aws/amazonlinux/amazonlinux
    command: ["/bin/sh"]
    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
    volumeMounts:
    - name: persistent-storage
      mountPath: /data
  volumes:
  - name: persistent-storage
    persistentVolumeClaim:
      claimName: ebs-claim
```

## **Result of describe call**
```
{
            "Iops": 2000,
            "Tags": [
                {
                    "Key": "Name",
                    "Value": "ebs-csi-e2e.k8s.local-dynamic-pvc-cffd7dc2-3d86-49a2-b787-e64861fc1f7c"
                },
                {
                    "Key": "cost-center",
                    "Value": ""
                },
                {
                    "Key": "ebs.csi.aws.com/cluster",
                    "Value": "true"
                },
                {
                    "Key": "CSIVolumeName",
                    "Value": "pvc-cffd7dc2-3d86-49a2-b787-e64861fc1f7c"
                },
                {
                    "Key": "extrakey",
                    "Value": "extraval"
                },
                {
                    "Key": "backup",
                    "Value": "false"
                },
                {
                    "Key": "kubernetes.io/cluster/ebs-csi-e2e.k8s.local",
                    "Value": "owned"
                },
                {
                    "Key": "kubernetes.io/created-for/pvc/name",
                    "Value": "ebs-claim"
                },
                {
                    "Key": "KubernetesCluster",
                    "Value": "ebs-csi-e2e.k8s.local"
                },
                {
                    "Key": "location",
                    "Value": "Seattle"
                },
                {
                    "Key": "kubernetes.io/created-for/pvc/namespace",
                    "Value": "default"
                },
                {
                    "Key": "pvcnamespaceTEST",
                    "Value": "default"
                },
                {
                    "Key": "VolumeNamespace",
                    "Value": "default"
                },
                {
                    "Key": "pvcnameTEST",
                    "Value": "ebs-claim"
                },
                {
                    "Key": "pvnameTEST",
                    "Value": "pvc-cffd7dc2-3d86-49a2-b787-e64861fc1f7c"
                },
                {
                    "Key": "kubernetes.io/created-for/pv/name",
                    "Value": "pvc-cffd7dc2-3d86-49a2-b787-e64861fc1f7c"
                }
            ],
            "VolumeType": "io2"...
```

#### Does this PR introduce a user-facing change?
```release-note
Added Proper Handling To Ensure Tags Added in a VAC Which a PVC Points To Get Added to the Provisioned Volume. Also Added Proper Handling To Ensure that extra-tags on the Controller Also Get Added to the Provisioned Volume.
```
