### PR TITLE
Have dependabot add release-note-none label

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -40,6 +40,7 @@ updates:
   labels:
     - "area/dependency"
     - "ok-to-test"
+    - "release-note-none"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
@@ -55,3 +56,4 @@ updates:
   labels:
     - "area/dependency"
     - "ok-to-test"
+    - "release-note-none"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

No need for dependabot PRs to have release note

#### How was this change tested?

Hasn't

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
