### PR TITLE
Ensure codebase uses DriverName constant instead of ebs.csi.aws.com

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -115,7 +115,7 @@ const (
 	// KubernetesTagKeyPrefix is the prefix of the key value that is reserved for Kubernetes.
 	KubernetesTagKeyPrefix = "kubernetes.io"
 	// AwsEbsDriverTagKey is the tag to identify if a volume/snapshot is managed by ebs csi driver.
-	AwsEbsDriverTagKey = "ebs.csi.aws.com/cluster"
+	AwsEbsDriverTagKey = util.DriverName + "/cluster"
 )
 
 // Batcher.

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package driver
 
-import "time"
+import (
+	"time"
+
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+)
 
 // constants of keys in PublishContext.
 const (
@@ -181,7 +185,7 @@ const (
 // constants for node k8s API use.
 const (
 	// AgentNotReadyNodeTaintKey contains the key of taints to be removed on driver startup.
-	AgentNotReadyNodeTaintKey = "ebs.csi.aws.com/agent-not-ready"
+	AgentNotReadyNodeTaintKey = util.DriverName + "/agent-not-ready"
 )
 
 type fileSystemConfig struct {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -46,14 +46,13 @@ const (
 )
 
 const (
-	DriverName               = "ebs.csi.aws.com"
-	AwsPartitionKey          = "topology." + DriverName + "/partition"
-	AwsAccountIDKey          = "topology." + DriverName + "/account-id"
-	AwsRegionKey             = "topology." + DriverName + "/region"
-	AwsOutpostIDKey          = "topology." + DriverName + "/outpost-id"
+	AwsPartitionKey          = "topology." + util.DriverName + "/partition"
+	AwsAccountIDKey          = "topology." + util.DriverName + "/account-id"
+	AwsRegionKey             = "topology." + util.DriverName + "/region"
+	AwsOutpostIDKey          = "topology." + util.DriverName + "/outpost-id"
 	WellKnownZoneTopologyKey = "topology.kubernetes.io/zone"
 	// Deprecated: Use the WellKnownZoneTopologyKey instead.
-	ZoneTopologyKey = "topology." + DriverName + "/zone"
+	ZoneTopologyKey = "topology." + util.DriverName + "/zone"
 	// This name is purposefully consistent with the CCM's ZoneID topology key.
 	// This key is only used for provisioning by az-id and will not be used for node topology
 	// to prevent any backwards compatibility issues.
@@ -70,7 +69,7 @@ type Driver struct {
 }
 
 func NewDriver(c cloud.Cloud, o *Options, m mounter.Mounter, md metadata.MetadataService, k kubernetes.Interface) (*Driver, error) {
-	klog.InfoS("Driver Information", "Driver", DriverName, "Version", driverVersion)
+	klog.InfoS("Driver Information", "Driver", util.DriverName, "Version", driverVersion)
 
 	if err := ValidateDriverOptions(o); err != nil {
 		return nil, fmt.Errorf("invalid driver options: %w", err)

--- a/pkg/driver/identity.go
+++ b/pkg/driver/identity.go
@@ -20,13 +20,14 @@ import (
 	"context"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"k8s.io/klog/v2"
 )
 
 func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	klog.V(6).InfoS("GetPluginInfo: called", "args", req)
 	resp := &csi.GetPluginInfoResponse{
-		Name:          DriverName,
+		Name:          util.DriverName,
 		VendorVersion: driverVersion,
 	}
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -1025,7 +1025,7 @@ func checkAllocatable(ctx context.Context, clientset kubernetes.Interface, nodeN
 	}
 
 	for _, driver := range csiNode.Spec.Drivers {
-		if driver.Name == DriverName {
+		if driver.Name == util.DriverName {
 			if driver.Allocatable != nil && driver.Allocatable.Count != nil {
 				klog.InfoS("CSINode Allocatable value is set", "nodeName", nodeName, "count", *driver.Allocatable.Count)
 				return nil

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/mounter"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -2582,7 +2583,7 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 					Spec: v1.CSINodeSpec{
 						Drivers: []v1.CSINodeDriver{
 							{
-								Name: DriverName,
+								Name: util.DriverName,
 								Allocatable: &v1.VolumeNodeResources{
 									Count: &count,
 								},
@@ -2638,7 +2639,7 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 					Spec: v1.CSINodeSpec{
 						Drivers: []v1.CSINodeDriver{
 							{
-								Name: DriverName,
+								Name: util.DriverName,
 								Allocatable: &v1.VolumeNodeResources{
 									Count: &count,
 								},
@@ -2740,7 +2741,7 @@ func TestStartNotReadyTaintWatcher(t *testing.T) {
 				Spec: v1.CSINodeSpec{
 					Drivers: []v1.CSINodeDriver{
 						{
-							Name: DriverName,
+							Name: util.DriverName,
 							Allocatable: &v1.VolumeNodeResources{
 								Count: &count,
 							},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -33,6 +33,10 @@ import (
 )
 
 const (
+	// DriverName is the domain for all EBS CSI Driver related components.
+	// In util package to avoid cyclic dependency conflicts.
+	DriverName = "ebs.csi.aws.com"
+
 	GiB              = int64(1024 * 1024 * 1024)
 	DefaultBlockSize = 4096
 )

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -19,6 +19,7 @@ import (
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -37,7 +38,7 @@ type ebsCSIDriver struct {
 // InitEbsCSIDriver returns ebsCSIDriver that implements DynamicPVTestDriver interface.
 func InitEbsCSIDriver() PVTestDriver {
 	return &ebsCSIDriver{
-		driverName: ebscsidriver.DriverName,
+		driverName: util.DriverName,
 	}
 }
 

--- a/tests/e2e/testsuites/modify_volume_tester.go
+++ b/tests/e2e/testsuites/modify_volume_tester.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
 	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ func (modifyVolumeTest *ModifyVolumeTest) Run(c clientset.Interface, ns *v1.Name
 	testVolume, _ := volumeDetails.SetupDynamicPersistentVolumeClaim(c, ns, ebsDriver)
 	defer testVolume.Cleanup()
 
-	parametersWithPrefix := PrefixAnnotations("ebs.csi.aws.com/", modifyVolumeTest.ModifyVolumeParameters)
+	parametersWithPrefix := PrefixAnnotations(util.DriverName+"/", modifyVolumeTest.ModifyVolumeParameters)
 
 	By("deploying pod continuously writing to volume")
 	formatOptionMountPod := createPodWithVolume(c, ns, PodCmdContinuousWrite(DefaultMountPath), testVolume, volumeDetails)
@@ -79,7 +80,7 @@ func (modifyVolumeTest *ModifyVolumeTest) Run(c clientset.Interface, ns *v1.Name
 				Name:      formatOptionMountPod.pod.Name,
 				Namespace: ns.Name,
 			},
-			DriverName: "ebs.csi.aws.com",
+			DriverName: util.DriverName,
 			Parameters: modifyVolumeTest.ModifyVolumeParameters,
 		}, metav1.CreateOptions{})
 		framework.ExpectNoError(err)

--- a/tests/e2e/testsuites/testsuites.go
+++ b/tests/e2e/testsuites/testsuites.go
@@ -24,6 +24,7 @@ import (
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	snapshotclientset "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
 	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apps "k8s.io/api/apps/v1"
@@ -169,7 +170,7 @@ func (t *TestVolumeSnapshotClass) CreateStaticVolumeSnapshotContent(snapshotID s
 				Name:      volumeSnapshotNameStatic,
 				Namespace: t.namespace.Name,
 			},
-			Driver: "ebs.csi.aws.com",
+			Driver: util.DriverName,
 			Source: volumesnapshotv1.VolumeSnapshotContentSource{
 				SnapshotHandle: aws.String(snapshotID),
 			},
@@ -373,7 +374,7 @@ func (t *TestPersistentVolumeClaim) ValidateProvisionedPersistentVolume() {
 
 			keyFound := false
 			for _, v := range t.persistentVolume.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions {
-				if v.Key == "topology.ebs.csi.aws.com/zone" {
+				if v.Key == "topology"+util.DriverName+"/zone" {
 					keyFound = true
 					Expect(v.Key).To(Equal(t.storageClass.AllowedTopologies[0].MatchLabelExpressions[0].Key))
 				}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Remove a couple of hardcodings. Helpful ahead of #2591. 

#### How was this change tested?

```
❯ rg "ebs.csi.aws.com" --glob '!hack/' --glob '!charts/' --glob '!examples/' --glob '!*.yaml' --glob '!*.md' --glob '!*.json' | rg -v "//"
pkg/util/util.go:	DriverName = "ebs.csi.aws.com"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
