### PR TITLE
Update Dependabot to run at 15:30 (3:30PM) on Fridays

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,8 +31,8 @@ multi-ecosystem-groups:
   all-dependencies:
     schedule:
       interval: weekly
-      day: Wednesday
-      time: "06:00"
+      day: Friday
+      time: "15:30"
       timezone: "America/New_York"
     labels:
       - "area/dependency"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

See title - more aligns Dependabot with when we do dependency bumps normally

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
