### PR TITLE
Migrate to golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubernetes Authors.
+# Copyright 2025 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -12,36 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 run:
   modules-download-mode: readonly
-issues:
-  exclude-rules:
-    # gosec recommends ignoring test files
-    - path: (.+)_test.go
-      linters:
-        - gosec
-    - path: tests/e2e
-      linters:
-        - gosec
-    - path: tests/sanity
-      linters:
-        - gosec
-linters-settings:
-  revive:
-    rules:
-      # Using += 1 instead of ++ is fine
-      - name: increment-decrement
-        disabled: true
-  stylecheck:
-    # Dot importing ginkgo and gomega is standard practice
-    dot-import-whitelist:
-      - "github.com/onsi/gomega"
-      - "github.com/onsi/ginkgo/v2"
-  usetesting:
-    # Turning check for os.MkdirTemp() off as t.TempDir() is not sufficient for mounter and sanity tests in their current state.
-    os-mkdir-temp: false 
 linters:
-  enable-all: true
+  default: all
   disable:
     - govet # We already run with `make verify/govet`
     # We do not use
@@ -52,7 +27,6 @@ linters:
     - funlen # Long func names happen
     - gocognit # Cognitive complexity
     - gocyclo # Cyclomatic complexity
-    - gofumpt # We don't rely on gofumpt
     - gomoddirectives # We need `replace` in `go.mod`
     - interfacebloat # No more than 10 interface methods
     - ireturn # Accept interfaces return concrete types
@@ -71,3 +45,44 @@ linters:
     - godox # Do not allow TODOs
     - nonamedreturns # Need to nolint/refactor a few places our code
     - paralleltest # There are many tests that aren't parallelized
+    - funcorder # Many of our existing files are out of order
+  settings:
+    revive:
+      rules:
+        # Using += 1 instead of ++ is fine
+        - name: increment-decrement
+          disabled: true
+    staticcheck:
+      # Dot importing ginkgo and gomega is standard practice
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo/v2
+    usetesting:
+      # Turning check for os.MkdirTemp() off as t.TempDir() is not sufficient for mounter and sanity tests in their current state.
+      os-mkdir-temp: false
+  exclusions:
+    # Exclude files that look auto-generated
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # gosec recommends ignoring test files
+      - linters:
+          - gosec
+        path: (.+)_test.go
+      - linters:
+          - gosec
+        path: tests/e2e
+      - linters:
+          - gosec
+        path: tests/sanity
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -27,7 +27,7 @@ EKSCTL_VERSION="v0.210.0"
 # https://github.com/onsi/ginkgo
 GINKGO_VERSION="v2.23.4"
 # https://github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION="v1.64.8"
+GOLANGCI_LINT_VERSION="v2.1.6"
 # https://github.com/hairyhenderson/gomplate
 GOMPLATE_VERSION="v4.3.2"
 # https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1825,6 +1825,8 @@ func (c *cloud) AvailabilityZones(ctx context.Context) (map[string]struct{}, err
 
 func needsVolumeModification(volume types.Volume, newSizeGiB int32, options *ModifyDiskOptions) bool {
 	oldSizeGiB := *volume.Size
+	//nolint:staticcheck // staticcheck suggests merging all of the below conditionals into one line,
+	// but that would be extremely difficult to read
 	needsModification := false
 
 	if oldSizeGiB < newSizeGiB {

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -139,7 +139,7 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case IopsPerGBKey:
 			parseIopsPerGBKey, parseIopsPerGBKeyErr := strconv.ParseInt(value, 10, 32)
 			if parseIopsPerGBKeyErr != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid iopsPerGB: %v", err)
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid iopsPerGB: %v", parseIopsPerGBKeyErr)
 			}
 			iopsPerGB = int32(parseIopsPerGBKey)
 		case AllowAutoIOPSPerGBIncreaseKey:
@@ -147,19 +147,19 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		case IopsKey:
 			parseIopsKey, parseIopsKeyErr := strconv.ParseInt(value, 10, 32)
 			if parseIopsKeyErr != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid iops: %v", err)
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid iops: %v", parseIopsKeyErr)
 			}
 			iops = int32(parseIopsKey)
 		case VolumeInitializationRateKey:
 			parseInitRate, parseInitRateErr := strconv.ParseInt(value, 10, 32)
 			if parseInitRateErr != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid volumeInitializationRate: %v", err)
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid volumeInitializationRate: %v", parseInitRateErr)
 			}
 			volumeInitializationRate = int32(parseInitRate)
 		case ThroughputKey:
 			parseThroughput, parseThroughputErr := strconv.ParseInt(value, 10, 32)
 			if parseThroughputErr != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid throughput: %v", err)
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid throughput: %v", parseThroughputErr)
 			}
 			throughput = int32(parseThroughput)
 		case EncryptedKey:

--- a/pkg/mounter/mount_linux.go
+++ b/pkg/mounter/mount_linux.go
@@ -72,7 +72,7 @@ func (m *NodeMounter) FindDevicePath(devicePath, volumeID, partition, region str
 	if exists {
 		stat, lstatErr := os.Lstat(devicePath)
 		if lstatErr != nil {
-			return "", fmt.Errorf("failed to lstat %q: %w", devicePath, err)
+			return "", fmt.Errorf("failed to lstat %q: %w", devicePath, lstatErr)
 		}
 
 		if stat.Mode()&os.ModeSymlink == os.ModeSymlink {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Migrates our config to golangci-lint v2's format. This was done by using the built-in migration tool, and then fixing some resulting issues (e.g. missing comments) in the generated file.

Also fixes several instances of incorrect errors found by a new linter, and adds a `nolint` for a particularly egregious suggestion by a new linter.

#### How was this change tested?

`make verfy/golangci-lint`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
