### PR TITLE
Update tests/e2e go.mod in Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,7 +16,7 @@ version: 2
 enable-beta-ecosystems: true
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directories: ["/", "/tests/e2e/"]
   allow:
   - dependency-type: "all"
   schedule:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

We split out a separate `go.mod` in #2471, but now Dependabot PRs are failing because it only tries to update the main `go.mod`. This PR fixes that issue.

#### How was this change tested?

It wasn't

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
