### PR TITLE
Remove AWS Snow Family Devices Deprecation Message

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/NOTES.txt
+++ b/charts/aws-ebs-csi-driver/templates/NOTES.txt
@@ -1,7 +1,3 @@
 To verify that aws-ebs-csi-driver has started, run:
 
     kubectl get pod -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "aws-ebs-csi-driver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
-
-[Deprecation announcement] AWS Snow Family device support for the EBS CSI Driver
-
-Support for the EBS CSI Driver on [AWS Snow Family devices](https://aws.amazon.com/snowball/) is deprecated, effective immediately. No further Snow-specific bugfixes or feature requests will be merged. The existing functionality for Snow devices has been removed on the 1.44 release of the EBS CSI Driver. Support of the EBS CSI Driver on other platforms, such as [Amazon EC2](https://aws.amazon.com/ec2/) or EC2 on [AWS Outposts](https://aws.amazon.com/outposts/) is not affected.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR removes the deprecation announcement for AWS Snow Family devices support on the driver, it has been on since version 1.40. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
