### PR TITLE
Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,10 @@ enable-beta-ecosystems: true
 updates:
   - package-ecosystem: gomod
     directories: ["/", "/tests/e2e/"]
+    groups:
+      all:
+        patterns:
+          - "*"
     schedule:
       interval: weekly
       day: "wednesday"
@@ -28,6 +32,10 @@ updates:
       - "release-note-none"
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      all:
+        patterns:
+          - "*"
     schedule:
       interval: weekly
       # Wednesday chosen to minimize time after Windows Patch Tuesdays


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Fixes a mistake in #2557 - by default dependabot has _no_ grouping, so we are getting 1 PR for each dependency upgrade right now.

#### How was this change tested?

:shrug: the dependabot experience

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
