### PR TITLE
Update io2MaxIOPSPerGb from 500 to 1000

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -29,12 +29,12 @@ The AWS EBS CSI Driver supports [tagging](tagging.md) through `StorageClass.para
 * If the requested IOPS (either directly from `iops` or from `iopsPerGB` multiplied by the volume's capacity) produces a value above the maximum IOPS allowed for the [volume type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html), the IOPS will be capped at the maximum value allowed. If the value is lower than the minimal supported IOPS value per volume, either an error is returned (the default behavior), or the value is increased to fit into the supported range when `allowautoiopspergbincrease` is `"true"`.
 * You may specify either the "iops" or "iopsPerGb" parameters, not both. Specifying both parameters will result in an invalid StorageClass.
 
-| Volume Type                | Min total IOPS | Max total IOPS | Max IOPS per GB   |
-|----------------------------|----------------|---------------|-------------------|
-| io1                        | 100            | 64000         | 50                |
-| io2 (blockExpress = false) | 100            | 64000         | 500               |
-| io2 (blockExpress = true)  | 100            | 256000        | 500               |
-| gp3                        | 3000           | 16000         | 500               |
+| Volume Type                | Min total IOPS | Max total IOPS | Max IOPS per GB |
+|----------------------------|----------------|---------------|-----------------|
+| io1                        | 100            | 64000         | 50              |
+| io2 (blockExpress = false) | 100            | 64000         | 1000            |
+| io2 (blockExpress = true)  | 100            | 256000        | 1000            |
+| gp3                        | 3000           | 16000         | 500             |
 
 ## Volume Availability Zone and Topologies
 

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -69,7 +69,7 @@ const (
 	io2MinTotalIOPS             = 100
 	io2MaxTotalIOPS             = 64000
 	io2BlockExpressMaxTotalIOPS = 256000
-	io2MaxIOPSPerGB             = 500
+	io2MaxIOPSPerGB             = 1000
 	gp3MaxTotalIOPS             = 16000
 	gp3MinTotalIOPS             = 3000
 	gp3MaxIOPSPerGB             = 500


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

EC2 updated io2 max IOPS to size ratio from 500 to 1000: 

```
❯ aws ec2 create-volume --availability-zone us-west-2a --size 6 --iops 10000 --volume-type io2

An error occurred (InvalidParameterCombination) when calling the CreateVolume operation: io2 volumes configured with greater than 64 TiB or 256K IOPS or 1000:1 IOPS:GB ratio are not supported.

❯ aws ec2 create-volume --availability-zone us-west-2a --size 6 --iops 6000 --volume-type io2
{
    "Iops": 6000,
    "Tags": [],
    "VolumeType": "io2",
    "MultiAttachEnabled": false,
    "VolumeId": "vol-0a8c747261f4e3a15",
    "Size": 6,
    "SnapshotId": "",
    "AvailabilityZone": "us-west-2a",
    "State": "creating",
    "CreateTime": "2025-05-14T14:55:30+00:00",
    "Encrypted": true
}
```

We should ensure driver reflects true value. In the longterm, we should avoid massaging/pre-validating user's IOPS parameter to avoid situations like this. 

#### How was this change tested?

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: ebs-claim
spec:
  accessModes:
    - ReadWriteOnce
  storageClassName: ebs-sc
  resources:
    requests:
      storage: 6Gi

apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ebs-sc
provisioner: ebs.csi.aws.com
parameters:
  csi.storage.k8s.io/fstype: ext4
  type: io2
  iopsPerGB: "999"
  encrypted: "true"
```

Before PR:

Volume incorrectly capped at 3k IOPS (6 * 500)

<img width="361" alt="image" src="https://github.com/user-attachments/assets/a92d2a23-bf92-45eb-9074-3bd545374090" />


After:

Volume created with 5994 IOPS!

<img width="321" alt="image" src="https://github.com/user-attachments/assets/6fd99e36-2984-433b-b6b0-94f11a70171f" />


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Increase io2 volume maximum iops:size ratio from 500:1 to 1000:1 to match EC2 behavior
```
