### PR TITLE
Fix Max IOPS Extraction From Error Bug

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -2730,12 +2730,13 @@ func (c *cloud) getVolumeLimits(ctx context.Context, volumeType string, azParams
 			},
 		},
 	}
+	// We only want either the Zone or ZoneID otherwise the DryRun call will fail with InvalidParameterCombination due to having both.
 	if azParams.availabilityZone != "" {
 		dryRunRequestInput.AvailabilityZone = aws.String(azParams.availabilityZone)
-	}
-	if azParams.availabilityZoneId != "" {
+	} else if azParams.availabilityZoneId != "" {
 		dryRunRequestInput.AvailabilityZoneId = aws.String(azParams.availabilityZoneId)
 	}
+
 	if azParams.outpostArn != "" {
 		dryRunRequestInput.OutpostArn = aws.String(azParams.outpostArn)
 	}
@@ -2796,23 +2797,19 @@ func extractMaxIOPSFromError(errorMsg string, volumeType string) (int32, error) 
 	if strings.Contains(errorMsg, "parameter iops is not supported") {
 		return 0, nil
 	}
-	// io1 and gp3 have the same error message but io2 has different one, using by default.
-	if volumeType == VolumeTypeIO2 {
-		if matches := io2ErrRegex.FindStringSubmatch(errorMsg); len(matches) > 1 {
-			if val, err := strconv.ParseInt(matches[1], 10, 32); err == nil {
-				result := val * 1000
-				// No real overflow concern here but adding for safety.
-				if result > math.MaxInt32 || result < math.MinInt32 {
-					return 0, fmt.Errorf("maximum IOPS value exceeds maximum value of int32: %d", val)
-				}
-				return int32(result), nil
-			}
+	// io1 and gp3 have the same error message but io2 has different one depending on the availability zone.
+	if matches := nonIo2ErrRegex.FindStringSubmatch(errorMsg); len(matches) > 1 {
+		if val, err := strconv.ParseInt(matches[1], 10, 32); err == nil {
+			return int32(val), nil
 		}
-	} else {
-		if matches := nonIo2ErrRegex.FindStringSubmatch(errorMsg); len(matches) > 1 {
-			if val, err := strconv.ParseInt(matches[1], 10, 32); err == nil {
-				return int32(val), nil
+	} else if matches := io2ErrRegex.FindStringSubmatch(errorMsg); len(matches) > 1 {
+		if val, err := strconv.ParseInt(matches[1], 10, 32); err == nil {
+			result := val * 1000
+			// No real overflow concern here but adding for safety.
+			if result > math.MaxInt32 || result < math.MinInt32 {
+				return 0, fmt.Errorf("maximum IOPS value exceeds maximum value of int32: %d", val)
 			}
+			return int32(result), nil
 		}
 	}
 

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -4724,6 +4724,12 @@ func TestExtractMaxIOPSFromError(t *testing.T) {
 			volumeType:      "io2",
 		},
 		{
+			name:            "Success: Properly gets expectedMaxIOPS from other possible io2 Error",
+			err:             errors.New("An error occurred (InvalidParameterValue) when calling the CreateVolume operation: Volume iops of 300000 is too high; maximum is 256000."),
+			expectedMaxIOPS: 256000,
+			volumeType:      "io2",
+		},
+		{
 			name:            "Success: Properly gets expectedMaxIOPS from io1 Error",
 			err:             errors.New("An error occurred (InvalidParameterValue) when calling the CreateVolume operation: Volume iops of 200000 is too high; maximum is 64000."),
 			expectedMaxIOPS: 64000,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What is this PR about? / Why do we need it?

This PR fixes two bugs in how the driver extract IOPS limits during Create and Resize/Modify:

1.) If both the AZ and AZ ID are passed to the DryRun call, it will fail with InvalidParameterCombination and default to hardcoded limits. With this change we pass either the AZ or the AZ ID but not both.

2.) If the volume type is io2,  the error returned for having to many IOPS (that is parsed to get the maximum IOPS) can change depending on the specific AZ. This PR ensures that regardless of the volume type, we try to parse both known error messages before defaulting to hardcoded values.

#### How was this change tested?

```
make verify && make test

Manually: 
- Create io2 volume
- Modify IOPS on the volume and ensure that regardless of the AZ it is still able to get the maximum IOPS
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
