### PR TITLE
Patch node metadata labels to include Volume/ENI count

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/cmd/hooks"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/cmd/patch"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
@@ -143,6 +144,17 @@ func main() {
 	region := os.Getenv("AWS_REGION")
 	var md metadata.MetadataService
 	var metadataErr error
+
+	switch options.Mode {
+	case driver.NodeMode:
+		time.Sleep(5e9) // TODO: for proof of concept remove later
+	case driver.ControllerMode:
+		clientset, _ := cfg.K8sAPIClient()
+		err := patch.UpdateMetadataEC2(clientset)
+		if err != nil {
+			klog.ErrorS(err, "unable to update ENI/Volume count on node labels")
+		}
+	}
 
 	if region != "" {
 		klog.InfoS("Region provided via AWS_REGION environment variable", "region", region)

--- a/cmd/patch/labels.go
+++ b/cmd/patch/labels.go
@@ -1,0 +1,103 @@
+package patch
+
+import (
+	"context"
+	json "encoding/json"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+type ENIsVolumes struct {
+	ENIs    int
+	Volumes int
+}
+
+func UpdateMetadataEC2(kubeclient kubernetes.Interface) error {
+	nodes, _ := kubeclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	region := nodes.Items[0].GetLabels()[v1.LabelTopologyRegion] // We assume every node in the cluster has the same region
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+
+	if err != nil {
+		klog.ErrorS(err, "unable to load SDK config")
+		return err
+	}
+
+	svc := ec2.NewFromConfig(cfg)
+
+	ENIsVolumeMap, err := GetMetadata(svc, region)
+	if err != nil {
+		klog.ErrorS(err, "unable to get ENI/Volume count")
+		return err
+	}
+
+	err = PatchNodes(nodes, ENIsVolumeMap, kubeclient)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetMetadata(client cloud.EC2API, region string) (map[string]ENIsVolumes, error) {
+	resp, err := client.DescribeInstances(context.TODO(), &ec2.DescribeInstancesInput{})
+	if err != nil {
+		klog.ErrorS(err, "failed to describe instances")
+		return nil, err
+	}
+
+	ENIsVolumesMap := make(map[string]ENIsVolumes)
+	for _, reservation := range resp.Reservations {
+		for _, instance := range reservation.Instances {
+			numAttachedENIs := 1
+			if instance.NetworkInterfaces != nil {
+				numAttachedENIs = len(instance.NetworkInterfaces)
+			}
+			numBlockDeviceMappings := 0
+			if instance.BlockDeviceMappings != nil {
+				numBlockDeviceMappings = len(instance.BlockDeviceMappings)
+			}
+			instanceID := *instance.InstanceId
+			ENIsVolumesMap[instanceID] = ENIsVolumes{ENIs: numAttachedENIs, Volumes: numBlockDeviceMappings}
+		}
+	}
+	return ENIsVolumesMap, nil
+}
+
+func PatchNodes(nodes *v1.NodeList, ENIsVolumeMap map[string]ENIsVolumes, clientset kubernetes.Interface) error {
+	for _, node := range nodes.Items {
+		newNode := node.DeepCopy()
+		numAttachedENIs := ENIsVolumeMap[node.Name].ENIs
+		numBlockDeviceMappings := ENIsVolumeMap[node.Name].Volumes
+		newNode.Labels["num-volumes"] = strconv.Itoa(numBlockDeviceMappings)
+		newNode.Labels["num-ENIs"] = strconv.Itoa(numAttachedENIs)
+
+		oldData, err := json.Marshal(node)
+		if err != nil {
+			klog.V(1).InfoS("failed to marshal the existing node", "node", node.Name)
+			return err
+		}
+		newData, err := json.Marshal(newNode)
+		if err != nil {
+			klog.V(1).InfoS("failed to marshal the new node", "node", newNode.Name)
+			return err
+		}
+		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, &v1.Node{})
+		if err != nil {
+			klog.V(1).InfoS("failed to create two way merge", "node", node.Name)
+			return err
+		}
+		if _, err := clientset.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+			klog.ErrorS(err, "Failed to patch node", "node", node.Name)
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/patch/labels_test.go
+++ b/cmd/patch/labels_test.go
@@ -1,0 +1,135 @@
+package patch
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/golang/mock/gomock"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func newFakeInstance(instanceID string, numENIs int, numVolumes int) types.Instance {
+	return types.Instance{
+		InstanceId:          &instanceID,
+		BlockDeviceMappings: make([]types.InstanceBlockDeviceMapping, numVolumes),
+		NetworkInterfaces:   make([]types.InstanceNetworkInterface, numENIs),
+	}
+}
+
+func TestGetMetadata(t *testing.T) {
+	testCases := []struct {
+		name             string
+		instances        []types.Instance
+		expectedMetadata map[string]ENIsVolumes
+		expErr           error
+	}{
+		{
+			name:      "success: normal",
+			instances: []types.Instance{newFakeInstance("i-001", 1, 1), newFakeInstance("i-002", 2, 0)},
+			expectedMetadata: map[string]ENIsVolumes{
+				"i-001": {ENIs: 1, Volumes: 1},
+				"i-002": {ENIs: 2, Volumes: 0},
+			},
+			expErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockEC2 := cloud.NewMockEC2API(mockCtrl)
+
+			mockEC2.EXPECT().DescribeInstances(gomock.Any(), gomock.Any()).Return(
+				&ec2.DescribeInstancesOutput{
+					Reservations: []types.Reservation{
+						{
+							Instances: tc.instances,
+						},
+					},
+				},
+				tc.expErr,
+			)
+
+			ENIsVolumesMap, err := GetMetadata(mockEC2, "us-west-2")
+			if err != nil {
+				if tc.expErr == nil {
+					t.Fatalf("GetMetadata() failed: expected no error, got: %v", err)
+				}
+				if err.Error() != tc.expErr.Error() {
+					t.Fatalf("GetMetadata() failed: expected error %q, got %q", tc.expErr, err)
+				}
+			} else {
+				if tc.expErr != nil {
+					t.Fatal("GetMetadata() failed: expected error, got nothing")
+				}
+				if !reflect.DeepEqual(ENIsVolumesMap, tc.expectedMetadata) {
+					t.Fatalf("GetMetadata() failed: expected %v, go: %v", tc.expectedMetadata, ENIsVolumesMap)
+				}
+			}
+			mockCtrl.Finish()
+		})
+	}
+}
+
+func TestPatchLabels(t *testing.T) {
+	testCases := []struct {
+		name           string
+		instance       types.Instance
+		ENIsVolumesMap map[string]ENIsVolumes
+		expErr         error
+	}{
+		{
+			name:     "success: normal",
+			instance: newFakeInstance("i-001", 1, 1),
+			ENIsVolumesMap: map[string]ENIsVolumes{
+				"i-001": {ENIs: 1, Volumes: 1},
+			},
+			expErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   *tc.instance.InstanceId,
+					Labels: map[string]string{},
+				},
+			}
+			nodes := corev1.NodeList{Items: []corev1.Node{node}}
+			clientset := fake.NewSimpleClientset(&node)
+			err := PatchNodes(&nodes, tc.ENIsVolumesMap, clientset)
+			if err != nil {
+				if tc.expErr == nil {
+					t.Fatalf("PatchNodes() failed: expected no error, got: %v", err)
+				}
+				if err.Error() != tc.expErr.Error() {
+					t.Fatalf("PatchNodes() failed: expected error %q, got %q", tc.expErr, err)
+				}
+			} else {
+				if tc.expErr != nil {
+					t.Fatal("PatchNodes() failed: expected error, got nothing")
+				}
+				node, _ := clientset.CoreV1().Nodes().Get(context.TODO(), *tc.instance.InstanceId, metav1.GetOptions{})
+				expectedENIs := strconv.Itoa(tc.ENIsVolumesMap[*tc.instance.InstanceId].ENIs)
+				gotENIs := node.GetLabels()["num-ENIs"]
+
+				expectedVolumes := strconv.Itoa(tc.ENIsVolumesMap[*tc.instance.InstanceId].Volumes)
+				gotVolumes := node.GetLabels()["num-volumes"]
+				if node.GetLabels()["num-ENIs"] != strconv.Itoa(tc.ENIsVolumesMap[*tc.instance.InstanceId].ENIs) {
+					t.Fatalf("PatchNodes() failed: expected %q ENIs, got %q", expectedENIs, gotENIs)
+				}
+				if node.GetLabels()["num-volumes"] != strconv.Itoa(tc.ENIsVolumesMap[*tc.instance.InstanceId].Volumes) {
+					t.Fatalf("PatchNodes() failed: expected %q volumes, got %q", expectedVolumes, gotVolumes)
+				}
+			}
+		})
+	}
+}

--- a/patch_nodes.yaml
+++ b/patch_nodes.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ebs-csi-node-patcher
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ebs-csi-node-patcher-binding
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+subjects:
+- kind: ServiceAccount
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-csi-node-patcher


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What is this PR about? / Why do we need it?
This PR gets the Volume and ENI count of each node via the EC2 API. It then adds this information to the metadata labels of each node in the cluster, so Kubernetes can get this information without IMDS access. 

#### How was this change tested?
Unit testing in labels_test.go

#### Does this PR introduce a user-facing change?
Yes, customers need to first configure RBAC permissions that allow the EBS CSI controllers to patch nodes in the cluster.
