### PR TITLE
Adding SnapshotLock Capabilities

### DIFF
--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -72,7 +72,8 @@ spec:
           "Effect": "Allow",
           "Action": [
             "ec2:CreateVolume",
-            "ec2:EnableFastSnapshotRestores"
+            "ec2:EnableFastSnapshotRestores",
+            "ec2:LockSnapshot"
           ],
           "Resource": "arn:aws:ec2:*:*:snapshot/*"
         },

--- a/pkg/cloud/interface.go
+++ b/pkg/cloud/interface.go
@@ -42,4 +42,5 @@ type Cloud interface {
 	AvailabilityZones(ctx context.Context) (map[string]struct{}, error)
 	DryRun(ctx context.Context) error
 	GetInstancesPatching(ctx context.Context, nodeIDs []string) ([]*types.Instance, error)
+	LockSnapshot(ctx context.Context, lockOptions *SnapshotLockOptions) (err error)
 }

--- a/pkg/cloud/mock_cloud.go
+++ b/pkg/cloud/mock_cloud.go
@@ -289,6 +289,20 @@ func (mr *MockCloudMockRecorder) ListSnapshots(ctx, volumeID, maxResults, nextTo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSnapshots", reflect.TypeOf((*MockCloud)(nil).ListSnapshots), ctx, volumeID, maxResults, nextToken)
 }
 
+// LockSnapshot mocks base method.
+func (m *MockCloud) LockSnapshot(ctx context.Context, lockOptions *SnapshotLockOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LockSnapshot", ctx, lockOptions)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LockSnapshot indicates an expected call of LockSnapshot.
+func (mr *MockCloudMockRecorder) LockSnapshot(ctx, lockOptions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockSnapshot", reflect.TypeOf((*MockCloud)(nil).LockSnapshot), ctx, lockOptions)
+}
+
 // ModifyTags mocks base method.
 func (m *MockCloud) ModifyTags(ctx context.Context, volumeID string, tagOptions ModifyTagsOptions) error {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/mock_ec2.go
+++ b/pkg/cloud/mock_ec2.go
@@ -375,6 +375,26 @@ func (mr *MockEC2APIMockRecorder) EnableFastSnapshotRestores(ctx, params interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableFastSnapshotRestores", reflect.TypeOf((*MockEC2API)(nil).EnableFastSnapshotRestores), varargs...)
 }
 
+// LockSnapshot mocks base method.
+func (m *MockEC2API) LockSnapshot(ctx context.Context, params *ec2.LockSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.LockSnapshotOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "LockSnapshot", varargs...)
+	ret0, _ := ret[0].(*ec2.LockSnapshotOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LockSnapshot indicates an expected call of LockSnapshot.
+func (mr *MockEC2APIMockRecorder) LockSnapshot(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockSnapshot", reflect.TypeOf((*MockEC2API)(nil).LockSnapshot), varargs...)
+}
+
 // ModifyVolume mocks base method.
 func (m *MockEC2API) ModifyVolume(ctx context.Context, params *ec2.ModifyVolumeInput, optFns ...func(*ec2.Options)) (*ec2.ModifyVolumeOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -129,6 +129,18 @@ const (
 const (
 	// FastSnapshotRestoreAvailabilityZones represents key for fast snapshot restore availability zones.
 	FastSnapshotRestoreAvailabilityZones = "fastsnapshotrestoreavailabilityzones"
+
+	// LockMode represents a key for indicating whether snapshots are locked in Governance or Compliance mode.
+	LockMode = "lockmode"
+
+	// LockDuration is a key for the duration for which to lock the snapshots, specified in days.
+	LockDuration = "lockduration"
+
+	// LockExpirationDate is a key for specifying the expiration date for the snapshot lock, specified in the format "YYYY-MM-DDThh:mm:ss.sssZ".
+	LockExpirationDate = "lockexpirationdate"
+
+	// LockCoolOffPeriod is a key specifying the cooling-off period for compliance mode, specified in hours.
+	LockCoolOffPeriod = "lockcooloffperiod"
 )
 
 // constants for volume tags and their values.

--- a/pkg/util/ec2_interface.go
+++ b/pkg/util/ec2_interface.go
@@ -42,4 +42,5 @@ type EC2API interface {
 	CreateTags(ctx context.Context, params *ec2.CreateTagsInput, optFns ...func(*ec2.Options)) (*ec2.CreateTagsOutput, error)
 	DeleteTags(ctx context.Context, params *ec2.DeleteTagsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error)
 	EnableFastSnapshotRestores(ctx context.Context, params *ec2.EnableFastSnapshotRestoresInput, optFns ...func(*ec2.Options)) (*ec2.EnableFastSnapshotRestoresOutput, error)
+	LockSnapshot(ctx context.Context, params *ec2.LockSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.LockSnapshotOutput, error)
 }

--- a/tests/sanity/fake_sanity_cloud.go
+++ b/tests/sanity/fake_sanity_cloud.go
@@ -210,6 +210,10 @@ func (d *fakeCloud) EnableFastSnapshotRestores(ctx context.Context, availability
 	return &ec2.EnableFastSnapshotRestoresOutput{}, nil
 }
 
+func (d *fakeCloud) LockSnapshot(ctx context.Context, lockOptions *cloud.SnapshotLockOptions) error {
+	return nil
+}
+
 func (d *fakeCloud) GetDiskByName(ctx context.Context, name string, capacityBytes int64) (*cloud.Disk, error) {
 	return &cloud.Disk{}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What is this PR about? / Why do we need it?

This PR adds the ability for users to [lock snapshots](https://docs.aws.amazon.com/ebs/latest/userguide/snapshot-lock-concepts.html) on creation by passing in desired [LockSnapshot parameters](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LockSnapshot.html) through the VolumeSnapshotClass. 

#### How was this change tested?
Ran various unit tests as well as e2e tests that: 
- Created locked snapshots in governance mode
- Create locked snapshots in compliance mode
- Create locked snapshots with FSR 


Also manually tested by running a modified version of our snapshot example.
- In the `examples/kubernetes/snapshot` Change `snapshotclass.yaml` to:
```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: csi-aws-vsc
driver: ebs.csi.aws.com
deletionPolicy: Delete
parameters: 
  snapshotLockMode: "governance"
  snapshotLockDuration: "1"
```
- Run through example, and just make sure to unlock snapshot through AWS CLI before doing cleanup by running: 
```
aws ec2 unlock-snapshot --snapshot-id  snap-<snapshot-id>
```



#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Added VolumeSnapshotClass parameters to lock EBS snapshots after creation. 
```
