### PR TITLE
Refactor NewCloud to remove needless redirection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -200,11 +200,7 @@ func main() {
 		}
 	}
 
-	cloud, err := cloud.NewCloud(region, accountID, options.AwsSdkDebugLog, options.UserAgentExtra, options.Batching, options.DeprecatedMetrics)
-	if err != nil {
-		klog.ErrorS(err, "failed to create cloud service")
-		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
-	}
+	cloud := cloud.NewCloud(region, accountID, options.AwsSdkDebugLog, options.UserAgentExtra, options.Batching, options.DeprecatedMetrics)
 
 	m, err := mounter.NewNodeMounter(options.WindowsHostProcess)
 	if err != nil {

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -337,12 +337,7 @@ var _ Cloud = &cloud{}
 
 // NewCloud returns a new instance of AWS cloud
 // It panics if session is invalid.
-func NewCloud(region string, accountID string, awsSdkDebugLog bool, userAgentExtra string, batching bool, deprecatedMetrics bool) (Cloud, error) {
-	c := newEC2Cloud(region, accountID, awsSdkDebugLog, userAgentExtra, batching, deprecatedMetrics)
-	return c, nil
-}
-
-func newEC2Cloud(region string, accountID string, awsSdkDebugLog bool, userAgentExtra string, batchingEnabled bool, deprecatedMetrics bool) Cloud {
+func NewCloud(region string, accountID string, awsSdkDebugLog bool, userAgentExtra string, batchingEnabled bool, deprecatedMetrics bool) Cloud {
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
 	if err != nil {
 		panic(err)
@@ -386,7 +381,7 @@ func newEC2Cloud(region string, accountID string, awsSdkDebugLog bool, userAgent
 
 	var bm *batcherManager
 	if batchingEnabled {
-		klog.V(4).InfoS("newEC2Cloud: batching enabled")
+		klog.V(4).InfoS("NewCloud: batching enabled")
 		bm = newBatcherManager(svc)
 	}
 

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -116,10 +116,7 @@ func TestNewCloud(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		ec2Cloud, err := NewCloud(tc.region, tc.accountID, tc.awsSdkDebugLog, tc.userAgentExtra, tc.batchingEnabled, tc.deprecatedMetrics)
-		if err != nil {
-			t.Fatalf("error %v", err)
-		}
+		ec2Cloud := NewCloud(tc.region, tc.accountID, tc.awsSdkDebugLog, tc.userAgentExtra, tc.batchingEnabled, tc.deprecatedMetrics)
 		ec2CloudAscloud, ok := ec2Cloud.(*cloud)
 		if !ok {
 			t.Fatalf("could not assert object ec2Cloud as cloud type, %v", ec2Cloud)

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -621,10 +621,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
-		cloud, err := awscloud.NewCloud(region, "", false, "", true, false)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
-		}
+		cloud := awscloud.NewCloud(region, "", false, "", true, false)
 
 		test := testsuites.DynamicallyProvisionedReclaimPolicyTest{
 			CSIDriver: ebsDriver,

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -87,10 +87,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Tags:             map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region, "", false, "", true, false)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
-		}
+		cloud = awscloud.NewCloud(region, "", false, "", true, false)
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
 		disk, err := cloud.CreateDisk(context.Background(), fmt.Sprintf("pvc-%d", r1.Uint64()), diskOptions)
 		if err != nil {
@@ -260,10 +257,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 			Tags:               map[string]string{awscloud.VolumeNameTagKey: dummyVolumeName, awscloud.AwsEbsDriverTagKey: "true"},
 		}
 		var err error
-		cloud, err = awscloud.NewCloud(region, "", false, "", true, false)
-		if err != nil {
-			Fail(fmt.Sprintf("could not get NewCloud: %v", err))
-		}
+		cloud = awscloud.NewCloud(region, "", false, "", true, false)
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
 		disk, err := cloud.CreateDisk(context.Background(), fmt.Sprintf("pvc-%d", r1.Uint64()), diskOptions)
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

No need to double wrap the function. Creating a new cloud does not error at the moment. 

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
