### PR TITLE
Add Helm parameters to customize PDB `maxUnavailable` and `minAvailable`

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
@@ -14,9 +14,15 @@ spec:
   {{- if .Values.controller.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ .Values.controller.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   {{- end }}
+  {{- if or .Values.controller.podDisruptionBudget.maxUnavailable .Values.controller.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.controller.podDisruptionBudget.maxUnavailable }}
+  minAvailable: {{ .Values.controller.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  {{- /* Default behavior if neither maxUnavailable nor minAvailable are specified in values */}}
   {{- if le (.Values.controller.replicaCount | int) 2 }}
   maxUnavailable: 1
   {{- else }}
   minAvailable: 2
+  {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -303,6 +303,16 @@
               "type": ["string", "null"],
               "description": "Unhealthy pod eviction policy for the EBS CSI Controller Pod's PodDisruptionBudget",
               "default": null
+            },
+            "maxUnavailable": {
+              "type": ["integer", "string", "null"],
+              "description": "Maximum number or percentage of unavailable pods for the PodDisruptionBudget. If non-null, no default value is used for both maxUnavailable and minAvailable.",
+              "default": null
+            },
+            "minAvailable": {
+              "type": ["integer", "string", "null"],
+              "description": "Minimum number or percentage of available pods for the PodDisruptionBudget. If non-null, no default value is used for both maxUnavailable and minAvailable.",
+              "default": null
             }
           }
         },

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -259,6 +259,10 @@ controller:
     # pod restarts or evictions.
     enabled: true
     # unhealthyPodEvictionPolicy:
+    # Configure the maxUnavailable or minAvailable for the PDB
+    # If either parameter is non-null, no default is used for both
+    # maxUnavailable:
+    # minAvailable:
   priorityClassName: system-cluster-critical
   # AWS region to use. If not specified then the region will be looked up via the AWS EC2 metadata
   # service.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind helm

#### What is this PR about? / Why do we need it?

Fixes #2702 

#### How was this change tested?

```
# Existing behavior should be unchanged
helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver -s templates/poddisruptionbudget-controller.yaml
helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set controller.replicaCount=3 -s templates/poddisruptionbudget-controller.yaml

# New parameters
helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set controller.podDisruptionBudget.maxUnavailable="10%" -s templates/poddisruptionbudget-controller.yaml
helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set controller.podDisruptionBudget.minAvailable=1 -s templates/poddisruptionbudget-controller.yaml
helm template aws-ebs-csi-driver ./charts/aws-ebs-csi-driver --set controller.podDisruptionBudget.maxUnavailable="10%" --set controller.podDisruptionBudget.minAvailable=1 -s templates/poddisruptionbudget-controller.yaml
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add Helm parameters to customize PDB `maxUnavailable` and `minAvailable`
```
