### PR TITLE
Add rate limiting to /metrics endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
 	golang.org/x/sys v0.35.0
+	golang.org/x/time v0.12.0
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.7
 	k8s.io/api v0.33.4
@@ -97,7 +98,6 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250811230008-5f3141c8851a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811230008-5f3141c8851a // indirect


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

This PR adds rate limiting to the /metrics endpoint to prevent Layer 7 DoS attacks or request flooding that could saturate the server's connection pool. The implementation uses Go's token bucket rate limiter (5 requests/second with burst capacity of 10) that returns 429 when the limit is exceeded

#### How was this change tested?

Tested concurrent request scenario to validate rate limiting blocks excessive requests and endpoint remains responsive.

https://gist.github.com/torredil/7c9e6e0942479c11cd101e57aa45a602

```
Sending 50 concurrent requests...

Results:
Successful requests (200): 10
Rate limited requests (429): 40
Error requests: 0
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
The metrics endpoint now includes rate limiting (5 requests/second with burst of 10). Excessive requests will receive HTTP 429 responses.
```
