### PR TITLE
Use correct name for nvme_collector_duration_seconds

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -65,20 +65,20 @@ The EBS CSI Driver will emit [container storage Interface managed devices metric
 
 The metrics will appear in the following format: 
 ```sh
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.001"} 0
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.0025"} 0
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.005"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.01"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.025"} 1
-nvme_collector_duration_seconds_bucket{instance_id="instance-id}",le="0.05"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.1"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.25"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.5"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="1"} 1
-nvme_collector_duration_seconds_bucket{instance_id="instance-id}",le="2.5"} 1
-nvme_collector_duration_seconds_bucket{instance_id="instance-id}",le="5"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="10"} 1
-nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="+Inf"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.001"} 0
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.0025"} 0
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.005"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.01"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.025"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="instance-id}",le="0.05"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.1"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.25"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="0.5"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="1"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="instance-id}",le="2.5"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="instance-id}",le="5"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="10"} 1
+aws_ebs_csi_nvme_collector_duration_seconds_bucket{instance_id="{instance-id}",le="+Inf"} 1
 ...
 ```
 


### PR DESCRIPTION
This is the actual name of the metric, as the namespace  `aws_ebs_csi_` is hardcoded in the code. Matches the other examples here too.

#### What type of PR is this?

/kind documentation

#### What is this PR about? / Why do we need it?

The example names for the node metrics were missing the prefix, making it slightly difficult
to validate that metrics collection is enabled.

#### How was this change tested?

I verified that these metrics *are* available in my installation.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
