### PR TITLE
Fix off-by-one error in volume limits for default nitro instances

### DIFF
--- a/pkg/cloud/volume_limits.go
+++ b/pkg/cloud/volume_limits.go
@@ -50,8 +50,8 @@ func GetVolumeLimits(instanceType string) (int, string) {
 		return limit.maxAttachments, limit.attachmentType
 	}
 
-	// Default to shared limit of 28
-	return 28, util.AttachmentShared
+	// Default to shared limit of 27
+	return 27, util.AttachmentShared
 }
 
 // KnownInstanceTypes returns all known instance types from the limits table.

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1074,6 +1074,21 @@ func TestGetVolumesLimit(t *testing.T) {
 			},
 		},
 		{
+			name: "m5.large_volume_attach_limit",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 27,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetInstanceType().Return("m5.large")
+				m.EXPECT().GetNumAttachedENIs().Return(0)
+				return m
+			},
+		},
+		{
 			name: "ReservedVolumeAttachments_specified",
 			options: &Options{
 				VolumeAttachLimit:         -1,

--- a/tests/e2e/metadata-labeler.go
+++ b/tests/e2e/metadata-labeler.go
@@ -171,7 +171,7 @@ var _ = framework.Describe("[ebs-csi-e2e] [Disruptive] Metadata Labeler Sidecar"
 
 // getAllocatableCount returns the limit of volumes that the node supports.
 func getAllocatableCount(volumes, enis int) int32 {
-	return int32(28 - volumes - enis)
+	return int32(27 - volumes - enis)
 }
 
 // getVolENIs gets the expected metadata of each instance from the ec2 API


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes #2748 

#### How was this change tested?

Manually + added a new unit test to guard this case

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Fix off-by-one error in volume limits for default nitro instances which would get PVCs stuck attempting to attach to a full instance.
```
