### PR TITLE
Include tests/e2e go.mod in make update/gomod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ update/mockgen: bin/mockgen
 .PHONY: update/gomod
 update/gomod:
 	go mod tidy
+	go mod tidy -C tests/e2e/
 
 .PHONY: update/shfmt
 update/shfmt: bin/shfmt


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Adds the new `tests/e2e` go.mod to `make update/gomod` action. The single-az/multi-az tests technically cover this, but this will (1) ensure `make update` actually does all needed updates and (2) cause a failure in `make verify` thus much faster feedback on this issue.

#### How was this change tested?

```bash
$ make update/gomod
go mod tidy
go mod tidy -C tests/e2e/
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
