### PR TITLE
fix(chart): only enable nodeAllocatableUpdatePeriodSeconds for EKS 1.34+

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/csidriver.yaml
+++ b/charts/aws-ebs-csi-driver/templates/csidriver.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   attachRequired: true
   podInfoOnMount: false
-  {{- if semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version }}
+  {{- if semverCompare ">=1.34.0-0" .Capabilities.KubeVersion.Version }}
   {{- if eq (.Values.nodeAllocatableUpdatePeriodSeconds | int) -1 }}
   nodeAllocatableUpdatePeriodSeconds: {{ (regexMatch "metadata-labeler" (.Values.node.metadataSources | default "")) | ternary "300" "10" }}
   {{- else if .Values.nodeAllocatableUpdatePeriodSeconds }}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

> The MutableCSINodeAllocatableCount feature gate is enabled by default in EKS 1.34

Per the AWS [documentation](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html#kubernetes-1-34)

There're also some issues reported when deploying on EKS < 1.34:

- https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2387#issuecomment-3381664889

#### How was this change tested?

For EKS < 1.34

1. For a 1.33 EKS 
2. Upgrade aws-ebs-csi-driver helm chart to this PR version

For EKS >= 1.34

1. Create a new 1.34 EKS 
3. Deploy this aws-ebs-csi-driver helm chart

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
N/A
```
