### PR TITLE
Reliably remove driver startup taint

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/clusterrole-csi-node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-csi-node.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]

--- a/deploy/kubernetes/base/clusterrole-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrole-csi-node.yaml
@@ -9,7 +9,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
#### What type of PR is this?

Fixes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2447
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

The current implementation uses a 1 s sleep to look for the `ebs.csi.aws.com/agent‑not‑ready` taint.  If `eks:node‑manager` (or any other controller) applies the taint *after* that initial probe, the driver never retries and the node stays unschedulable until the pod is restarted.

This patch replaces that logic with a short‑lived, event‑driven Node informer filtered to the current node as a better mechanism for reliably removing the startup taint.

Note: Some minor refactoring was done in the existing unit tests because we no longer need to mock the call to retrieve the node object in `removeNotReadyTaint` -  now, the node object gets passed in directly into `removeNotReadyTaint` from the informer's event handling.

#### How was this change tested?

- `make verify && make test`.
- Manually, a scenario where where the taint is present before node pod starts, and a scenario where the taint is added after node pod starts.


Driver logs:
```
kubectl logs ebs-csi-node-hjq2g -n kube-system                                               ✔  torredil-Isengard@dev.us-east-1.eksctl.io ○  torredil@dev-dsk-torredil-1d-e1003bcc
Defaulted container "ebs-plugin" out of: ebs-plugin, node-driver-registrar, liveness-probe
I0519 13:43:52.611344       1 main.go:153] "Initializing metadata"
I0519 13:43:52.611404       1 metadata.go:54] "Attempting to retrieve instance metadata from IMDS"
I0519 13:43:52.615709       1 metadata.go:57] "Retrieved metadata from IMDS"
I0519 13:43:52.616754       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I0519 13:43:52.616768       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I0519 13:43:52.616772       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I0519 13:43:52.616776       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I0519 13:43:52.616780       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I0519 13:43:52.617071       1 driver.go:69] "Driver Information" Driver="ebs.csi.aws.com" Version="v1.43.0"
I0519 13:43:52.629161       1 reflector.go:430] "Caches populated" type="*v1.Node" reflector="/gomodcache/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285"
I0519 13:43:54.167774       1 node.go:1009] "CSINode Allocatable value is set" nodeName="ip-192-168-15-218.ec2.internal" count=26
I0519 13:43:54.184703       1 node.go:996] "Removed taint(s) from local node" node="ip-192-168-15-218.ec2.internal"
I0519 13:43:54.184719       1 node.go:877] "Successfully removed agent‑not‑ready taint; stopping watcher"
```

```
kubectl describe node ip-192-168-15-218.ec2.internal | grep "Taints"            
Taints:             <none>
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Reliably remove the `ebs.csi.aws.com/agent-not-ready` taint at start‑up using a short‑lived informer, eliminating a race condition that could leave nodes unschedulable.
```
