### PR TITLE
Fix IOPS handling

### DIFF
--- a/tests/e2e/requires_aws_api.go
+++ b/tests/e2e/requires_aws_api.go
@@ -412,11 +412,11 @@ var _ = Describe("[ebs-csi-e2e] [single-az] [requires-aws-api] Dynamic Provision
 				{
 					CreateVolumeParameters: map[string]string{
 						ebscsidriver.EncryptedKey:  "true",
-						ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP2,
+						ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
 						ebscsidriver.IopsKey:       sourceIops,
 						ebscsidriver.FSTypeKey:     ebscsidriver.FSTypeExt4,
 					},
-					ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+					ClaimSize:   "10Gi", // Must be higher than minimum to be within max IOPS ratio.
 					VolumeMount: testsuites.DefaultGeneratedVolumeMount,
 				},
 			},
@@ -428,7 +428,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] [requires-aws-api] Dynamic Provision
 					CreateVolumeParameters: map[string]string{
 						ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
 					},
-					ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+					ClaimSize:   "10Gi",
 					VolumeMount: testsuites.DefaultGeneratedVolumeMount,
 				},
 			},


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fix several places IOPS is handled incorrectly:
- Fixes clone E2E test which tries to create a GP2 volume with IOPS (previously worked due to a bug)
- Fixes `extractMaxIOPSFromError` to return `0` for cases when the volume type is invalid
- Fixes `CreateDisk`/`ResizeOrModifyDisk` to not fail if the volume type is unknown
- Fix `capIOPS` to not apply limits when they are 0

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Improve handling of volume types that do not have hardcoded IOPS limits and/or do not support IOPS
```
