### PR TITLE
Merge Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,44 +17,21 @@ enable-beta-ecosystems: true
 updates:
   - package-ecosystem: gomod
     directories: ["/", "/tests/e2e/"]
-    groups:
-      all:
-        patterns:
-          - "*"
-    schedule:
-      interval: weekly
-      day: "wednesday"
-      time: "06:00"
-      timezone: "America/New_York"
-    labels:
-      - "area/dependency"
-      - "ok-to-test"
-      - "release-note-none"
-  - package-ecosystem: "github-actions"
+    patterns: ["*"]
+    multi-ecosystem-group: all-dependencies
+  - package-ecosystem: github-actions
     directory: "/"
-    groups:
-      all:
-        patterns:
-          - "*"
-    schedule:
-      interval: weekly
-      # Wednesday chosen to minimize time after Windows Patch Tuesdays
-      day: "wednesday"
-      time: "06:00"
-      timezone: "America/New_York"
-    labels:
-      - "area/dependency"
-      - "ok-to-test"
-      - "release-note-none"
+    patterns: ["*"]
+    multi-ecosystem-group: all-dependencies
   - package-ecosystem: docker
     directory: "/"
-    groups:
-      all:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: all-dependencies
+multi-ecosystem-groups:
+  all-dependencies:
     schedule:
       interval: weekly
-      day: "wednesday"
+      day: Wednesday
       time: "06:00"
       timezone: "America/New_York"
     labels:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?
Merge's Dependabot's updates into one PR so we don't get spammed with 3 PRs like right now.

Also ran the file through `yq` to make the formatting consistent

#### How was this change tested?
lol - testing a Dependabot change, good one (GitHub doesn't let you)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
