### PR TITLE
Makefile: Add validation to prevent Windows clusters with kOps

### DIFF
--- a/hack/e2e/create-cluster.sh
+++ b/hack/e2e/create-cluster.sh
@@ -29,6 +29,11 @@ source "${BASE_DIR}/util.sh"
 source "${BASE_DIR}/kops/kops.sh"
 source "${BASE_DIR}/eksctl/eksctl.sh"
 
+if [[ "${WINDOWS}" == "true" ]] && [[ "${CLUSTER_TYPE}" == "kops" ]]; then
+  echo "Error: Windows clusters are not supported with kops. Please set CLUSTER_TYPE=eksctl when WINDOWS=true" >&2
+  exit 1
+fi
+
 if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
   BUCKET_CHECK=$("${BIN}/aws" s3api head-bucket --region us-east-1 --bucket "${KOPS_BUCKET}" 2>&1 || true)
   if grep -q "Forbidden" <<<"${BUCKET_CHECK}"; then


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

Currently, running `make cluster/create` with `WINDOWS=true` and the default `CLUSTER_TYPE=kops` creates a cluster with no Windows nodes, which is confusing for developers expecting Windows support.

#### How was this change tested?

```
make cluster/create WINDOWS=true                                                                                                                                                                             
Error: Windows clusters are not supported with kops. Please set CLUSTER_TYPE=eksctl when WINDOWS=true
make: *** [cluster/create] Error 1
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
