### PR TITLE
Add environment variable to skip driver installation in E2E tests

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -78,7 +78,7 @@ if [[ "${EBS_INSTALL_SNAPSHOT}" == true ]]; then
   kubectl apply --kubeconfig "${KUBECONFIG}" -f - <<<${SNAPSHOT_CONTROLLER_MANIFEST}
 fi
 
-if [[ "${HELM_CT_TEST}" != true ]]; then
+if [[ "${HELM_CT_TEST}" != true ]] && [ -z "${SKIP_DRIVER_INSTALL+x}" ]; then
   startSec=$(date +'%s')
   install_driver
   endSec=$(date +'%s')
@@ -201,7 +201,9 @@ if [[ "${HELM_CT_TEST}" != true ]]; then
     kubectl get pods -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver" -o custom-columns="POD:.metadata.name,CONTAINER:.spec.containers[*].name,RESTARTS:.status.containerStatuses[*].restartCount" --kubeconfig "${KUBECONFIG}"
     TEST_PASSED=1
   fi
-  uninstall_driver
+  if [ -z "${SKIP_DRIVER_INSTALL+x}" ]; then
+    uninstall_driver
+  fi
 fi
 
 if [[ "${EBS_INSTALL_SNAPSHOT}" == true ]]; then


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Adds an option to skip installing the driver for E2E tests, allowing testing against an already installed driver

#### How was this change tested?

```
SKIP_DRIVER_INSTALL=true make e2e/external
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
