### PR TITLE
Fix patch releases in generate-release-pr script

### DIFF
--- a/hack/release-scripts/generate-release-pr
+++ b/hack/release-scripts/generate-release-pr
@@ -112,10 +112,17 @@ update_installmd() {
 
 update_chart_and_overlays() {
   log "Updating helm chart and generates kustomize"
-  prev_minor_patch_version=$(echo "$PREV_DRIVER_VERSION" | sed 's/v[0-9]*\.//')
-  new_minor_patch_version=$(echo "$NEW_DRIVER_VERSION" | sed 's/v[0-9]*\.//')
+  new_driver_version_no_prefix=$(echo "$NEW_DRIVER_VERSION" | sed 's/v//')
 
-  $SED "s/$prev_minor_patch_version$/$new_minor_patch_version/g" -i "$CHART_PATH"
+  # Set appVersion to new driver version
+  yq ".appVersion=\"$new_driver_version_no_prefix\"" -i "$CHART_PATH"
+  # If minor version has changed, set chart version to appVersion with 2 as major version
+  # If not (patch release), just bump the chart patch version
+  if [ "${PREV_DRIVER_VERSION%.*}" != "${NEW_DRIVER_VERSION%.*}" ]; then
+    yq ".version = (\"$new_driver_version_no_prefix\" | split(\".\") | .[0] = \"2\" | join(\".\"))" -i "$CHART_PATH"
+  else
+    yq '.version |= (split(".") | .[2] |= (to_number + 1) | join("."))' -i "$CHART_PATH"
+  fi
 
   (
     cd "$ROOT_DIRECTORY"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes patch release handling in `hack/release-scripts/generate-release-pr`

#### How was this change tested?

**Testing patch release (same minor version):**
```
$ ./hack/release-scripts/generate-release-pr v1.51.1 v1.51.2
2025-11-06 11:38:06 [INFO] - Confirming v1.51.1 < v1.51.2
2025-11-06 11:38:06 [INFO] - Updating README.md
2025-11-06 11:38:06 [INFO] - Updating Makefile
2025-11-06 11:38:06 [INFO] - Updating docs/install.md
2025-11-06 11:38:06 [INFO] - Updating helm chart and generates kustomize
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17.1M  100 17.1M    0     0  35.3M      0 --:--:-- --:--:-- --:--:-- 35.3M
SUCCESS!
Before you submit the release PR, you must also:
  1. Check that 'git diff' produces what you expected.
  2. Update CHANGELOG.md
  3. Update charts/aws-ebs-csi-driver/CHANGELOG.md
```

```diff
$ git diff charts/
diff --git a/charts/aws-ebs-csi-driver/Chart.yaml b/charts/aws-ebs-csi-driver/Chart.yaml
index b03fa105..7143c068 100644
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.51.1
+appVersion: 1.51.2
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.51.2
+version: 2.51.3
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
```

**Testing new minore release after patch:**

```
$ ./hack/release-scripts/generate-release-pr v1.51.1 v1.52.0
2025-11-06 11:39:26 [INFO] - Confirming v1.51.1 < v1.52.0
2025-11-06 11:39:26 [INFO] - Updating README.md
2025-11-06 11:39:26 [INFO] - Updating Makefile
2025-11-06 11:39:26 [INFO] - Updating docs/install.md
2025-11-06 11:39:26 [INFO] - Updating helm chart and generates kustomize
SUCCESS!
Before you submit the release PR, you must also:
  1. Check that 'git diff' produces what you expected.
  2. Update CHANGELOG.md
  3. Update charts/aws-ebs-csi-driver/CHANGELOG.md
```

```diff
$ git diff charts/
diff --git a/charts/aws-ebs-csi-driver/Chart.yaml b/charts/aws-ebs-csi-driver/Chart.yaml
index b03fa105..b3c97c89 100644
--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.51.1
+appVersion: 1.52.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.51.2
+version: 2.52.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
