### PR TITLE
Adjust error codes

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -168,6 +168,9 @@ var (
 	// name, but different size, is found.
 	ErrDiskExistsDiffSize = errors.New("there is already a disk with same name and different size")
 
+	// ErrSourceNotFound is returned when a volume's source is not found when provisioning using a source (snapshot or volume).
+	ErrSourceNotFound = errors.New("source was not found")
+
 	// ErrNotFound is returned when a resource is not found.
 	ErrNotFound = errors.New("resource was not found")
 
@@ -745,7 +748,9 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 	if err != nil {
 		switch {
 		case isAWSErrorSnapshotNotFound(err):
-			return nil, ErrNotFound
+			return nil, ErrSourceNotFound
+		case isAWSErrorVolumeNotFound(err):
+			return nil, ErrSourceNotFound
 		case isAWSErrorIdempotentParameterMismatch(err):
 			nextTokenNumber := 2
 			if tokenNumber, ok := c.latestClientTokens.Get(volumeName); ok {

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1287,7 +1287,7 @@ func TestCreateDisk(t *testing.T) {
 				AvailabilityZone: expZone,
 			},
 			expCreateVolumeInput: &ec2.CreateVolumeInput{},
-			expErr:               ErrNotFound,
+			expErr:               ErrSourceNotFound,
 			expCreateVolumeErr: &smithy.GenericAPIError{
 				Code:    "InvalidSnapshot.NotFound",
 				Message: "Snapshot not found",

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -405,16 +405,14 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if err != nil {
 		var errCode codes.Code
 		switch {
-		case errors.Is(err, cloud.ErrNotFound):
-			errCode = codes.NotFound
 		case errors.Is(err, cloud.ErrIdempotentParameterMismatch), errors.Is(err, cloud.ErrAlreadyExists):
 			errCode = codes.AlreadyExists
-		case errors.Is(err, cloud.ErrLimitExceeded):
-			errCode = codes.ResourceExhausted
 		case errors.Is(err, cloud.ErrInvalidArgument):
 			errCode = codes.InvalidArgument
+		case errors.Is(err, cloud.ErrSourceNotFound):
+			errCode = codes.NotFound
 		default:
-			errCode = codes.Internal
+			errCode = codes.Aborted
 		}
 		return nil, status.Errorf(errCode, "Could not create volume %q: %v", volName, err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -2445,62 +2445,7 @@ func TestCreateVolume(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "returns ResourceExhausted with MaxIOPSLimitExceeded error",
-			testFunc: func(t *testing.T) {
-				t.Helper()
-				req := &csi.CreateVolumeRequest{
-					Name:               "vol-test",
-					CapacityRange:      stdCapRange,
-					VolumeCapabilities: stdVolCap,
-				}
 
-				ctx := t.Context()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().CreateDisk(gomock.Eq(ctx), gomock.Eq(req.GetName()), gomock.Any()).Return(nil, cloud.ErrLimitExceeded)
-
-				awsDriver := ControllerService{
-					cloud:    mockCloud,
-					inFlight: internal.NewInFlight(),
-					options:  &Options{},
-				}
-
-				_, err := awsDriver.CreateVolume(ctx, req)
-				checkExpectedErrorCode(t, err, codes.ResourceExhausted)
-			},
-		},
-		{
-			name: "returns ResourceExhausted with VolumeLimitExceeded error",
-			testFunc: func(t *testing.T) {
-				t.Helper()
-				req := &csi.CreateVolumeRequest{
-					Name:               "vol-test",
-					CapacityRange:      stdCapRange,
-					VolumeCapabilities: stdVolCap,
-				}
-
-				ctx := t.Context()
-
-				mockCtl := gomock.NewController(t)
-				defer mockCtl.Finish()
-
-				mockCloud := cloud.NewMockCloud(mockCtl)
-				mockCloud.EXPECT().CreateDisk(gomock.Eq(ctx), gomock.Eq(req.GetName()), gomock.Any()).Return(nil, cloud.ErrLimitExceeded)
-
-				awsDriver := ControllerService{
-					cloud:    mockCloud,
-					inFlight: internal.NewInFlight(),
-					options:  &Options{},
-				}
-
-				_, err := awsDriver.CreateVolume(ctx, req)
-				checkExpectedErrorCode(t, err, codes.ResourceExhausted)
-			},
-		},
 		{
 			name: "success user tags override cluster tags",
 			testFunc: func(t *testing.T) {

--- a/tests/sanity/fake_sanity_cloud.go
+++ b/tests/sanity/fake_sanity_cloud.go
@@ -55,7 +55,7 @@ func (d *fakeCloud) CreateDisk(ctx context.Context, volumeID string, diskOptions
 
 	if diskOptions.SnapshotID != "" {
 		if _, exists := d.snapshots[diskOptions.SnapshotID]; !exists {
-			return nil, cloud.ErrNotFound
+			return nil, cloud.ErrSourceNotFound
 		}
 		newDisk := &cloud.Disk{
 			SnapshotID:       diskOptions.SnapshotID,


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What is this PR about? / Why do we need it?
This PR is to address what error codes we return on createVolume failures when we are unsure if a volume could have been created already.

#### How was this change tested?
New change not applied 

1. Created volume with describe volumes removed from managed policy
2. deleted pvc 
3. volume leaks 
4. fixed managed policy
5. external provisioner never retried as it did not receive aborted error code

After change with aborted error code is applied.

1. Created volume with describe volumes removed from managed policy
2. deleted pvc 
3. volume leaks 
4. fixed managed policy
5. external provisioner retries 
6. pv is created 
7. pv deleted 
8. leaked volume is deleted 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Adjust errors codes on create path to fix rare volume leak edge case
```
