### PR TITLE
Fix a1 e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,8 @@ e2e/external: bin/helm bin/kubetest2
 	COLLECT_METRICS="true" \
 	./hack/e2e/run.sh
 
-.PHONY: e2e/external-a1-eks
-e2e/external-a1-eks: bin/helm bin/kubetest2
+.PHONY: e2e/external-a1
+e2e/external-a1: bin/helm bin/kubetest2
 	HELM_EXTRA_FLAGS="--set=a1CompatibilityDaemonSet=true" \
 	./hack/e2e/run.sh
 

--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -70,7 +70,7 @@ function build_and_push() {
 
   PUSH_TYPE="sub-push"
 
-  if [[ "$INSTANCE_TYPE" == "a1.large" ]]; then
+  if [[ "$INSTANCE_TYPE" == "a1.xlarge" ]]; then
     # In the case of a1compat image we need both controller image and a1 compat node image
     PUSH_TYPE="sub-push sub-push-a1compat"
   fi

--- a/hack/e2e/create-cluster.sh
+++ b/hack/e2e/create-cluster.sh
@@ -59,7 +59,8 @@ if [[ "${CLUSTER_TYPE}" == "kops" ]]; then
     "$KUBECONFIG" \
     "${BASE_DIR}/kops/patch-cluster.yaml" \
     "${BASE_DIR}/kops/patch-node.yaml" \
-    "s3://${KOPS_BUCKET}"
+    "s3://${KOPS_BUCKET}" \
+    "${BIN}/gomplate"
 elif [[ "${CLUSTER_TYPE}" == "eksctl" ]]; then
   eksctl_create_cluster \
     "$CLUSTER_NAME" \

--- a/hack/e2e/kops/kops.sh
+++ b/hack/e2e/kops/kops.sh
@@ -32,6 +32,7 @@ function kops_create_cluster() {
   KOPS_PATCH_FILE=${10}
   KOPS_PATCH_NODE_FILE=${11}
   KOPS_STATE_FILE=${12}
+  GOMPLATE_BIN=${13}
   declare -x KOPS_TOO_NEW_VERSION=true
 
   if kops_cluster_exists "${CLUSTER_NAME}" "${KOPS_BIN}" "${KOPS_STATE_FILE}"; then
@@ -50,7 +51,10 @@ function kops_create_cluster() {
       "${CLUSTER_NAME}" >"${CLUSTER_FILE}"
 
     if test -f "$KOPS_PATCH_FILE"; then
-      kops_patch_cluster_file "$CLUSTER_FILE" "$KOPS_PATCH_FILE" "Cluster" ""
+      loudecho "Templating $KOPS_PATCH_FILE to $KOPS_PATCH_FILE.processed"
+      INSTANCE_TYPE="$INSTANCE_TYPE" \
+        ${GOMPLATE_BIN} -f "$KOPS_PATCH_FILE" -o "$KOPS_PATCH_FILE.processed"
+      kops_patch_cluster_file "$CLUSTER_FILE" "$KOPS_PATCH_FILE.processed" "Cluster" ""
     fi
     if test -f "$KOPS_PATCH_NODE_FILE"; then
       kops_patch_cluster_file "$CLUSTER_FILE" "$KOPS_PATCH_NODE_FILE" "InstanceGroup" "Node"

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -24,6 +24,20 @@ spec:
   kubeScheduler:
     featureGates:
       VolumeAttributesClass: "true"
+{{- if hasPrefix "a1." (env.Getenv "INSTANCE_TYPE") }}
+  containerd:
+    version: "1.7.28"
+    runc:
+      version: "1.3.0"
+  networking:
+    cilium: null
+    flannel:
+      backend: vxlan
+    podCIDR: 100.96.0.0/11
+    serviceClusterIPRange: 100.64.0.0/13
+  kubeProxy:
+    enabled: true
+{{- end }}
   additionalPolicies:
     node: |
       [

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -49,13 +49,13 @@ test-e2e-external-eks)
   TEST="external"
   export CLUSTER_TYPE="eksctl"
   ;;
-test-e2e-external-a1-eks)
-  TEST="external-a1-eks"
-  export K8S_VERSION_EKSCTL="1.30"
-  export INSTANCE_TYPE="a1.large"
+test-e2e-external-a1)
+  TEST="external-a1"
+  export AWS_AVAILABILITY_ZONES="us-west-2b,us-west-2c"
+  export INSTANCE_TYPE="a1.xlarge"
   export IMAGE_ARCH="arm64"
-  export CLUSTER_TYPE="eksctl"
-  export AMI_FAMILY="AmazonLinux2"
+  export AMI_PARAMETER="/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2"
+  export CLUSTER_TYPE="kops"
   ;;
 test-e2e-external-eks-bottlerocket)
   TEST="external-eks-bottlerocket"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind cleanup

#### What is this PR about? / Why do we need it?
This PR fixes up the a1 tests such that they can be run in CI again
#### How was this change tested?
Ran make e2e/external-a1 on an a1 cluster

```
Ran 106 of 7450 Specs in 348.622 seconds
SUCCESS! -- 106 Passed | 0 Failed | 0 Pending | 7344 Skipped


Ginkgo ran 1 suite in 5m51.955206757s
Test Suite Passed
+ TEST_PASSED=0
+ set -e
+ set +x
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
