### PR TITLE
Enable std-error-handling linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,6 @@ linters:
       - comments
       - common-false-positives
       - legacy
-      - std-error-handling
     rules:
       # gosec recommends ignoring test files
       - linters:

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -355,9 +355,13 @@ func NewCloud(region string, awsSdkDebugLog bool, userAgentExtra string, batchin
 
 	// Set the env var so that the session appends custom user agent string
 	if userAgentExtra != "" {
-		os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion+"-"+userAgentExtra)
+		if err := os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion+"-"+userAgentExtra); err != nil {
+			klog.ErrorS(err, "Failed to set AWS_EXECUTION_ENV")
+		}
 	} else {
-		os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion)
+		if err := os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion); err != nil {
+			klog.ErrorS(err, "Failed to set AWS_EXECUTION_ENV")
+		}
 	}
 
 	svc := ec2.NewFromConfig(cfg, func(o *ec2.Options) {

--- a/pkg/metrics/nvme.go
+++ b/pkg/metrics/nvme.go
@@ -287,7 +287,11 @@ func getNVMEMetrics(devicePath string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getNVMEMetrics: error opening device: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			klog.ErrorS(err, "Failed to close device file", "devicePath", devicePath)
+		}
+	}()
 
 	data, err := nvmeReadLogPage(f.Fd(), 0xD0)
 	if err != nil {

--- a/pkg/mounter/mount_linux_test.go
+++ b/pkg/mounter/mount_linux_test.go
@@ -20,7 +20,6 @@ package mounter
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -85,15 +84,7 @@ func TestNeedResize(t *testing.T) {
 
 func TestMakeDir(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := os.MkdirTemp("", "mount-ebs-csi")
-	if err != nil {
-		t.Fatalf("error creating directory %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("Failed to remove temp directory: %v", err)
-		}
-	}()
+	dir := t.TempDir()
 
 	targetPath := filepath.Join(dir, "targetdir")
 
@@ -117,15 +108,7 @@ func TestMakeDir(t *testing.T) {
 
 func TestMakeFile(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := os.MkdirTemp("", "mount-ebs-csi")
-	if err != nil {
-		t.Fatalf("error creating directory %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("Failed to remove temp directory: %v", err)
-		}
-	}()
+	dir := t.TempDir()
 
 	targetPath := filepath.Join(dir, "targetfile")
 
@@ -149,15 +132,7 @@ func TestMakeFile(t *testing.T) {
 
 func TestPathExists(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := os.MkdirTemp("", "mount-ebs-csi")
-	if err != nil {
-		t.Fatalf("error creating directory %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("Failed to remove temp directory: %v", err)
-		}
-	}()
+	dir := t.TempDir()
 
 	targetPath := filepath.Join(dir, "notafile")
 
@@ -179,15 +154,7 @@ func TestPathExists(t *testing.T) {
 
 func TestGetDeviceName(t *testing.T) {
 	// Setup the full driver and its environment
-	dir, err := os.MkdirTemp("", "mount-ebs-csi")
-	if err != nil {
-		t.Fatalf("error creating directory %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("Failed to remove temp directory: %v", err)
-		}
-	}()
+	dir := t.TempDir()
 
 	targetPath := filepath.Join(dir, "notafile")
 

--- a/pkg/mounter/mount_linux_test.go
+++ b/pkg/mounter/mount_linux_test.go
@@ -89,7 +89,11 @@ func TestMakeDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	targetPath := filepath.Join(dir, "targetdir")
 
@@ -117,7 +121,11 @@ func TestMakeFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	targetPath := filepath.Join(dir, "targetfile")
 
@@ -145,7 +153,11 @@ func TestPathExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	targetPath := filepath.Join(dir, "notafile")
 
@@ -171,7 +183,11 @@ func TestGetDeviceName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating directory %v", err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	targetPath := filepath.Join(dir, "notafile")
 

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -46,7 +46,11 @@ func TestSanity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create sanity temp working dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("Failed to remove temp directory: %v", err)
+		}
+	}()
 
 	defer func() {
 		if err = os.RemoveAll(tmpDir); err != nil {

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -18,7 +18,6 @@ package sanity
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -42,21 +41,7 @@ func TestSanity(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	tmpDir, err := os.MkdirTemp("", "csi-sanity-")
-	if err != nil {
-		t.Fatalf("Failed to create sanity temp working dir: %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			t.Logf("Failed to remove temp directory: %v", err)
-		}
-	}()
-
-	defer func() {
-		if err = os.RemoveAll(tmpDir); err != nil {
-			t.Fatalf("Failed to clean up sanity temp working dir %s: %v", tmpDir, err.Error())
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	endpoint := fmt.Sprintf("unix:%s/csi.sock", tmpDir)
 	mountPath := path.Join(tmpDir, "mount")


### PR DESCRIPTION
/hold
#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

This PR enables the `std-error-handling` checker in the Gosec linter. It also fixes issues caught by the checker:

```
pkg/cloud/cloud.go:358:12: Error return value of `os.Setenv` is not checked (errcheck)
		os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion+"-"+userAgentExtra)
		         ^
pkg/cloud/cloud.go:360:12: Error return value of `os.Setenv` is not checked (errcheck)
		os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion)
		         ^
pkg/metrics/nvme.go:290:15: Error return value of `f.Close` is not checked (errcheck)
	defer f.Close()
	             ^
pkg/mounter/mount_linux_test.go:92:20: Error return value of `os.RemoveAll` is not checked (errcheck)
	defer os.RemoveAll(dir)
	                  ^
pkg/mounter/mount_linux_test.go:120:20: Error return value of `os.RemoveAll` is not checked (errcheck)
	defer os.RemoveAll(dir)
	                  ^
pkg/mounter/mount_linux_test.go:148:20: Error return value of `os.RemoveAll` is not checked (errcheck)
	defer os.RemoveAll(dir)
```

#### How was this change tested?

```
make verify && make test
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
