### PR TITLE
Add clone example in examples

### DIFF
--- a/examples/kubernetes/clone/README.md
+++ b/examples/kubernetes/clone/README.md
@@ -1,0 +1,82 @@
+# Volume Cloning
+
+## Prerequisites
+
+1. The [aws-ebs-csi-driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) on at least v1.51.0 installed.
+2. Default managed policy will need to be adjusted see [install.md](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/install.md)  
+
+## Usage
+
+This example shows you how to clone an existing EBS `PersistentVolume` to create a new volume with the same data.
+
+### Create Source Volume
+
+1. Create the `StorageClass`:
+    ```sh
+    $ kubectl apply -f manifests/classes/
+
+    storageclass.storage.k8s.io/ebs-sc created
+    ```
+
+2. Deploy the provided pod on your cluster along with the `PersistentVolumeClaim`:
+    ```sh
+    $ kubectl apply -f manifests/app/
+
+    persistentvolumeclaim/ebs-claim created
+    pod/app created
+    ```
+
+3. Validate the `PersistentVolumeClaim` is bound to your `PersistentVolume`:
+    ```sh
+    $ kubectl get pvc ebs-claim
+
+    NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    ebs-claim   Bound    pvc-c2e5476c-d9f5-4a49-bbb2-9dfdb27db4c8   4Gi        RWO            ebs-sc         43s
+    ```
+
+4. Validate the pod successfully wrote data to the volume:
+    ```sh
+    $ kubectl exec app -- cat /data/out.txt
+
+    Thu Feb 24 04:07:57 UTC 2022
+    ...
+    ```
+
+### Clone Volume
+
+5. Create a clone of the existing volume with a `PersistentVolumeClaim` referencing the source PVC in its `dataSource`:
+    ```sh
+    $ kubectl apply -f manifests/clone/
+
+    persistentvolumeclaim/ebs-clone-claim created
+    pod/clone-app created
+    ```
+
+6. Validate the cloned volume contains the same data:
+    ```sh
+    $ kubectl exec clone-app -- cat /data/out.txt
+
+    Thu Feb 24 04:07:57 UTC 2022
+    ...
+    ```
+
+7. Cleanup resources:
+    ```sh
+    $ kubectl delete -f manifests/clone/
+
+    persistentvolumeclaim "ebs-clone-claim" deleted
+    pod "clone-app" deleted
+    ```
+
+    ```sh
+    $ kubectl delete -f manifests/app/
+
+    persistentvolumeclaim "ebs-claim" deleted
+    pod "app" deleted
+    ```
+
+    ```sh
+    $ kubectl delete -f manifests/classes/
+
+    storageclass.storage.k8s.io "ebs-sc" deleted
+    ```

--- a/examples/kubernetes/clone/manifests/app/claim.yaml
+++ b/examples/kubernetes/clone/manifests/app/claim.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi

--- a/examples/kubernetes/clone/manifests/app/pod.yaml
+++ b/examples/kubernetes/clone/manifests/app/pod.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+spec:
+  containers:
+  - name: app
+    image: public.ecr.aws/amazonlinux/amazonlinux
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: ebs-claim

--- a/examples/kubernetes/clone/manifests/classes/storageclass.yaml
+++ b/examples/kubernetes/clone/manifests/classes/storageclass.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+parameters:
+  encrypted: "true"
+volumeBindingMode: WaitForFirstConsumer

--- a/examples/kubernetes/clone/manifests/clone/claim.yaml
+++ b/examples/kubernetes/clone/manifests/clone/claim.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-clone-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: ebs-claim

--- a/examples/kubernetes/clone/manifests/clone/pod.yaml
+++ b/examples/kubernetes/clone/manifests/clone/pod.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clone-app
+spec:
+  containers:
+  - name: clone-app
+    image: public.ecr.aws/amazonlinux/amazonlinux
+    command: ["/bin/sh"]
+    args: ["-c", "echo 'Cloned data:'; cat /data/out.txt; echo 'Adding new data to clone...'; while true; do echo $(date -u) >> /data/clone-out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: ebs-clone-claim


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind documentation
#### What is this PR about? / Why do we need it?
Adds a clones example so users can see an example of how to create a clone 
#### How was this change tested?
Ran through the example 


```
kubectl apply -f manifests/classes/                                                                                                                                                                             ─╯
storageclass.storage.k8s.io/ebs-sc created


╰─ kubectl apply -f manifests/app/                                                                                                                                                                                 ─╯
persistentvolumeclaim/ebs-claim created
pod/app created

╰─ kubectl get pvc ebs-claim                                                                                                                                                                                       ─╯
NAME        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
ebs-claim   Bound    pvc-876de6ca-d497-458f-b76c-5dc8caf117a7   4Gi        RWO            ebs-sc         <unset>                 14s


╰─ kubectl exec app -- cat /data/out.txt                                                                                                                                                                           ─╯
Wed Oct 15 20:36:28 UTC 2025
Wed Oct 15 20:36:33 UTC 2025
Wed Oct 15 20:36:38 UTC 2025
Wed Oct 15 20:36:43 UTC 2025
Wed Oct 15 20:36:48 UTC 2025


╰─ kubectl apply -f manifests/clone/                                                                                                                                                                               ─╯
persistentvolumeclaim/ebs-clone-claim created
pod/clone-app created


╰─ kubectl exec clone-app -- cat /data/out.txt                                                                                                                                                                     ─╯
Wed Oct 15 20:36:28 UTC 2025
Wed Oct 15 20:36:33 UTC 2025
Wed Oct 15 20:36:38 UTC 2025
Wed Oct 15 20:36:43 UTC 2025
Wed Oct 15 20:36:48 UTC 2025
Wed Oct 15 20:36:53 UTC 2025


╰─ kubectl delete -f manifests/clone/                                                                                                                                                                              ─╯
persistentvolumeclaim "ebs-clone-claim" deleted
pod "clone-app" deleted

╰─ kubectl delete -f manifests/app/                                                                                                                                                                                ─╯
persistentvolumeclaim "ebs-claim" deleted
pod "app" deleted

╰─ kubectl delete -f manifests/classes/                                                                                                                                                                            ─╯
storageclass.storage.k8s.io "ebs-sc" deleted
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
