### PR TITLE
Add containerPort spec for metrics endpoint

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -152,6 +152,11 @@ spec:
             - name: healthz
               containerPort: 9808
               protocol: TCP
+            {{- if .Values.node.enableMetrics }}
+            - name: metrics
+              containerPort: 3302
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -270,6 +270,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- if .Values.controller.enableMetrics }}
+          ports:
+            - name: metrics
+              containerPort: 3302
+              protocol: TCP
+          {{- end }}
           {{- with default .Values.controller.resources .Values.sidecars.provisioner.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -333,6 +339,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- if .Values.controller.enableMetrics }}
+          ports:
+            - name: metrics
+              containerPort: 3303
+              protocol: TCP
+          {{- end }}
           {{- with default .Values.controller.resources .Values.sidecars.attacher.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -386,6 +398,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- if .Values.controller.enableMetrics }}
+          ports:
+            - name: metrics
+              containerPort: 3306
+              protocol: TCP
+          {{- end }}
           {{- with default .Values.controller.resources .Values.sidecars.snapshotter.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -451,6 +469,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- if .Values.controller.enableMetrics }}
+          ports:
+            - name: metrics
+              containerPort: 3307
+              protocol: TCP
+          {{- end }}
           {{- with default .Values.controller.resources .Values.sidecars.volumemodifier.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -522,6 +546,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- if .Values.controller.enableMetrics }}
+          ports:
+            - name: metrics
+              containerPort: 3304
+              protocol: TCP
+          {{- end }}
           {{- with default .Values.controller.resources .Values.sidecars.resizer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -549,6 +579,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          {{- if .Values.controller.enableMetrics }}
+          ports:
+            - name: metrics
+              containerPort: 3305
+              protocol: TCP
+          {{- end }}
           {{- with default .Values.controller.resources .Values.sidecars.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

#closes #2653

#### How was this change tested?

Verified that all sidecar containers now have matching containerPort declarations, conditionally added only when enableMetrics is true.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Added containerPort declarations for containers in Helm chart to enable proper metrics discovery by monitoring systems
```