### PR TITLE
Add Helm parameter to disable mutation for node SA

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -123,6 +123,10 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            {{- if .Values.node.serviceAccount.disableMutation }}
+            - name: DISABLE_TAINT_WATCHER
+              value: "true"
+            {{- end }}
             {{- with .Values.node.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -123,6 +123,10 @@ spec:
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
             {{- end }}
+            {{- if .Values.node.serviceAccount.disableMutation }}
+            - name: DISABLE_TAINT_WATCHER
+              value: "true"
+            {{- end }}
             {{- with .Values.node.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/clusterrole-csi-node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/clusterrole-csi-node.yaml
@@ -6,12 +6,19 @@ metadata:
   labels:
     {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
 rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  {{- if not .Values.node.serviceAccount.disableMutation }}
+  {{- /* We also disable some read APIs here as they are only used in the taint removal feature */}}
+  {{- /* But those are not the important part and could be re-added in the future if needed */}}
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get"]
+  {{- end }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -717,6 +717,11 @@
               "type": ["object", "null"],
               "description": "Additional annotations added to the ebs-csi-node-sa service account",
               "default": null
+            },
+            "disableMutation": {
+              "type": ["boolean", "null"],
+              "description": "Disable mutating permissions for the node service account. When enabled, some features of the EBS CSI Driver node pods will not function, such as taint removal. Primarily useful in particularly security-sensitive environments, or on multi-tenant clusters that isolate tenants by node.",
+              "default": false
             }
           }
         },

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -418,6 +418,10 @@ node:
     ## Enable if EKS IAM for SA is used
     # eks.amazonaws.com/role-arn: arn:<partition>:iam::<account>:role/ebs-csi-role
     automountServiceAccountToken: true
+    # Disable mutating permissions for the node service account.
+    # When enabled, some features of the EBS CSI Driver node pods will not function, such as taint removal.
+    # Primarily useful in particularly security-sensitive environments, or on multi-tenant clusters that isolate tenants by node.
+    disableMutation: false
   # Enable the linux daemonset creation
   enableLinux: true
   enableWindows: true

--- a/deploy/kubernetes/base/clusterrole-csi-node.yaml
+++ b/deploy/kubernetes/base/clusterrole-csi-node.yaml
@@ -7,12 +7,15 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
 rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get"]

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -842,6 +842,10 @@ func collectMountOptions(fsType string, mntFlags []string) []string {
 // startNotReadyTaintWatcher launches a short‑lived Node informer that removes the
 // ebs.csi.aws.com/agent‑not‑ready taint. The informer is stopped after maxWatchDuration.
 func startNotReadyTaintWatcher(clientset kubernetes.Interface, maxWatchDuration time.Duration) {
+	if os.Getenv("DISABLE_TAINT_WATCHER") != "" {
+		klog.V(4).InfoS("DISABLE_TAINT_WATCHER set, skipping taint watcher")
+		return
+	}
 	nodeName := os.Getenv("CSI_NODE_NAME")
 	if nodeName == "" {
 		klog.V(4).InfoS("CSI_NODE_NAME missing, skipping taint watcher")


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Adds a parameter `node.serviceAccount.disableMutation` to disable mutating permissions on the node SA. Also updates the node code to detect and gracefully handle this case rather than attempting and failing to patch the node.

#### How was this change tested?

Logs (at verbosity 4) with param true:
```
$ HELM_EXTRA_FLAGS="--set=node.serviceAccount.disableMutation=true" make cluster/install
...
###
## Sucessfully installed driver via helm
#

$ kubectl -n kube-system logs ebs-csi-node-28d7k
Defaulted container "ebs-plugin" out of: ebs-plugin, node-driver-registrar, liveness-probe
I1016 21:01:24.249024       1 main.go:154] "Initializing metadata"
I1016 21:01:24.249136       1 metadata.go:66] "Attempting to retrieve instance metadata from IMDS"
I1016 21:01:24.253786       1 metadata.go:69] "Retrieved metadata from IMDS"
I1016 21:01:24.254123       1 mount_linux.go:316] Cannot create temp dir to detect safe 'not mounted' behavior: mkdir /tmp/kubelet-detect-safe-umount4269331495: read-only file system
I1016 21:01:24.254465       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I1016 21:01:24.254510       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I1016 21:01:24.254533       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I1016 21:01:24.254553       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I1016 21:01:24.254573       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I1016 21:01:24.255019       1 driver.go:72] "Driver Information" Driver="ebs.csi.aws.com" Version="v1.51.0"
I1016 21:01:24.255364       1 driver.go:142] "Listening for connections" address="/csi/csi.sock"
I1016 21:01:24.255439       1 node.go:846] "DISABLE_TAINT_WATCHER set, skipping taint watcher"
I1016 21:01:25.105315       1 node.go:577] "NodeGetInfo: called" args=""
```

Logs (at verbosity 4) with param false (default behavior):
```
$ make cluster/install
./hack/e2e/install.sh
...
###
## Sucessfully installed driver via helm
#

$ kubectl logs -n kube-system ebs-csi-node-4hlxz
Defaulted container "ebs-plugin" out of: ebs-plugin, node-driver-registrar, liveness-probe
I1016 20:57:42.007027       1 main.go:154] "Initializing metadata"
I1016 20:57:42.007853       1 metadata.go:66] "Attempting to retrieve instance metadata from IMDS"
I1016 20:57:42.014704       1 metadata.go:69] "Retrieved metadata from IMDS"
I1016 20:57:42.015023       1 mount_linux.go:316] Cannot create temp dir to detect safe 'not mounted' behavior: mkdir /tmp/kubelet-detect-safe-umount3378500581: read-only file system
I1016 20:57:42.015258       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false
I1016 20:57:42.015285       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false
I1016 20:57:42.015292       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false
I1016 20:57:42.015297       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false
I1016 20:57:42.015304       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true
I1016 20:57:42.015740       1 driver.go:72] "Driver Information" Driver="ebs.csi.aws.com" Version="v1.51.0"
I1016 20:57:42.016601       1 driver.go:142] "Listening for connections" address="/csi/csi.sock"
I1016 20:57:42.016818       1 reflector.go:358] "Starting reflector" type="*v1.Node" resyncPeriod="5s" reflector="/gomodcache/k8s.io/client-go@v0.34.1/tools/cache/reflector.go:290"
I1016 20:57:42.016833       1 reflector.go:404] "Listing and watching" type="*v1.Node" reflector="/gomodcache/k8s.io/client-go@v0.34.1/tools/cache/reflector.go:290"
I1016 20:57:42.032172       1 reflector.go:436] "Caches populated" type="*v1.Node" reflector="/gomodcache/k8s.io/client-go@v0.34.1/tools/cache/reflector.go:290"
I1016 20:57:42.231855       1 node.go:577] "NodeGetInfo: called" args=""
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add Helm parameter `node.serviceAccount.disableMutation` to disable mutating RBAC permissions to the `ebs-csi-node` service account. When enabled, driver features such as taint removal may not function.
```
