### PR TITLE
improving extraVolumeTags validation to follow EC2 tagging convention

### DIFF
--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -1147,8 +1147,7 @@
       "propertyNames": {
         "type": "string",
         "minLength": 1,
-        "maxLength": 128,
-        "pattern": "^.*$"
+        "maxLength": 128
       },
       "patternProperties": {
         "^.*$": {

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -1148,14 +1148,13 @@
         "type": "string",
         "minLength": 1,
         "maxLength": 128,
-        "pattern": "^[a-zA-Z0-9 _\\.:\\/=+\\-@]*$"
+        "pattern": "^.*$"
       },
       "patternProperties": {
         "^.*$": {
           "type": "string",
           "minLength": 0,
-          "maxLength": 256,
-          "pattern": "^[a-zA-Z0-9 _\\.:\\/=+\\-@]*$"
+          "maxLength": 256
         }
       }
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

We need this PR to improve our `extraVolumeTags` validation to follow EC2 tagging convention as described [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions)
This PR addresses #2491 

#### How was this change tested?

`cd aws-ebs-csi-driver/charts/aws-ebs-csi-driver`

`helm template . -f test-file.yaml --debug | grep "extra-tag"`

created 3 files

1. valid-test-values.yaml

```
controller:
  extraVolumeTags:
    # Normal valid cases
    normal-key: "normal-value"
    with.dot: "value.with.dot"
    with_underscore: "value_with_underscore"
    with-hyphen: "value-with-hyphen"
    withNumber123: "value123"
    UPPERCASE: "UPPERCASE_VALUE"
    "key:with:colon": "value:with:colon"
    "key@with@at": "value@with@at"
    "key/with/slash": "value/with/slash"
    "unicode_key_测试": "unicode_value_测试"
    
    # Edge cases that look like aws: but are valid
    awstest: "valid"
    aws-test: "valid"
    aws.test: "valid"
    aws_test: "valid"
    AWStest: "valid"
    awsS: "valid"
    awSs: "valid"
    
    # Length limit edge cases
    "k": "single-char-key"  # minimum key length (1)
    normalkey: ""  # empty value (allowed)
    "kxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": "valid"  # exactly 128 chars
    shortkey: "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv1234"  # exactly 256 chars

    # Special characters in values
    special-chars: "value;with;semicolons"
    more-special: "value/with/slashes"
    even-more: "value with spaces"
    symbols: "!@#$%^&*()"
```

2. invalid-test-value.yaml 

```
controller:
  extraVolumeTags:
  
    # Invalid aws: prefix cases (all case combinations)
    aws:test: "value"
    AWS:test: "value"
    Aws:test: "value"
    aWs:test: "value"
    awS:test: "value"
    AwS:test: "value"
    aWS:test: "value"
    AWs:test: "value"

    # Invalid length cases
    "": "empty-key-not-allowed"  # key too short (0 chars)
    "kxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": "invalid"  # key too long (129 chars)
    toolong: "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv1234"  # value too long (257 chars)
```

3. 51-tag.yaml

```
controller:
  extraVolumeTags:
    tag01: "value01"
    tag02: "value02"
    tag03: "value03"
    tag04: "value04"
    tag05: "value05"
    tag06: "value06"
    tag07: "value07"
    tag08: "value08"
    tag09: "value09"
    tag10: "value10"
    tag11: "value11"
    tag12: "value12"
    tag13: "value13"
    tag14: "value14"
    tag15: "value15"
    tag16: "value16"
    tag17: "value17"
    tag18: "value18"
    tag19: "value19"
    tag20: "value20"
    tag21: "value21"
    tag22: "value22"
    tag23: "value23"
    tag24: "value24"
    tag25: "value25"
    tag26: "value26"
    tag27: "value27"
    tag28: "value28"
    tag29: "value29"
    tag30: "value30"
    tag31: "value31"
    tag32: "value32"
    tag33: "value33"
    tag34: "value34"
    tag35: "value35"
    tag36: "value36"
    tag37: "value37"
    tag38: "value38"
    tag39: "value39"
    tag40: "value40"
    tag41: "value41"
    tag42: "value42"
    tag43: "value43"
    tag44: "value44"
    tag45: "value45"
    tag46: "value46"
    tag47: "value47"
    tag48: "value48"
    tag49: "value49"
    tag50: "value50"
    tag51: "value51"  # This makes it exceed 50 tags
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Fixed the validation of `extraVolumeTags` to follow EC2 tagging requirements
```

edit : 

I made another commit : [9db1ad1](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2504/commits/9db1ad1cc67faaaeff610125a893fec3307ff8aa) :

as I was educated that all i was trying to do is already being validated is being done at `validation.go` so no need `maxProperties` and checking for `"pattern": "^([^aA]|[aA][^wW]|[aA][wW][^sS]|[aA][wW][sS][^:])"` so all the previous info in PR may not be of concern anymore.

happy to learn more from my mistake.
