### PR TITLE
Upgrade kOps/CI to Kubernetes 1.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})
 CLUSTER_NAME?=ebs-csi-e2e.k8s.local
 CLUSTER_TYPE?=kops
 
-GINKGO_WINDOWS_SKIP?="\[Disruptive\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|\[Feature:VolumeSnapshotDataSource\]|\(xfs\)|\(ext4\)|\(block volmode\)"
+GINKGO_WINDOWS_SKIP?="\[Disruptive\]|\[Serial\]|\[Flaky\]|\[LinuxOnly\]|\[Feature:VolumeSnapshotDataSource\]|\(xfs\)|\(ext4\)|\(block volmode\)|should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished"
 GINKGO_BOTTLEROCKET_SKIP?="\[Disruptive\]|\[Serial\]|\[Flaky\]|should not mount / map unused volumes in a pod \[LinuxOnly\]"
 
 # split words on hyphen, access by 1-index

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -121,7 +121,7 @@ The AWS EBS CSI Driver supports the modifying of tags of existing volumes throug
 
 If a key has the prefix `tagSpecification`, the CSI driver will treat the value as a key-value pair to be added to the existing volume. If there is already an existing tag with the specified key, the CSI driver will overwrite the value of that tag with the new value specified. 
 ```
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: io2-class
@@ -140,7 +140,7 @@ parameters:
 
 If a key has the prefix `tagDeletion`, the CSI driver will treat the value as a tag key, and the existing tag with that key will be removed from the volume.
 ```
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: io2-class

--- a/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
+++ b/examples/kubernetes/modify-volume/manifests/volumeattributesclass.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: io2-class

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -42,8 +42,8 @@ FIPS_TEST=${FIPS_TEST:-"false"}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
-K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.33.3}
-K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-1.33}
+K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.34.1}
+K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-1.34}
 
 # Override AMI - eksctl clusters only
 LINUX_AMI=${LINUX_AMI:-}

--- a/hack/ebs-scale-test/helpers/scale-test/expand-and-modify-test/expand-and-modify.yaml
+++ b/hack/ebs-scale-test/helpers/scale-test/expand-and-modify-test/expand-and-modify.yaml
@@ -26,7 +26,7 @@ parameters:
   type: gp2
   tagSpecification_1: "ebs-scale-test={{ .Env.SCALABILITY_TEST_RUN_NAME }}"
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 driverName: ebs.csi.aws.com
 metadata:

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -37,7 +37,7 @@ HELM_VERSION="v3.19.0"
 # https://github.com/kubernetes/kops
 # Commit is preferred over version if non-empty, and can
 # be used to test new Kubernetes releases earlier
-KOPS_VERSION="v1.33.1"
+KOPS_VERSION="v1.34.0-alpha.1"
 KOPS_COMMIT=""
 # https://pkg.go.dev/sigs.k8s.io/kubetest2?tab=versions
 KUBETEST2_VERSION="v0.0.0-20250902173658-9560e3922fc0"

--- a/tests/e2e-kubernetes/volumeattributesclass.yaml
+++ b/tests/e2e-kubernetes/volumeattributesclass.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: VolumeAttributesClass
 metadata:
   name: gp2-class


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

Upgrades kOps cluster creation in CI to kk 1.34.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
