### PR TITLE
Refactor run.sh to not print pod logs

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -168,15 +168,6 @@ else
     set -e
     set +x
   fi
-
-  PODS=$(kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver" -o json --kubeconfig "${KUBECONFIG}" | jq -r .items[].metadata.name)
-
-  while IFS= read -r POD; do
-    loudecho "Printing pod ${POD} container logs"
-    set +e
-    kubectl logs "${POD}" -n kube-system --all-containers --ignore-errors --kubeconfig "${KUBECONFIG}"
-    set -e
-  done <<<"${PODS}"
 fi
 
 # Collect periodic performance metrics - this should only run in Prow


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind cleanup
#### What is this PR about? / Why do we need it?
This PR removes the pod logging from our e2e tests such that the only logs printed are those of the test run.
#### How was this change tested?
CI
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
