### PR TITLE
Add debugLogs parameter to helm chart

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -88,7 +88,11 @@ spec:
             {{- with .Values.node.loggingFormat }}
             - --logging-format={{ . }}
             {{- end }}
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.node.logLevel }}
+            {{- end }}
             {{- if .Values.node.otelTracing }}
             - --enable-otel-tracing=true
             {{- end}}
@@ -181,7 +185,11 @@ spec:
           {{- if .Values.node.windowsHostProcess }}
             - --plugin-registration-path=$(PLUGIN_REG_DIR)
           {{- end }}
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.nodeDriverRegistrar.logLevel }}
+            {{- end }}
           env:
             - name: ADDRESS
             {{- if .Values.node.windowsHostProcess }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -92,7 +92,11 @@ spec:
             {{- with .Values.node.loggingFormat }}
             - --logging-format={{ . }}
             {{- end }}
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.node.logLevel }}
+            {{- end }}
             {{- if .Values.node.otelTracing }}
             - --enable-otel-tracing=true
             {{- end}}
@@ -181,7 +185,11 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.nodeDriverRegistrar.logLevel }}
+            {{- end }}
             {{- range .Values.sidecars.nodeDriverRegistrar.additionalArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -88,7 +88,7 @@ spec:
             {{- with .Values.controller.httpEndpoint }}
             - --http-endpoint={{ . }}
             {{- end }}
-            {{- if .Values.controller.sdkDebugLog }}
+            {{- if or .Values.controller.sdkDebugLog .Values.debugLogs }}
             - --aws-sdk-debug-log=true
             {{- end}}
             {{- if .Values.controller.batching }}
@@ -103,7 +103,11 @@ spec:
             {{- if .Values.controller.otelTracing }}
             - --enable-otel-tracing=true
             {{- end}}
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.controller.logLevel }}
+            {{- end }}
             {{- range .Values.controller.additionalArgs }}
             - {{ . }}
             {{- end }}
@@ -211,7 +215,11 @@ spec:
             - --timeout=60s
             {{- end }}
             - --csi-address=$(ADDRESS)
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.provisioner.logLevel }}
+            {{- end }}
             - --feature-gates=Topology=true
             {{- if .Values.controller.extraCreateMetadata }}
             - --extra-create-metadata
@@ -275,7 +283,11 @@ spec:
             - --timeout=6m
             {{- end }}
             - --csi-address=$(ADDRESS)
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.attacher.logLevel }}
+            {{- end }}
             - --leader-election={{ .Values.sidecars.attacher.leaderElection.enabled | required "leader election state for csi-attacher is required, must be set to true || false." }}
             {{- if .Values.sidecars.attacher.leaderElection.enabled }}
             {{- if .Values.sidecars.attacher.leaderElection.leaseDuration }}
@@ -330,7 +342,11 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.snapshotter.logLevel }}
+            {{- end }}
             {{- if .Values.controller.extraCreateMetadata }}
             - --extra-create-metadata
             {{- end}}
@@ -379,7 +395,11 @@ spec:
             - --timeout=60s
             {{- end }}
             - --csi-address=$(ADDRESS)
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.volumemodifier.logLevel }}
+            {{- end }}
             - --leader-election={{ .Values.sidecars.volumemodifier.leaderElection.enabled | required "leader election state for csi-volumemodifier is required, must be set to true || false." }}
             {{- if .Values.sidecars.volumemodifier.leaderElection.enabled }}
             {{- if .Values.sidecars.volumemodifier.leaderElection.leaseDuration }}
@@ -439,7 +459,11 @@ spec:
             - --extra-modify-metadata
             {{- end}}
             - --csi-address=$(ADDRESS)
+            {{- if .Values.debugLogs }}
+            - --v=7
+            {{- else }}
             - --v={{ .Values.sidecars.resizer.logLevel }}
+            {{- end }}
             - --handle-volume-inuse-error=false
             {{- with .Values.sidecars.resizer.leaderElection }}
             - --leader-election={{ .enabled | default true }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -126,6 +126,11 @@
       "description": "Instruct the AWS SDK to use AWS FIPS endpoints, and deploy container built with BoringCrypto (a FIPS-validated cryptographic library) instead of the Go default. The EBS CSI Driver FIPS images have not undergone FIPS certification, and no official guarantee is made about the compliance of these images under the FIPS standard. Users relying on these images for FIPS compliance should perform their own independent evaluation",
       "default": "false"
     },
+    "debugLogs": {
+      "type": "boolean",
+      "description": "Set maximum verbosity for logs of each container and other recommended debugging parameters such as enabling AWS SDK debug logging",
+      "default": "false"
+    },
     "fullnameOverride": {
       "type": ["string", "null"],
       "default": ""

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -513,6 +513,8 @@ useOldCSIDriver: false
 nodeAllocatableUpdatePeriodSeconds: 10
 # Deploy EBS CSI Driver without controller and associated resources
 nodeComponentOnly: false
+# Set maximum verbosity for logs of each container and other recommended debugging parameters such as enabling AWS SDK debug logging
+debugLogs: false
 helmTester:
   enabled: true
   # Supply a custom image to the ebs-csi-driver-test pod in helm-tester.yaml


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Let customers easily show debug logs of all containers from add-on/helm installation. 

#### How was this change tested?

```
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver | grep "v="
            - --v=2
            - --v=2
            - --v=2
            - --v=2
            - --v=2
            - --v=2
            - --v=2
            - --v=2
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set debugLogs=true | grep "v="
            - --v=7
            - --v=7
            - --v=7
            - --v=7
            - --v=7
            - --v=7
            - --v=7
            - --v=7
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set debugLogs=true | grep "sdk"
            - --aws-sdk-debug-log=true
❯ helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set debugLogs=false | grep "sdk"
<NOTHING>
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add debugLogs helm parameter to turn on maximum verbosity for each EBS CSI Driver container
```
