### PR TITLE
Fix action in clone volumes documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -132,7 +132,7 @@ The following statements give the EBS CSI Driver access to clone volumes:
 {
   "Effect": "Allow",
   "Action": [
-    "ec2:CopyVolumes"
+    "ec2:CreateTags"
   ],
   "Resource": "arn:aws:ec2:*:*:volume/*",
   "Condition": {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind documentation

#### What is this PR about? / Why do we need it?

Split out of #2756. https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2716 added volume cloning functionality and updated the IAM policy in various places. When comparing `hack/e2e/kops/patch-cluster.yaml` and `docs/install.md` it was also noticed that one of the Actions was incorrect in `docs/install.md` and should have been `ec2:CreateTags`

#### How was this change tested?

n/a

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
