### PR TITLE
Merge dependabot Golang groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,26 +17,11 @@ enable-beta-ecosystems: true
 updates:
   - package-ecosystem: gomod
     directories: ["/", "/tests/e2e/"]
-    allow:
-      - dependency-type: "all"
     schedule:
       interval: weekly
       day: "wednesday"
       time: "06:00"
       timezone: "America/New_York"
-    groups:
-      k8s-dependencies:
-        patterns:
-          - "k8s.io*"
-          - "sigs.k8s.io*"
-          - "github.com/kubernetes-csi*"
-      misc-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "k8s.io*"
-          - "sigs.k8s.io*"
-          - "github.com/kubernetes-csi*"
     labels:
       - "area/dependency"
       - "ok-to-test"
@@ -49,10 +34,6 @@ updates:
       day: "wednesday"
       time: "06:00"
       timezone: "America/New_York"
-    groups:
-      actions:
-        patterns:
-          - "*"
     labels:
       - "area/dependency"
       - "ok-to-test"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Merging the dependabot schemas as we discussed offline because the separated groups keep causing issues (e.g. #2548)

#### How was this change tested?

I put the config through a dependabot schema validator :shrug:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
