### PR TITLE
[release-1.49] Fix off-by-one error in volume limits for default nitro instances

### DIFF
--- a/pkg/cloud/volume_limits.go
+++ b/pkg/cloud/volume_limits.go
@@ -49,8 +49,8 @@ func GetVolumeLimits(instanceType string) (int, string) {
 		return limit.maxAttachments, limit.attachmentType
 	}
 
-	// Default to shared limit of 28
-	return 28, util.AttachmentShared
+	// Default to shared limit of 27
+	return 27, util.AttachmentShared
 }
 
 // KnownInstanceTypes returns all known instance types from the limits table.

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1074,6 +1074,21 @@ func TestGetVolumesLimit(t *testing.T) {
 			},
 		},
 		{
+			name: "m5.large_volume_attach_limit",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 27,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetInstanceType().Return("m5.large")
+				m.EXPECT().GetNumAttachedENIs().Return(0)
+				return m
+			},
+		},
+		{
 			name: "ReservedVolumeAttachments_specified",
 			options: &Options{
 				VolumeAttachLimit:         -1,


### PR DESCRIPTION
This is a manual cherry-pick of #2749

```release-note
Fix off-by-one error in volume limits for default nitro instances which would get PVCs stuck attempting to attach to a full instance.
```