### PR TITLE
Remove completed TODO comment

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -962,7 +962,6 @@ func (c *cloud) DetachDisk(ctx context.Context, volumeID, nodeID string) error {
 		return err
 	}
 
-	// TODO: check if attached
 	device, err := c.dm.GetDevice(instance, volumeID)
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR removes the TODO comment to check if the device is attached before releasing as that is already being done in this function, here we defer the release: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/af089444c5b7e17907cef26415febc511b7699aa/pkg/cloud/cloud.go#L970 

Right before the function returns we check that the volume is in an detached state and if it isn't we log it:  https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/af089444c5b7e17907cef26415febc511b7699aa/pkg/cloud/cloud.go#L994-L1001


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
