### PR TITLE
Add security Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,10 @@ update-sidecar-dependencies: update-truth-sidecars generate-sidecar-tags update/
 update-image-dependencies: update-sidecar-dependencies
 	./hack/release-scripts/update-e2e-images
 
+.PHONY: security
+security: bin/govulncheck
+	./hack/tools/check-security.sh
+
 ## CI aliases
 # Targets intended to be executed mostly or only by CI jobs
 

--- a/hack/tools/check-security.sh
+++ b/hack/tools/check-security.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Script that runs a few security tools to ensure we have no vulnerabilities.
+
+BASE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+ROOT_DIR="$BASE_DIR/../.."
+BIN="${ROOT_DIR}/bin"
+"$BIN/govulncheck" -C "$ROOT_DIR" "./cmd/..." "./pkg/..."

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -30,6 +30,8 @@ GINKGO_VERSION="v2.23.4"
 GOLANGCI_LINT_VERSION="v1.64.8"
 # https://github.com/hairyhenderson/gomplate
 GOMPLATE_VERSION="v4.3.1"
+# https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
+GOVULNCHECK_VERSION="v1.1.4"
 # https://github.com/helm/helm
 HELM_VERSION="v3.17.3"
 # https://github.com/kubernetes/kops
@@ -145,6 +147,12 @@ function install_gomplate() {
   # gomplate includes library from no longer existing domain inet.af, and thus cannot be installed via go install
   # install the released binary from GitHub releases instead
   install_binary "${INSTALL_PATH}" "https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_${OS}-${ARCH}" "gomplate"
+}
+
+function install_govulncheck() {
+  INSTALL_PATH="${1}"
+
+  install_go "${INSTALL_PATH}" "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
 }
 
 function install_helm() {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Add security Makefile target that currently runs govulncheck against only our ebs-csi-driver module. That way we can move our govulncheck GH action to Prow (so we can override it). 

#### How was this change tested?

Spotted a vuln on release-1.39 branch!

```
❯ git checkout release-1.39
Your branch is ahead of 'upstream/release-1.39' by 1 commit.

❯ make clean && make security
rm -rf bin/
/home/linuxbrew/.linuxbrew/bin/python3
./hack/tools/check-security.sh
=== Symbol Results ===

Vulnerability #1: GO-2025-3547
    Kubernetes kube-apiserver Vulnerable to Race Condition in k8s.io/kubernetes
  More info: https://pkg.go.dev/vuln/GO-2025-3547
  Module: k8s.io/kubernetes
    Found in: k8s.io/kubernetes@v1.32.2
    Fixed in: N/A
    Example traces found:
      #1: pkg/driver/node.go:43:2: driver.init calls volume.init, which eventually calls common.init
      #2: pkg/cloud/metadata/k8s.go:105:45: metadata.KubernetesAPIInstanceInfo calls 
...
Your code is affected by 2 vulnerabilities from 1 module.
This scan also found 0 vulnerabilities in packages you import and 3
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
make: *** [security] Error 3
❯ echo $?
2
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
