### PR TITLE
Add Karpenter ebs-scale-test cluster type

### DIFF
--- a/hack/ebs-scale-test/README.md
+++ b/hack/ebs-scale-test/README.md
@@ -6,7 +6,7 @@ Setup and run an EBS CSI Driver scalability test with our `scale-test` tool:
 
 ```shell
 # Set scalability parameters
-export CLUSTER_TYPE="pre-allocated"
+export CLUSTER_TYPE="karpenter"
 export TEST_TYPE="scale-sts"
 export REPLICAS="1000"
 
@@ -65,6 +65,7 @@ Set the `CLUSTER_TYPE` and `TEST_TYPE` environment variables to set up and run d
 
 - `CLUSTER_TYPE` dictates what type of scalability cluster `scale-test` creates and which nodes are used during a scalability test run. Options include: 
   - 'pre-allocated': Additional worker nodes are created during cluster setup. By default, we pre-allocate 1 `m7a.48xlarge` EC2 instance for every 100 StatefulSet replicas.
+  - 'karpenter': Installs [Karpenter](https://github.com/aws/karpenter-provider-aws) during cluster setup. Karpenter will provision and delete worker nodes during scalability test run.
 
 - `TEST_TYPE` dictates what type of scalability test we want to run. Options include: 
   - 'scale-sts': Scales a StatefulSet to `$REPLICAS`. Waits for all pods to be ready. Delete Sts. Waits for all PVs to be deleted. Exercises the complete dynamic provisioning lifecycle for block volumes.

--- a/hack/ebs-scale-test/helpers/cluster-setup/nodes-karpenter.yaml
+++ b/hack/ebs-scale-test/helpers/cluster-setup/nodes-karpenter.yaml
@@ -1,0 +1,65 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: ebs-scale-test
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["6"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: ebs-scale-test
+      expireAfter: 720h
+      startupTaints:
+        - key: ebs.csi.aws.com/agent-not-ready
+          effect: NoExecute
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 20m
+---
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: ebs-scale-test
+spec:
+  role: "KarpenterNodeRole-{{ .Env.CLUSTER_NAME }}"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "{{ .Env.CLUSTER_NAME }}"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "{{ .Env.CLUSTER_NAME }}"
+  amiSelectorTerms:
+    - alias: al2023@latest
+  metadataOptions:
+    httpPutResponseHopLimit: 2

--- a/hack/ebs-scale-test/helpers/cluster-setup/scale-cluster-config.yaml
+++ b/hack/ebs-scale-test/helpers/cluster-setup/scale-cluster-config.yaml
@@ -30,6 +30,14 @@ iam:
         ebsCSIController: true
 
 managedNodeGroups:
+{{- if eq ( getenv "CLUSTER_TYPE" ) "karpenter" }}
+  - instanceType: m5.2xlarge
+    amiFamily: AmazonLinux2023
+    name: add-on-ng
+    desiredCapacity: 2
+    minSize: 1
+    maxSize: 3
+{{- end }}
 {{- if eq ( getenv "CLUSTER_TYPE" ) "pre-allocated" }}
   - instanceType: m7a.48xlarge
     amiFamily: AmazonLinux2023

--- a/hack/ebs-scale-test/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.sh
+++ b/hack/ebs-scale-test/helpers/scale-test/snapshot-volume-scale-test/snapshot-volume-scale.sh
@@ -76,8 +76,8 @@ wait_for_pvcs_bound() {
 }
 
 create_snapshots() {
-  for i in {0..$(($REPLICAS - 1))}; do
-    for j in {1..$SNAPSHOTS_PER_VOLUME}; do
+  for ((i = 0; i < REPLICAS; i++)); do
+    for ((j = 1; j <= SNAPSHOTS_PER_VOLUME; j++)); do
       cat <<EOF | kubectl apply -f -
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot

--- a/hack/ebs-scale-test/scale-test
+++ b/hack/ebs-scale-test/scale-test
@@ -39,10 +39,11 @@ SCALABILITY_TEST_RUN_NAME=${SCALABILITY_TEST_RUN_NAME:="$CLUSTER_NAME-$TEST_TYPE
 EXPORT_DIR=${EXPORT_DIR:="/tmp/ebs-scale-test/$SCALABILITY_TEST_RUN_NAME"}
 
 ## Internal environment variables
-export PRE_ALLOCATED_NODES K8S_VERSION AWS_ACCOUNT_ID AWS_REGION BASE_DIR TEMPOUT
+export PRE_ALLOCATED_NODES K8S_VERSION KARPENTER_VERSION AWS_ACCOUNT_ID AWS_REGION BASE_DIR TEMPOUT
 
 PRE_ALLOCATED_NODES=${PRE_ALLOCATED_NODES:=$((($REPLICAS / 100) + 1))}
 K8S_VERSION=$(aws eks describe-cluster-versions --query "clusterVersions[0].clusterVersion")
+KARPENTER_VERSION="1.5.1"
 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 AWS_REGION=$(aws configure get region)
@@ -82,6 +83,11 @@ check_dependencies_helper() {
 # Functions sourced from helpers/cluster-setup/manage-cluster.sh
 setup_scale() {
   create_cluster
+
+  if [[ $CLUSTER_TYPE == "karpenter" ]]; then
+    deploy_karpenter
+  fi
+
   deploy_snapshot_controller
   deploy_ebs_csi_driver
 }
@@ -105,6 +111,10 @@ run_scale() {
 
 # Functions sourced from helpers/cluster-setup/manage-cluster.sh
 clean_scale() {
+  if [[ $CLUSTER_TYPE == "karpenter" ]]; then
+    cleanup_karpenter
+  fi
+
   cleanup_cluster
   check_lingering_volumes
   check_lingering_snapshots


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind documentation

#### What is this PR about? / Why do we need it?

Adds cluster type which installs [Karpenter](https://github.com/aws/karpenter-provider-aws) during cluster setup. 

Karpenter will provision and delete worker nodes during scalability test run as needed.

Bonus: Creating a karpenter cluster when running NON `scale-sts` tests is super frugal because only 2 m5large nodes are up!

#### How was this change tested?

Running 

```
# Set scalability parameters
export CLUSTER_TYPE="karpenter"
export TEST_TYPE="scale-sts"
export REPLICAS="1000"

# Setup an EKS scalability cluster and install EBS CSI Driver.
./scale-test setup

# Run a scalability test and export results.
./scale-test run

# Cleanup all AWS resources related to scalability cluster.
./scale-test cleanup
```

But for each test-type 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add Karpenter ebs-scale-test cluster type
```
