### PR TITLE
Improve Prom ServiceMonitor CRD detection

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_metrics.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_metrics.tpl
@@ -23,7 +23,7 @@ spec:
   {{- with .InternalTrafficPolicy }}
   internalTrafficPolicy: {{ . }}
   {{- end }}
-{{- if or .ServiceMonitor.forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if or .ServiceMonitor.forceEnable (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

The existing Helm ServiceMonitor config creates a service monitor even when only other Prometheus CRDs are installed because it checks for the general API group `monitoring.coreos.com/v1` rather than the specific `monitoring.coreos.com/v1/ServiceMonitor` CRD.

This PR updates the logic to ensure that `ServiceMonitor` resources are only created when The ServiceMonitor CRD is actually available in the cluster OR `serviceMonitor.forceEnable` is explicitly set to true.

closes #2774

#### How was this change tested?

```
make update && make verify && make test
```

Manually:

- ServiceMonitor CRD not available:

```
# 1. Install only PrometheusRule CRD (without ServiceMonitor)
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml

# 2. Install the driver with metrics enabled
helm install aws-ebs-csi-driver ./charts/aws-ebs-csi-driver \
  --set controller.enableMetrics=true \
  --set node.enableMetrics=true \
  --namespace kube-system

# 3. Verify installation succeeds and NO ServiceMonitor is created
kubectl get servicemonitor -n kube-system
error: the server doesn't have a resource type "servicemonitor"
```

- ServiceMonitor CRD installed:

```
 1. Install ServiceMonitor CRD
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml

# 2. Install the driver with metrics enabled (same as above)

# 3. Verify instsallation succeeds and service monitor objects are created:

kubectl get servicemonitor -n kube-system
NAME                                AGE
ebs-csi-controller                  6s
ebs-csi-controller-attacher         6s
ebs-csi-controller-liveness-probe   6s
ebs-csi-controller-provisioner      6s
ebs-csi-controller-resizer          6s
ebs-csi-node                        6s
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Helm: Check for specific ServiceMonitor CRD availability instead of generic `monitoring.coreos.com/v1` API group when creating service monitor object for metrics.
```
