### PR TITLE
Bump cloudbuild to machine type with 32GB of RAM

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,3 +20,5 @@ steps:
       - GIT_TAG=${_GIT_TAG}
       - PULL_BASE_REF=${_PULL_BASE_REF}
       - HOME=/root
+options:
+  machineType: E2_HIGHCPU_32


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Bumps the cloudbuild image, because our current jobs are timing out building the driver images for release.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
