### PR TITLE
Add blockAttachUntilInitialized SC parameter

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -266,7 +266,7 @@ spec:
           imagePullPolicy: {{ default .Values.image.pullPolicy .Values.sidecars.attacher.image.pullPolicy }}
           args:
             {{- if not (regexMatch "(-timeout)" (join " " .Values.sidecars.attacher.additionalArgs)) }}
-            - --timeout=60s
+            - --timeout=6m
             {{- end }}
             - --csi-address=$(ADDRESS)
             - --v={{ .Values.sidecars.attacher.logLevel }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -169,7 +169,7 @@ spec:
           image: public.ecr.aws/csi-components/csi-attacher:v4.9.0-eksbuild.3
           imagePullPolicy: IfNotPresent
           args:
-            - --timeout=60s
+            - --timeout=6m
             - --csi-address=$(ADDRESS)
             - --v=2
             - --leader-election=true

--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -9,7 +9,8 @@
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications"
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus"
       ],
       "Resource": "*"
     },

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.231.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0
 	github.com/aws/smithy-go v1.22.4
 	github.com/awslabs/volume-modifier-for-k8s v0.7.0
 	github.com/container-storage-interface/spec v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 h1:i2vNHQiXUvKhs3quBR
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36/go.mod h1:UdyGa7Q91id/sdyHPwth+043HhmP6yP9MBHgbZM0xo8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.231.0 h1:uhIwvt6crp2kQenKojfDShGw39WEIrtPRfYZ3FAFlJk=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.231.0/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0 h1:UPPzQR5eKqKWNRdGh1YLNYvUftQL5YH+Jawr0gp2dM0=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 h1:t0E6FzREdtCsiLIoLCWsYliNsRBgyGD/MCK571qk4MI=

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -35,7 +35,8 @@ spec:
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",
             "ec2:DescribeVolumes",
-            "ec2:DescribeVolumesModifications"
+            "ec2:DescribeVolumesModifications",
+            "ec2:DescribeVolumeStatus"
           ],
           "Resource": "*"
         },

--- a/pkg/cloud/ec2_interface.go
+++ b/pkg/cloud/ec2_interface.go
@@ -22,6 +22,7 @@ import (
 
 type EC2API interface {
 	DescribeVolumes(ctx context.Context, params *ec2.DescribeVolumesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error)
+	DescribeVolumeStatus(ctx context.Context, params *ec2.DescribeVolumeStatusInput, optFns ...func(options *ec2.Options)) (*ec2.DescribeVolumeStatusOutput, error)
 	CreateVolume(ctx context.Context, params *ec2.CreateVolumeInput, optFns ...func(*ec2.Options)) (*ec2.CreateVolumeOutput, error)
 	DeleteVolume(ctx context.Context, params *ec2.DeleteVolumeInput, optFns ...func(*ec2.Options)) (*ec2.DeleteVolumeOutput, error)
 	AttachVolume(ctx context.Context, params *ec2.AttachVolumeInput, optFns ...func(*ec2.Options)) (*ec2.AttachVolumeOutput, error)

--- a/pkg/cloud/interface.go
+++ b/pkg/cloud/interface.go
@@ -29,6 +29,7 @@ type Cloud interface {
 	ModifyTags(ctx context.Context, volumeID string, tagOptions ModifyTagsOptions) (err error)
 	ResizeOrModifyDisk(ctx context.Context, volumeID string, newSizeBytes int64, options *ModifyDiskOptions) (newSize int32, err error)
 	WaitForAttachmentState(ctx context.Context, expectedState types.VolumeAttachmentState, volumeID string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*types.VolumeAttachment, error)
+	IsVolumeInitialized(ctx context.Context, volumeID string) (bool, error)
 	GetDiskByName(ctx context.Context, name string, capacityBytes int64) (disk *Disk, err error)
 	GetDiskByID(ctx context.Context, volumeID string) (disk *Disk, err error)
 	CreateSnapshot(ctx context.Context, volumeID string, snapshotOptions *SnapshotOptions) (snapshot *Snapshot, err error)

--- a/pkg/cloud/mock_cloud.go
+++ b/pkg/cloud/mock_cloud.go
@@ -215,6 +215,21 @@ func (mr *MockCloudMockRecorder) GetSnapshotByName(ctx, name interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshotByName", reflect.TypeOf((*MockCloud)(nil).GetSnapshotByName), ctx, name)
 }
 
+// IsVolumeInitialized mocks base method.
+func (m *MockCloud) IsVolumeInitialized(ctx context.Context, volumeID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsVolumeInitialized", ctx, volumeID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsVolumeInitialized indicates an expected call of IsVolumeInitialized.
+func (mr *MockCloudMockRecorder) IsVolumeInitialized(ctx, volumeID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsVolumeInitialized", reflect.TypeOf((*MockCloud)(nil).IsVolumeInitialized), ctx, volumeID)
+}
+
 // ListSnapshots mocks base method.
 func (m *MockCloud) ListSnapshots(ctx context.Context, volumeID string, maxResults int32, nextToken string) (*ListSnapshotsResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/mock_ec2.go
+++ b/pkg/cloud/mock_ec2.go
@@ -255,6 +255,26 @@ func (mr *MockEC2APIMockRecorder) DescribeTags(ctx, params interface{}, optFns .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTags", reflect.TypeOf((*MockEC2API)(nil).DescribeTags), varargs...)
 }
 
+// DescribeVolumeStatus mocks base method.
+func (m *MockEC2API) DescribeVolumeStatus(ctx context.Context, params *ec2.DescribeVolumeStatusInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumeStatusOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeVolumeStatus", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeVolumeStatusOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeVolumeStatus indicates an expected call of DescribeVolumeStatus.
+func (mr *MockEC2APIMockRecorder) DescribeVolumeStatus(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeStatus", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeStatus), varargs...)
+}
+
 // DescribeVolumes mocks base method.
 func (m *MockEC2API) DescribeVolumes(ctx context.Context, params *ec2.DescribeVolumesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeVolumesOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -108,6 +108,9 @@ const (
 
 	// OutpostArn represents key for outpost's arn.
 	OutpostArnKey = "outpostarn"
+
+	// BlockAttachUntilInitializedKey will prevent restored volume from being attached until it is fully initialized.
+	BlockAttachUntilInitializedKey = "blockattachuntilinitialized"
 )
 
 // constants of keys in snapshot parameters.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/url"
@@ -26,6 +27,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 )
@@ -167,4 +169,17 @@ func SanitizeRequest(req interface{}) interface{} {
 		v.Set(e)
 	}
 	return req
+}
+
+// WaitUntilTimeOrContext returns once time wakeup has elapsed or ctx is done.
+func WaitUntilTimeOrContext(ctx context.Context, wakeup time.Time) {
+	now := time.Now()
+	if wakeup.Before(now) {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Until(wakeup)):
+	}
 }

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -3,7 +3,7 @@ module github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.231.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/kubernetes-sigs/aws-ebs-csi-driver v1.45.0

--- a/tests/e2e/go.sum
+++ b/tests/e2e/go.sum
@@ -28,8 +28,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 h1:i2vNHQiXUvKhs3quBR
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36/go.mod h1:UdyGa7Q91id/sdyHPwth+043HhmP6yP9MBHgbZM0xo8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.231.0 h1:uhIwvt6crp2kQenKojfDShGw39WEIrtPRfYZ3FAFlJk=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.231.0/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0 h1:UPPzQR5eKqKWNRdGh1YLNYvUftQL5YH+Jawr0gp2dM0=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.232.0/go.mod h1:35jGWx7ECvCwTsApqicFYzZ7JFEnBc6oHUuOQ3xIS54=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 h1:t0E6FzREdtCsiLIoLCWsYliNsRBgyGD/MCK571qk4MI=

--- a/tests/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_volume_snapshot_tester.go
@@ -49,7 +49,7 @@ func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(client clientset.Interfac
 	By("deploying the pod")
 	tpod.Create()
 	defer tpod.Cleanup()
-	By("checking that the pods command exits with no error")
+	By("checking that the pod's command exits with no error")
 	tpod.WaitForSuccess()
 
 	By("taking snapshots")
@@ -72,9 +72,10 @@ func (t *DynamicallyProvisionedVolumeSnapshotTest) Run(client clientset.Interfac
 	By("deploying a second pod with a volume restored from the snapshot")
 	trpod.Create()
 	defer trpod.Cleanup()
-	By("checking that the pods command exits with no error")
+	By("checking that the second pod's command exits with no error")
 	trpod.WaitForSuccess()
 
+	By("validating that expected events happened via AWS API")
 	if t.ValidateFunc != nil {
 		t.ValidateFunc(snapshot)
 	}

--- a/tests/sanity/fake_sanity_cloud.go
+++ b/tests/sanity/fake_sanity_cloud.go
@@ -217,3 +217,7 @@ func (d *fakeCloud) ModifyTags(ctx context.Context, volumeID string, tagOptions 
 func (d *fakeCloud) WaitForAttachmentState(ctx context.Context, expectedState types.VolumeAttachmentState, volumeID string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*types.VolumeAttachment, error) {
 	return &types.VolumeAttachment{}, nil
 }
+
+func (d *fakeCloud) IsVolumeInitialized(ctx context.Context, volumeID string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Allows users to delay ControllerPublishVolume success (and therefore start of workload) until a volume restored from snapshot is fully initialized. 

This is achieved by polling `EC2 DescribeVolumeStatus` after volume attached. 

If feature is popular, In future we may add:
- ability to override blocking via VAC parameter
- Parallel polling for volume attachment and for volume initialized

#### How was this change tested?

- Our new E2E test (initialization rate + blockAttachUntilInitialized)
- Manually testing blockAttachUntilInitialized on volume restored from snapshot WITHOUT initializationRate
- Manually testing blockAttachUntilInitialized on non-restored volume

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Added StorageClass parameter 'blockAttachUntilInitialized' for users who want to delay ControllerPublishVolume success (and therefore start of workload) until a volume restored from snapshot is fully initialized 
```
