### PR TITLE
Update IAM policy for CopyVolumes

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -25,6 +25,15 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:CopyVolumes"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/vol-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:AttachVolume",
         "ec2:DetachVolume"
       ],
@@ -54,7 +63,8 @@
         "StringEquals": {
           "ec2:CreateAction": [
             "CreateVolume",
-            "CreateSnapshot"
+            "CreateSnapshot",
+            "CopyVolumes"
           ]
         }
       }
@@ -72,7 +82,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateVolume"
+        "ec2:CreateVolume",
+        "ec2:CopyVolumes"
       ],
       "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {
@@ -84,7 +95,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CreateVolume"
+        "ec2:CreateVolume",
+        "ec2:CopyVolumes"
       ],
       "Resource": "arn:aws:ec2:*:*:volume/*",
       "Condition": {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind documentation

#### What is this PR about? / Why do we need it?

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2716 added volume cloning functionality and updated the IAM policy in various places. It unfortunately omitted `docs/example-iam-policy.json`.

When comparing `hack/e2e/kops/patch-cluster.yaml` and `docs/install.md` it was also noticed that one of the `Action`s was incorrect in `docs/install.md` and should have been `ec2:CreateTags`

#### How was this change tested?

n/a

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
