### PR TITLE
Autofix some golangci-lint errors in make update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test/coverage:
 tools: bin/aws bin/ct bin/eksctl bin/ginkgo bin/golangci-lint bin/gomplate bin/helm bin/kops bin/kubetest2 bin/mockgen bin/shfmt
 
 .PHONY: update
-update: update/gofix update/gofmt update/kustomize update/mockgen update/gomod update/shfmt update/generate-license-header
+update: update/gofix update/gofmt update/golangci-fix update/kustomize update/mockgen update/gomod update/shfmt update/generate-license-header
 	@echo "All updates succeeded!"
 
 .PHONY: verify
@@ -304,6 +304,12 @@ update/gofix:
 .PHONY: update/gofmt
 update/gofmt:
 	gofmt -s -w .
+
+.PHONY: update/golangci-fix
+update/golangci-fix: bin/golangci-lint
+ifndef SKIP_GOLANGCI_FIX
+	./bin/golangci-lint run --fix ./... || true
+endif
 
 .PHONY: update/kustomize
 update/kustomize: bin/helm

--- a/hack/verify-update.sh
+++ b/hack/verify-update.sh
@@ -25,7 +25,7 @@ TEST_DIR=$(mktemp -d)
 trap "rm -rf \"${TEST_DIR}\"" EXIT
 cp -rf "${ROOT}/." "${TEST_DIR}"
 
-if ! make -C "${TEST_DIR}" update >/dev/null; then
+if ! SKIP_GOLANGCI_FIX=true make -C "${TEST_DIR}" update >/dev/null; then
   echo "\`make update\` failed!"
   exit 1
 fi


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

golangci-lint has the ability to autofix many linter errors by adding the `--fix` flag. By running a version of this in make update we can reduce developer toil (and CI failures). 

#### How was this change tested?

Enjoy an easier life soon:

```
❯ git diff cmd
<WRONG IMPORT ORDER>

❯ make verify
go vet $(go list ./...)
./bin/golangci-lint run --timeout=10m --verbose
INFO golangci-lint has version 2.3.1 built with go1.24.5 from 5256574b on 2025-08-02T21:24:45Z
...
INFO [runner] linters took 977.720427ms with stages: goanalysis_metalinter: 968.993476ms
cmd/main.go:30:1: File is not properly formatted (gci)
	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/metrics"
^
1 issues:
* gci: 1
INFO File cache stats: 1 entries of total size 6.5KiB
INFO Memory: 19 samples, avg is 153.7MB, max is 753.1MB
INFO Execution took 1.781640987s
make: *** [verify/golangci-lint] Error 1

❯ make update
go fix ./...
gofmt -s -w .
[[ "" != "true" ]] && ./bin/golangci-lint run --fix ./... || true
0 issues.
./hack/update-kustomize.sh
./hack/update-mockgen.sh
go mod tidy
go mod tidy -C tests/e2e/
./bin/shfmt -w -i 2 -d ./hack/
./hack/generate-license-header.sh
Adding license header...
All updates succeeded!

❯ make verify
go vet $(go list ./...)
./bin/golangci-lint run --timeout=10m --verbose
INFO golangci-lint has version 2.3.1 built with go1.24.5 from 5256574b on 2025-08-02T21:24:45Z
...
INFO [runner] linters took 585.835444ms with stages: goanalysis_metalinter: 577.058235ms
0 issues.
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 13 samples, avg is 77.2MB, max is 142.2MB
INFO Execution took 1.152458069s
./hack/verify-update.sh
All verifications passed!
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
