### PR TITLE
Upgrade volume-modifier-for-k8s

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -167,7 +167,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
-      tag: "v0.8.0"
+      tag: "v0.9.0"
     leaderElection:
       enabled: true
       # Optional values to tune lease behavior.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

Upgrades volume-modifier-for-k8s to address https://github.com/advisories/GHSA-qh38-484v-w52x.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
