### PR TITLE
Added Verification Of Expected Parameters for e2e tests

### DIFF
--- a/tests/e2e/testsuites/dynamically_provisioned_volume_properties_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_volume_properties_tester.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testsuites
+
+import (
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// DynamicallyProvisionedVolumePropertiesTest will create a pod along with a volume.
+// It will then wait until the volume is created and verify input parameters were
+// properly applied to the volume.
+type DynamicallyProvisionedVolumePropertiesTest struct {
+	CreateVolumeParameters map[string]string
+	ClaimSize              string
+}
+
+func (t *DynamicallyProvisionedVolumePropertiesTest) Run(c clientset.Interface, ns *v1.Namespace, ebsDriver driver.PVTestDriver) {
+	volumeDetails := CreateVolumeDetails(t.CreateVolumeParameters, t.ClaimSize)
+	testVolume, _ := volumeDetails.SetupDynamicPersistentVolumeClaim(c, ns, ebsDriver)
+	defer testVolume.Cleanup()
+
+	pod := createPodWithVolume(c, ns, "", testVolume, volumeDetails)
+	defer pod.Cleanup()
+	pod.WaitForSuccess()
+
+	By("verifying volume properties")
+	volumeID := testVolume.persistentVolume.Spec.CSI.VolumeHandle
+
+	expected := BuildExpectedParameters(t.CreateVolumeParameters, t.ClaimSize)
+	VerifyVolumeProperties(volumeID, expected)
+}

--- a/tests/e2e/testsuites/modify_volume_tester.go
+++ b/tests/e2e/testsuites/modify_volume_tester.go
@@ -112,6 +112,17 @@ func (modifyVolumeTest *ModifyVolumeTest) Run(c clientset.Interface, ns *v1.Name
 		err = WaitForPvToResize(c, ns, testVolume.persistentVolume.Name, updatedPvcSize, DefaultResizeTimout, DefaultK8sAPIPollingInterval)
 		framework.ExpectNoError(err, fmt.Sprintf("fail to resize pv(%s): %v", modifyingPvc.Name, err))
 	}
+
+	By("verifying volume properties")
+	volumeID := testVolume.persistentVolume.Spec.CSI.VolumeHandle
+
+	expected := BuildExpectedParameters(modifyVolumeTest.ModifyVolumeParameters, "")
+	if modifyVolumeTest.ShouldResizeVolume {
+		sizeGiB := util.BytesToGiB(updatedPvcSize.Value())
+		expected.Size = &sizeGiB
+	}
+
+	VerifyVolumeProperties(volumeID, expected)
 }
 
 func attemptInvalidModification(c clientset.Interface, ns *v1.Namespace, testVolume *TestPersistentVolumeClaim) {

--- a/tests/e2e/volume_properties.go
+++ b/tests/e2e/volume_properties.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/testsuites"
+	. "github.com/onsi/ginkgo/v2"
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = Describe("[ebs-csi-e2e] [single-az] Volume Properties Verification", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		ebsDriver driver.PVTestDriver
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		ebsDriver = driver.InitEbsCSIDriver()
+	})
+
+	It("should create a gp3 volume with custom IOPS", func() {
+		test := testsuites.DynamicallyProvisionedVolumePropertiesTest{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+				ebscsidriver.IopsKey:       "4000",
+			},
+			ClaimSize: "10Gi",
+		}
+		test.Run(cs, ns, ebsDriver)
+	})
+
+	It("should create a gp3 volume with custom IOPS and throughput", func() {
+		test := testsuites.DynamicallyProvisionedVolumePropertiesTest{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+				ebscsidriver.IopsKey:       "5000",
+				ebscsidriver.ThroughputKey: "250",
+			},
+			ClaimSize: "10Gi",
+		}
+		test.Run(cs, ns, ebsDriver)
+	})
+
+	It("should create an io2 volume with custom IOPS", func() {
+		test := testsuites.DynamicallyProvisionedVolumePropertiesTest{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeIO2,
+				ebscsidriver.IopsKey:       "10000",
+			},
+			ClaimSize: "10Gi",
+		}
+		test.Run(cs, ns, ebsDriver)
+	})
+
+	It("should create a io2 volume with custom IOPS and encryption", func() {
+		test := testsuites.DynamicallyProvisionedVolumePropertiesTest{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeIO2,
+				ebscsidriver.IopsKey:       "5000",
+				ebscsidriver.EncryptedKey:  "true",
+			},
+			ClaimSize: "10Gi",
+		}
+		test.Run(cs, ns, ebsDriver)
+	})
+
+	It("should create an io2 volume with encryption", func() {
+		test := testsuites.DynamicallyProvisionedVolumePropertiesTest{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeIO2,
+				ebscsidriver.IopsKey:       "1000",
+				ebscsidriver.EncryptedKey:  "true",
+			},
+			ClaimSize: "10Gi",
+		}
+		test.Run(cs, ns, ebsDriver)
+	})
+
+	It("should create an gp3 volume with custom size, IOPS, throughput, and encryption", func() {
+		test := testsuites.DynamicallyProvisionedVolumePropertiesTest{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+				ebscsidriver.IopsKey:       "4000",
+				ebscsidriver.ThroughputKey: "250",
+				ebscsidriver.EncryptedKey:  "true",
+			},
+			ClaimSize: "10Gi",
+		}
+		test.Run(cs, ns, ebsDriver)
+	})
+
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR has two purposes, the first is to verify that the volumes modified in the modify volume e2e tests are checked to ensure that the desired attributes have been actually modified on the volume. The second is adding some simple create volume tests that ensure that volumes are created with the inputted user values. 

#### How was this change tested?

```
make update && make verify && make test

Manually (cd into tests/e2e):
> ginkgo run -focus="Volume Properties Verification" -procs=4 -timeout=10m -v

Ran 4 of 82 Specs in 37.025 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 78 Skipped

> ginkgo run -focus="will modify associated PV and EBS Volume via external-resizer" -procs=9 -timeout=10m -v

Ran 9 of 82 Specs in 93.208 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 73 Skipped

```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
