### PR TITLE
Add `dnsConfig` parameter for node plugin

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -299,5 +299,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+      {{- if .Values.node.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.node.dnsConfig | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -304,5 +304,9 @@ spec:
         {{- with .Values.node.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if .Values.node.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.node.dnsConfig | nindent 8 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -784,6 +784,11 @@
           },
           "description": "Enable opentelemetry tracing for the plugin running on the daemonset",
           "default": null
+        },
+        "dnsConfig": {
+          "type": ["object", "null"],
+          "description": "DNS configuration for the node pods",
+          "default": null
         }
       }
     },

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -362,7 +362,7 @@ controller:
   #  otelServiceName: ebs-csi-controller
   #  otelExporterEndpoint: "http://localhost:4317"
 
-  # Enable dnsConfig for the controller and node pods
+  # dnsConfig for the controller pods
   dnsConfig: {}
 node:
   # Enable SELinux-only optimizations on the EBS CSI Driver node pods
@@ -493,6 +493,9 @@ node:
   otelTracing: {}
   #  otelServiceName: ebs-csi-node
   #  otelExporterEndpoint: "http://localhost:4317"
+
+  # dnsConfig for the node pods
+  dnsConfig: {}
 additionalDaemonSets:
 # Additional node DaemonSets, using the node config structure
 # See docs/additional-daemonsets.md for more information


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

This PR adds `node.dnsConfig` Helm parameter to allow DNS configuration for node pods. Similar concept to the already existing `controller.dnsConfig`.

closes #2777

#### How was this change tested?

```
make update && make verify && make test
```

Manually:

```
helm upgrade --install aws-ebs-csi-driver \
  --namespace kube-system \
  ./charts/aws-ebs-csi-driver \
  --set 'node.dnsConfig.options[0].name=ndots' \
  --set 'node.dnsConfig.options[0].value="2"'

kubectl get daemonset ebs-csi-node -n kube-system -o yaml | grep -A 5 "dnsConfig:"
      dnsConfig:
        options:
        - name: ndots
          value: '"2"'

 kubectl get pod -n kube-system -l app=ebs-csi-node -o jsonpath='{.items[0].spec.dnsConfig}' | jq
{
  "options": [
    {
      "name": "ndots",
      "value": "\"2\""
    }
  ]
}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add dnsConfig Helm parameter for node pods.
```
