### PR TITLE
Run Dependabot daily and auto-merge if CI passes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,11 +30,11 @@ updates:
 multi-ecosystem-groups:
   all-dependencies:
     schedule:
-      interval: weekly
-      day: Friday
-      time: "15:30"
-      timezone: "America/New_York"
+      interval: daily
     labels:
       - "area/dependency"
       - "ok-to-test"
       - "release-note-none"
+      # Auto merge if CI passes
+      - "lgtm"
+      - "approved"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Instead of running Dependabot on a random day, just run it every day so we have the most up to date dependencies possible. Auto merge if CI passes too to avoid wasting reviewer's time.

Also renames the file to `dependabot.yml` because for some reason all the GitHub tooling seems to prefer that.

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
