### PR TITLE
Remove duplicate ErrNotFound log

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -419,7 +419,6 @@ func (d *ControllerService) ControllerPublishVolume(ctx context.Context, req *cs
 	devicePath, err := d.cloud.AttachDisk(ctx, volumeID, nodeID)
 	if err != nil {
 		if errors.Is(err, cloud.ErrNotFound) {
-			klog.InfoS("ControllerPublishVolume: volume not found", "volumeID", volumeID, "nodeID", nodeID)
 			return nil, status.Errorf(codes.NotFound, "Volume %q not found", volumeID)
 		}
 		return nil, status.Errorf(codes.Internal, "Could not attach volume %q to node %q: %v", volumeID, nodeID, err)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?



See https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2500#discussion_r2104772103. 

This ErrNotFound information already gets logged from two different places (once from the middleware handler in cloud, and once from the gRPC interceptor in driver.go), so there isn't any value logging it a third time.

#### How was this change tested?

Logs so N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Remove duplicate ErrNotFound log
```
