### PR TITLE
Align node and controller metrics to consistent experience

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_metrics.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_metrics.tpl
@@ -1,0 +1,54 @@
+{{- define "metrics" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Name }}
+  {{- if .EnableAnnotations }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Port }}"
+  {{- end }}
+spec:
+  selector:
+    app: {{ .TargetPod }}
+  ports:
+    - name: metrics
+      port: {{ .Port }}
+      targetPort: {{ .Port }}
+  type: ClusterIP
+  {{- with .InternalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+{{- if or .ServiceMonitor.forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Name }}
+    {{- if .ServiceMonitor.labels }}
+    {{- toYaml .ServiceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - targetPort: {{ .Port }}
+      path: /metrics
+      interval: {{ .ServiceMonitor.interval | default "15s"}}
+      {{- if .ServiceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .ServiceMonitor.relabelings | nindent 6 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -240,6 +240,9 @@ spec:
             {{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass" }}
             - --feature-gates=VolumeAttributesClass=true
             {{- end }}
+            {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.provisioner.additionalArgs))) }}
+            - --http-endpoint=0.0.0.0:3302
+            {{- end}}
             {{- range .Values.sidecars.provisioner.additionalArgs }}
             - {{ . }}
             {{- end }}
@@ -296,6 +299,9 @@ spec:
             {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.attacher.additionalArgs)) }}
             - --retry-interval-max=5m
             {{- end }}
+            {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.attacher.additionalArgs))) }}
+            - --http-endpoint=0.0.0.0:3303
+            {{- end}}
             {{- range .Values.sidecars.attacher.additionalArgs }}
             - {{ . }}
             {{- end }}
@@ -342,6 +348,9 @@ spec:
             {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.snapshotter.additionalArgs)) }}
             - --retry-interval-max=30m
             {{- end }}
+            {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.snapshotter.additionalArgs))) }}
+            - --http-endpoint=0.0.0.0:3306
+            {{- end}}
             {{- range .Values.sidecars.snapshotter.additionalArgs }}
             - {{ . }}
             {{- end }}
@@ -392,6 +401,9 @@ spec:
             - --leader-election-retry-period={{ .Values.sidecars.volumemodifier.leaderElection.retryPeriod }}
             {{- end }}
             {{- end }}
+            {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.volumemodifier.additionalArgs))) }}
+            - --http-endpoint=0.0.0.0:3307
+            {{- end}}
             {{- range .Values.sidecars.volumemodifier.additionalArgs }}
             - {{ . }}
             {{- end }}
@@ -464,6 +476,9 @@ spec:
             {{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass" }}
             - --feature-gates=VolumeAttributesClass=true
             {{- end }}
+            {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.resizer.additionalArgs))) }}
+            - --http-endpoint=0.0.0.0:3304
+            {{- end}}
             {{- range .Values.sidecars.resizer.additionalArgs }}
             - {{ . }}
             {{- end }}
@@ -496,6 +511,9 @@ spec:
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.livenessProbe.image.pullPolicy }}
           args:
             - --csi-address=/csi/csi.sock
+            {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-metrics-address)" (join " " .Values.sidecars.livenessProbe.additionalArgs))) }}
+            - --metrics-address=0.0.0.0:3305
+            {{- end}}
             {{- range .Values.sidecars.livenessProbe.additionalArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/metrics.yaml
+++ b/charts/aws-ebs-csi-driver/templates/metrics.yaml
@@ -1,68 +1,67 @@
 {{- if and .Values.controller.enableMetrics (not .Values.nodeComponentOnly) -}}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ebs-csi-controller
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: ebs-csi-controller
-spec:
-  selector:
-    app: ebs-csi-controller
-  ports:
-    - name: metrics
-      port: 3301
-      targetPort: 3301
-  type: ClusterIP
----
-{{- if or .Values.controller.serviceMonitor.forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: ebs-csi-controller
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: ebs-csi-controller
-    {{- if .Values.controller.serviceMonitor.labels }}
-    {{- toYaml .Values.controller.serviceMonitor.labels | nindent 4 }}
-    {{- end }}
-spec:
-  selector:
-    matchLabels:
-      app: ebs-csi-controller
-  namespaceSelector:
-    matchNames:
-      - {{ .Release.Namespace }}
-  endpoints:
-    - targetPort: 3301
-      path: /metrics
-      interval: {{ .Values.controller.serviceMonitor.interval | default "15s"}}
-      {{- if .Values.controller.serviceMonitor.relabelings }}
-      relabelings:
-      {{- toYaml .Values.controller.serviceMonitor.relabelings | nindent 6 }}
-      {{- end }}
+{{/* Metrics for the controller pods - we create a separate service per container
+because the prometheus.io annotations don't allow specifying multiple ports */}}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3301
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller-provisioner"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3302
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller-attacher"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3303
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller-resizer"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3304
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller-liveness-probe"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3305
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
+{{- if or .Values.sidecars.snapshotter.forceEnable (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") }}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller-snapshotter"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3306
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
+{{- end }}
+{{- if (.Values.controller.volumeModificationFeature).enabled }}
+{{- include "metrics" (dict
+  "Name" "ebs-csi-controller-volumemodifier"
+  "TargetPod" "ebs-csi-controller"
+  "Port" 3307
+  "ServiceMonitor" .Values.controller.serviceMonitor
+  "EnableAnnotations" .Values.controller.enablePrometheusAnnotations
+  "Release" .Release "Capabilities" .Capabilities) -}}
 {{- end }}
 {{- end }}
----
 {{- if .Values.node.enableMetrics }}
-apiVersion: v1
-kind: Service
-metadata:
-  name: ebs-csi-node
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "3302"
-  labels:
-    app: ebs-csi-node
-spec:
-  selector:
-    app: ebs-csi-node
-  ports:
-    - name: metrics
-      port: 3302
-      targetPort: 3302
-  internalTrafficPolicy: Local
-  type: ClusterIP
+{{- include "metrics" (dict
+  "Name" "ebs-csi-node"
+  "TargetPod" "ebs-csi-node"
+  "Port" 3302
+  "ServiceMonitor" .Values.node.serviceMonitor
+  "EnableAnnotations" .Values.node.enablePrometheusAnnotations
+  "InternalTrafficPolicy" "Local"
+  "Release" .Release "Capabilities" .Capabilities) -}}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -204,6 +204,11 @@
           "description": "Enable metrics collection for the controller pod",
           "default": false
         },
+        "enablePrometheusAnnotations": {
+          "type": "boolean",
+          "description": "If metrics are enabled, add prometheus.io/scrape and prometheus.io/port annotations to the metrics services",
+          "default": true
+        },
         "extraVolumeTags": {
           "$ref": "#/$defs/extraVolumeTags",
           "description": "Additional tags to be added to all EBS volumes",
@@ -405,18 +410,22 @@
         },
         "serviceMonitor": {
           "type": "object",
+          "description": "Parameters to configure the ServiceMonitor for the EBS CSI controller pods",
           "additionalProperties": false,
           "properties": {
             "forceEnable": {
               "type": "boolean",
+              "description": "Render ServiceMonitor object even when CRD is not detected",
               "default": false
             },
             "labels": {
               "type": "object",
-              "description": "Additional labels for ServiceMonitor object"
+              "description": "Additional labels for ServiceMonitor object",
+              "default": {}
             },
             "interval": {
               "type": "string",
+              "description": "Scrape interval for the ServiceMonitor object",
               "default": "15s"
             },
             "relabelings": {
@@ -551,6 +560,41 @@
           "type": "boolean",
           "description": "Enable metrics collection for the node pods",
           "default": false
+        },
+        "enablePrometheusAnnotations": {
+          "type": "boolean",
+          "description": "If metrics are enabled, add prometheus.io/scrape and prometheus.io/port annotations to the metrics services",
+          "default": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "description": "Parameters to configure the ServiceMonitor for the EBS CSI node pods",
+          "additionalProperties": false,
+          "properties": {
+            "forceEnable": {
+              "type": "boolean",
+              "description": "Render ServiceMonitor object even when CRD is not detected",
+              "default": false
+            },
+            "labels": {
+              "type": "object",
+              "description": "Additional labels for ServiceMonitor object",
+              "default": {}
+            },
+            "interval": {
+              "type": "string",
+              "description": "Scrape interval for the ServiceMonitor object",
+              "default": "15s"
+            },
+            "relabelings": {
+              "type": "array",
+              "description": "Additional relabeling configurations for ServiceMonitor",
+              "default": [],
+              "items": {
+                "type": "object"
+              }
+            }
+          }
         },
         "enableWindows": {
           "type": "boolean",

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -234,12 +234,14 @@ controller:
   # The default is empty string, which means metrics endpoint is disabled.
   # ---
   enableMetrics: false
+  # If metrics are enabled, add prometheus.io/scrape and prometheus.io/port
+  # annotations to the metrics services.
+  enablePrometheusAnnotations: true
   serviceMonitor:
     # Enables the ServiceMonitor resource even if the prometheus-operator CRDs are not installed
     forceEnable: false
     # Additional labels for ServiceMonitor object
-    labels:
-      release: prometheus
+    labels: {}
     interval: "15s"
   # If set to true, AWS API call metrics will be exported to the following
   # TCP endpoint: "0.0.0.0:3301"
@@ -356,6 +358,15 @@ node:
   loggingFormat: text
   logLevel: 2
   enableMetrics: false
+  # If metrics are enabled, add prometheus.io/scrape and prometheus.io/port
+  # annotations to the metrics services.
+  enablePrometheusAnnotations: true
+  serviceMonitor:
+    # Enables the ServiceMonitor resource even if the prometheus-operator CRDs are not installed
+    forceEnable: false
+    # Additional labels for ServiceMonitor object
+    labels: {}
+    interval: "15s"
   priorityClassName:
   additionalArgs: []
   affinity:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

The goal of this PR is to make the metrics experience between the node and controller consistent, via these changes:
- Enable sidecar metrics in `controller.enableMetrics`
- Add appropriate `prometheus.io/scrape` and `prometheus.io/port` to the controller metrics service (Included a parameter to disable this if needed, as otherwise it could result in double scrapes like @sidewinder12s mentions below)
- Add a `ServiceMonitor` object for the node metrics
- Set default additional labels for both `ServiceMonitor` objects to an empty object (instead of setting a `release` label which is likely to be confusing to Helm users)
- Update `metrics.md` to remove confusing or incorrect information, and greatly improve clarity

Fixes #2556 

#### How was this change tested?

Check new serives and service monitors:
```
$ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set controller.enableMetrics=true --set controller.serviceMonitor.forceEnable=true --set node.enableMetrics=true --set node.serviceMonitor.forceEnable=true -s templates/metrics.yaml 
---
# Source: aws-ebs-csi-driver/templates/metrics.yaml
apiVersion: v1
kind: Service
metadata:
  name: ebs-csi-controller
  namespace: default
  labels:
    app: ebs-csi-controller
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "3301"
spec:
  selector:
    app: ebs-csi-controller
  ports:
    - name: metrics
      port: 3301
      targetPort: 3301
  type: ClusterIP
... VERY long, cut for brevity, run locally to check full output ...
```

Check `enablePrometheusAnnotations` parameter:
```
$ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set node.enableMetrics=true --set node.enablePrometheusAnnotations=false -s templates/metrics.yaml 
---
# Source: aws-ebs-csi-driver/templates/metrics.yaml
apiVersion: v1
kind: Service
metadata:
  name: ebs-csi-node
  namespace: default
  labels:
    app: ebs-csi-node
spec:
  selector:
    app: ebs-csi-node
  ports:
    - name: metrics
      port: 3302
      targetPort: 3302
  type: ClusterIP
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Align node and controller metrics to consistent experience supporting `prometheus.io` annotations and `ServiceMonitor` objects for both; Enable sidecar metrics when controller metrics are enabled
```
