### PR TITLE
Remove broken client-go replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.216.0
 	github.com/aws/smithy-go v1.22.3
-	github.com/awslabs/volume-modifier-for-k8s v0.5.1
+	github.com/awslabs/volume-modifier-for-k8s v0.5.0
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.7.0
@@ -27,7 +27,7 @@ require (
 	google.golang.org/protobuf v1.36.6
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.33.0
 	k8s.io/component-base v0.33.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/mount-utils v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/Xv
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/awslabs/volume-modifier-for-k8s v0.5.1 h1:p8Tuq8Ih4CoX808dGQtfqGY3ssIp73ZKtcB8s0F62OE=
-github.com/awslabs/volume-modifier-for-k8s v0.5.1/go.mod h1:bnzcPxtoRWwc2S/BTCwH5wMoxSR/3PFX9fT078FDqq4=
+github.com/awslabs/volume-modifier-for-k8s v0.5.0 h1:VeDSCnS4vmUmQxHWUVGX65MK0y7hZa/yaVEAMrWz6os=
+github.com/awslabs/volume-modifier-for-k8s v0.5.0/go.mod h1:mxCd00E3+dQoT3G4mAKRl5UsJmlGLmAz4/pSrenLPkQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.33.0
 	k8s.io/kubernetes v1.33.0
 	k8s.io/pod-security-admission v0.32.0
 )
@@ -32,7 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 // indirect
 	github.com/aws/smithy-go v1.22.3 // indirect
-	github.com/awslabs/volume-modifier-for-k8s v0.5.1 // indirect
+	github.com/awslabs/volume-modifier-for-k8s v0.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -42,8 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/Xv
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/awslabs/volume-modifier-for-k8s v0.5.1 h1:p8Tuq8Ih4CoX808dGQtfqGY3ssIp73ZKtcB8s0F62OE=
-github.com/awslabs/volume-modifier-for-k8s v0.5.1/go.mod h1:bnzcPxtoRWwc2S/BTCwH5wMoxSR/3PFX9fT078FDqq4=
+github.com/awslabs/volume-modifier-for-k8s v0.5.0 h1:VeDSCnS4vmUmQxHWUVGX65MK0y7hZa/yaVEAMrWz6os=
+github.com/awslabs/volume-modifier-for-k8s v0.5.0/go.mod h1:mxCd00E3+dQoT3G4mAKRl5UsJmlGLmAz4/pSrenLPkQ=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Currently, our go.mod replaces client-go, which causes it to incorrectly "upgrade" to v1.5.2. This PR undoes that breakage and pins external-resizer to a non-broken version.

This brokenness comes to us from `volume-modifier-for-k8s`, and will be fixed there in https://github.com/awslabs/volume-modifier-for-k8s/pull/52

#### How was this change tested?

Standard E2E Run + CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
