### PR TITLE
feat(helm): support metricRelabelings in ServiceMonitor

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -38,6 +38,10 @@ spec:
     - targetPort: 3301
       path: /metrics
       interval: {{ .Values.controller.serviceMonitor.interval | default "15s"}}
+      {{- if .Values.controller.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.controller.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -413,6 +413,11 @@
             "interval": {
               "type": "string",
               "default": "15s"
+            },
+            "metricRelabelings": {
+              "type": "array",
+              "description": "List of metricRelabelings for ServiceMonitor endpoints. See Prometheus docs for details.",
+              "default": []
             }
           }
         },

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -241,6 +241,8 @@ controller:
     labels:
       release: prometheus
     interval: "15s"
+    # List of metricRelabelings for ServiceMonitor endpoints. See Prometheus docs for details.
+    metricRelabelings: []
   # If set to true, AWS API call metrics will be exported to the following
   # TCP endpoint: "0.0.0.0:3301"
   # ---

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,7 +17,7 @@ $ helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws
 
 ## Overview
 
-Installing the Prometheus Operator and enabling metrics will deploy a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object that exposes the EBS CSI Driver's controller metric port through a `ClusterIP`. Additionally, a [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#:~:text=Alertmanager-,ServiceMonitor,-See%20the%20Alerting) object is deployed which updates the Prometheus scrape configuration and allows scraping metrics from the endpoint defined. For more information, see the manifest [metrics.yaml](/charts/aws-ebs-csi-driver/templates/metrics.yaml)
+Installing the Prometheus Operator and enabling metrics will deploy a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object that exposes the EBS CSI Driver's controller metric port through a `ClusterIP`. Additionally, a [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md#:~:text=Alertmanager-,ServiceMonitor,-See%20the%20Alerting) object is deployed which updates the Prometheus scrape configuration and allows scraping metrics from the endpoint defined. For more information, see the manifest [servicemonitor.yaml](/charts/aws-ebs-csi-driver/templates/servicemonitor.yaml)
 
 ## AWS API Metrics
 


### PR DESCRIPTION
#### What type of PR is this?
feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?
This PR adds support for configuring metricRelabelings in the ServiceMonitor resource of the Helm chart. This allows users to specify custom Prometheus metric relabeling rules for the controller metrics endpoint.
#### How was this change tested?
Did local rendering
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
None
```
