### PR TITLE
Add null to `nodeAllocatableUpdatePeriodSeconds.type` in Helm schema

### DIFF
--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -107,7 +107,7 @@
       "default": false
     },
     "nodeAllocatableUpdatePeriodSeconds": {
-      "type": "integer",
+      "type": ["integer", "null"],
       "description": "nodeAllocatableUpdatePeriodSeconds updates the node's max attachable volume count by directing Kubelet to periodically call NodeGetInfo at the configured interval. Kubernetes enforces a minimum update interval of 10 seconds. This parameter is supported in Kubernetes 1.33+, the MutableCSINodeAllocatableCount feature gate must be enabled in kubelet and kube-apiserver.",
       "default": 10
     },


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Users can disable rendering the `nodeAllocatableUpdatePeriodSeconds` field in the CSIDriver object by setting `nodeAllocatableUpdatePeriodSeconds: 0`. With this patch, the field can be disabled by setting `nodeAllocatableUpdatePeriodSeconds: null` as well.

#### How was this change tested?

Setting `nodeAllocatableUpdatePeriodSeconds: null` in values.yaml and rendering the chart:

```
helm template driver ./charts/aws-ebs-csi-driver -s templates/csidriver.yaml    
---
# Source: aws-ebs-csi-driver/templates/csidriver.yaml
apiVersion: storage.k8s.io/v1
kind: CSIDriver
metadata:
  name: ebs.csi.aws.com
  labels:
    app.kubernetes.io/name: aws-ebs-csi-driver
    app.kubernetes.io/instance: driver
    helm.sh/chart: aws-ebs-csi-driver-2.46.0
    app.kubernetes.io/version: "1.46.0"
    app.kubernetes.io/component: csi-driver
    app.kubernetes.io/managed-by: Helm
spec:
  attachRequired: true
  podInfoOnMount: false
  fsGroupPolicy: File
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Allow `null` to be set for `nodeAllocatableUpdatePeriodSeconds.type` in Helm schema
```
