### PR TITLE
Run Helm release action on release branches, not master

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -17,7 +17,7 @@ name: Release Helm Charts
 on:
   push:
     branches:
-      - master
+      - 'release-*'
     paths:
       - "charts/**/Chart.yaml"
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Fixes Helm release action so we can correctly release patch releases.

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
