### PR TITLE
Pre-create report dir in config.sh

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -21,7 +21,7 @@ BIN="${BASE_DIR}/../../bin"
 TEST_DIR="${BASE_DIR}/csi-test-artifacts"
 # On Prow, $ARTIFACTS indicates where to put the artifacts for skylens upload
 REPORT_DIR="${ARTIFACTS:-${TEST_DIR}/artifacts}"
-mkdir -p "${TEST_DIR}"
+mkdir -p "${TEST_DIR}" "${REPORT_DIR}"
 CLUSTER_FILE=${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.yaml
 KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig"}
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

We're seeing failures in https://github.com/aws/csi-components/pull/23 because `REPORT_DIR` doesn't exist when it tries to dump the pod logs. I'm not exactly sure why this doesn't happen on the "real" CI, I suspect it has something to do with whether `ARTIFACTS` is set or not.

Regardless, always pre-create this directory so we know it's available.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
