### PR TITLE
Set seLinuxMount on CSIDriver when appropriate

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -11,4 +11,7 @@ spec:
   {{- if not .Values.useOldCSIDriver }}
   fsGroupPolicy: File
   {{- end }}
+  {{- if .Values.node.selinux }}
+  seLinuxMount: true
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What is this PR about? / Why do we need it?
In conjunction with https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2253 and https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2311, addresses https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2228

Currently the `.node.selinux` configuration value mounts directories which are required for selinux-aware mounting. However, it does not set the `seLinuxMount` field in the CSIDriver spec which is required for Kubernetes to pass SELinux content mount options to the driver. This PR fixes that.

#### How was this change tested?


#### Does this PR introduce a user-facing change?
```release-note
NONE
```
