### PR TITLE
Disable nrext64 if LegacyXFSProgs is set

### DIFF
--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -267,7 +267,7 @@ func (d *NodeService) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		formatOptions = append(formatOptions, "-C", ext4ClusterSize)
 	}
 	if fsType == FSTypeXfs && d.options.LegacyXFSProgs {
-		formatOptions = append(formatOptions, "-m", "bigtime=0,inobtcount=0,reflink=0")
+		formatOptions = append(formatOptions, "-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0")
 	}
 	err = d.mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fsType, mountOptions, nil, formatOptions)
 	if err != nil {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -990,7 +990,7 @@ func TestNodeStageVolume(t *testing.T) {
 				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("xfs"), gomock.Any(), gomock.Any(), gomock.Eq([]string{"-i", "size=512", "-m", "bigtime=0,inobtcount=0,reflink=0"})).Return(nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("xfs"), gomock.Any(), gomock.Any(), gomock.Eq([]string{"-i", "size=512", "-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"})).Return(nil)
 				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -91,7 +91,7 @@ type Options struct {
 	ReservedVolumeAttachments int
 	// ALPHA: WindowsHostProcess indicates whether the driver is running in a Windows privileged container
 	WindowsHostProcess bool
-	// LegacyXFSProgs formats XFS volumes with `bigtime=0,inobtcount=0,reflink=0`, so that they can be mounted onto nodes with linux kernel ≤ v5.4. Volumes formatted with this option may experience issues after 2038, and will be unable to use some XFS features (for example, reflinks).
+	// LegacyXFSProgs formats XFS volumes with `bigtime=0,inobtcount=0,reflink=0,nrext64=0`, so that they can be mounted onto nodes with linux kernel ≤ v5.4. Volumes formatted with this option may experience issues after 2038, and will be unable to use some XFS features (for example, reflinks).
 	LegacyXFSProgs bool
 	// CsiMountPointPath is the path where CSI volumes are expected to be mounted on the node.
 	CsiMountPointPath string
@@ -129,7 +129,7 @@ func (o *Options) AddFlags(f *flag.FlagSet) {
 		f.Int64Var(&o.VolumeAttachLimit, "volume-attach-limit", -1, "Value for the maximum number of volumes attachable per node. If specified, the limit applies to all nodes and overrides --reserved-volume-attachments. If not specified, the value is approximated from the instance type.")
 		f.IntVar(&o.ReservedVolumeAttachments, "reserved-volume-attachments", -1, "Number of volume attachments reserved for system use. Not used when --volume-attach-limit is specified. The total amount of volume attachments for a node is computed as: <nr. of attachments for corresponding instance type> - <number of NICs, if relevant to the instance type> - <reserved-volume-attachments value>. When -1, the amount of reserved attachments is loaded from instance metadata that captured state at node boot and may include not only system disks but also CSI volumes.")
 		f.BoolVar(&o.WindowsHostProcess, "windows-host-process", false, "ALPHA: Indicates whether the driver is running in a Windows privileged container")
-		f.BoolVar(&o.LegacyXFSProgs, "legacy-xfs", false, "Warning: This option will be removed in a future version of EBS CSI Driver. Formats XFS volumes with `bigtime=0,inobtcount=0,reflink=0`, so that they can be mounted onto nodes with linux kernel ≤ v5.4. Volumes formatted with this option may experience issues after 2038, and will be unable to use some XFS features (for example, reflinks).")
+		f.BoolVar(&o.LegacyXFSProgs, "legacy-xfs", false, "Warning: This option will be removed in a future version of EBS CSI Driver. Formats XFS volumes with `bigtime=0,inobtcount=0,reflink=0,nrext64=0`, so that they can be mounted onto nodes with linux kernel ≤ v5.4. Volumes formatted with this option may experience issues after 2038, and will be unable to use some XFS features (for example, reflinks).")
 		f.StringVar(&o.CsiMountPointPath, "csi-mount-point-prefix", "", "A prefix of the mountpoints of all CSI-managed volumes. If this value is non-empty, all volumes mounted to a path beginning with the provided value are assumed to be CSI volumes owned by the EBS CSI Driver and safe to treat as such (for example, by exposing volume metrics).")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What is this PR about? / Why do we need it?

The EKS-D base image used by the EBS CSI Driver upgraded xfsprogs from 5.18.0 to 6.12.0. This appears to have caused XFS volumes to be formatted with the nrext64 feature, which is not supported by the Kernel used in Amazon Linux 2. This PR  disables the nrext64 if `legacyXFS` is set to true. 

#### How was this change tested?

- `make test`
- Manually by:
Putting up an EKS cluster that had the driver installed with these changes and the flag set, then provisioning a volume that has `csi.storage.k8s.io/fstype: xfs` and making sure it successfully creates and attaches. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Setting legacyXFS to true now disables nrext64. 
```
