### PR TITLE
Update CSIDriver object to include `nodeAllocatableUpdatePeriodSeconds`

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -8,6 +8,11 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  {{- if semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version }}
+  {{- with .Values.nodeAllocatableUpdatePeriodSeconds }}
+  nodeAllocatableUpdatePeriodSeconds: {{ . }}
+  {{- end }}
+  {{- end }}
   {{- if not .Values.useOldCSIDriver }}
   fsGroupPolicy: File
   {{- end }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -106,6 +106,11 @@
       "description": "Use old CSIDriver without an fsGroupPolicy set Intended for use with older clusters that cannot easily replace the CSIDriver objectThis parameter should always be false for new installations",
       "default": false
     },
+    "nodeAllocatableUpdatePeriodSeconds": {
+      "type": "integer",
+      "description": "nodeAllocatableUpdatePeriodSeconds updates the node's max attachable volume count by directing Kubelet to periodically call NodeGetInfo at the configured interval. Kubernetes enforces a minimum update interval of 10 seconds. This parameter is supported in Kubernetes 1.33+, the MutableCSINodeAllocatableCount feature gate must be enabled in kubelet and kube-apiserver.",
+      "default": 10
+    },
     "nodeComponentOnly": {
       "type": "boolean",
       "description": "Deploy EBS CSI Driver without controller and associated resources",

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -507,6 +507,12 @@ volumeSnapshotClasses: []
 # Intended for use with older clusters that cannot easily replace the CSIDriver object
 # This parameter should always be false for new installations
 useOldCSIDriver: false
+
+# nodeAllocatableUpdatePeriodSeconds updates the node's max attachable volume count by directing Kubelet to periodically call NodeGetInfo at the configured interval.
+# Kubernetes enforces a minimum update interval of 10 seconds.
+# This parameter is supported in Kubernetes 1.33+ and requires the MutableCSINodeAllocatableCount feature gate to be enabled in kubelet and kube-apiserver.
+nodeAllocatableUpdatePeriodSeconds: 10
+
 # Deploy EBS CSI Driver without controller and associated resources
 nodeComponentOnly: false
 helmTester:

--- a/deploy/kubernetes/base/csidriver.yaml
+++ b/deploy/kubernetes/base/csidriver.yaml
@@ -9,4 +9,5 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
+  nodeAllocatableUpdatePeriodSeconds: 10
   fsGroupPolicy: File


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

For background, see https://kubernetes.io/blog/2025/05/02/kubernetes-1-33-mutable-csi-node-allocatable-count/.

This PR adds the new `nodeAllocatableUpdatePeriodSeconds` parameter to the CSIDriver object.

#### How was this change tested?

```
make update && make verify && make test
```

Manually:

- Kubernetes 1.32.0 (Parameter set; Feature Not Available):

```
helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --values ./charts/aws-ebs-csi-driver/values.yaml
Release "aws-ebs-csi-driver" does not exist. Installing it now.
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Jun 25 17:16:39 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

[Deprecation announcement] AWS Snow Family device support for the EBS CSI Driver

Support for the EBS CSI Driver on [AWS Snow Family devices](https://aws.amazon.com/snowball/) is deprecated, effective immediately. No further Snow-specific bugfixes or feature requests will be merged. The existing functionality for Snow devices has been removed on the 1.44 release of the EBS CSI Driver. Support of the EBS CSI Driver on other platforms, such as [Amazon EC2](https://aws.amazon.com/ec2/) or EC2 on [AWS Outposts](https://aws.amazon.com/outposts/) is not affected.
```

```
kubectl describe csidriver ebs.csi.aws.com | grep "Allocatable"
```

- Kubernetes 1.33.1 (Parameter set; Feature Gate Disabled):

```
helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --values ./charts/aws-ebs-csi-driver/values.yaml
Release "aws-ebs-csi-driver" does not exist. Installing it now.
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Jun 25 16:56:19 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

[Deprecation announcement] AWS Snow Family device support for the EBS CSI Driver

Support for the EBS CSI Driver on [AWS Snow Family devices](https://aws.amazon.com/snowball/) is deprecated, effective immediately. No further Snow-specific bugfixes or feature requests will be merged. The existing functionality for Snow devices has been removed on the 1.44 release of the EBS CSI Driver. Support of the EBS CSI Driver on other platforms, such as [Amazon EC2](https://aws.amazon.com/ec2/) or EC2 on [AWS Outposts](https://aws.amazon.com/outposts/) is not affected.
```

```
kubectl describe csidriver ebs.csi.aws.com | grep "Allocatable"
```

- Kubernetes 1.33.1 (Parameter set; Feature Gate Enabled):

```
helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --values ./charts/aws-ebs-csi-driver/values.yaml
Release "aws-ebs-csi-driver" does not exist. Installing it now.
NAME: aws-ebs-csi-driver
LAST DEPLOYED: Wed Jun 25 16:40:54 2025
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

[Deprecation announcement] AWS Snow Family device support for the EBS CSI Driver

Support for the EBS CSI Driver on [AWS Snow Family devices](https://aws.amazon.com/snowball/) is deprecated, effective immediately. No further Snow-specific bugfixes or feature requests will be merged. The existing functionality for Snow devices has been removed on the 1.44 release of the EBS CSI Driver. Support of the EBS CSI Driver on other platforms, such as [Amazon EC2](https://aws.amazon.com/ec2/) or EC2 on [AWS Outposts](https://aws.amazon.com/outposts/) is not affected.
```

```
kubectl describe csidriver ebs.csi.aws.com | grep "Allocatable"

Node Allocatable Update Period Seconds:  10
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Added new Helm parameter: nodeAllocatableUpdatePeriodSeconds. This parameter updates the node's max attachable volume count by directing Kubelet to periodically call NodeGetInfo at the configured interval. Kubernetes enforces a minimum update interval of 10 seconds. This parameter is supported in Kubernetes 1.33+ and requires the MutableCSINodeAllocatableCount feature gate to be enabled in kubelet and kube-apiserver.
```
