### PR TITLE
Fix service monitor for ebs-csi-node and ebs-csi-controller

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_metrics.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_metrics.tpl
@@ -43,7 +43,7 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
-    - targetPort: {{ .Port }}
+    - port: metrics
       path: /metrics
       interval: {{ .ServiceMonitor.interval | default "15s"}}
       {{- if .ServiceMonitor.relabelings }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What is this PR about? / Why do we need it?

Currently, the service monitor introduced in #2558 does not work correctly, because `targetPort` is used, but the ports are not specified on the Pod resources.
A ServiceMonitor has two ways to specify the port of the metrics endpoint. `port` is used for the port name of the Service, `targetPort` is used for the port number on the Pod. A ports used as `targetPort` also has to be specified in the port list of the Pod resource. Since this is not the case for ebs-csi-node and ebs-csi-controller, `port` has to be used.

If you prefer, I can also change the PR to keep using `targetPort` and add the correct port specifications to the Pods.

#### How was this change tested?

The change was tested by manually editing the ServiceMonitor to use `port`.

#### Does this PR introduce a user-facing change?
```release-note
Fix ServiceMonitor port discovery for ebs-csi-node and ebs-csi-controller
```
