### PR TITLE
Enable VAC v1beta1 fallback for K8s 1.31-1.33

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -261,6 +261,8 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_VAC_FALLBACK
+              value: "true"
             {{- if .Values.proxy.http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}
@@ -575,6 +577,8 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_VAC_FALLBACK
+              value: "true"
             {{- if .Values.proxy.http_proxy }}
             {{- include "aws-ebs-csi-driver.http-proxy" . | nindent 12 }}
             {{- end }}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -158,6 +158,8 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_VAC_FALLBACK
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -251,6 +253,8 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: ENABLE_VAC_FALLBACK
+              value: "true"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

VolumeAttributesClass (VAC) has graduated to GA in K8s 1.34, moving from `storage.k8s.io/v1beta1` to `storage.k8s.io/v1`. Kubernetes only supports the v1 API in newer external-provisioner (v6+) and external-resizer (v2+) releases with no fallback behavior.

As a result, users on K8s 1.31-1.33 who upgrade to upcoming CSI driver releases including external provisioner v6+ and resizer v2+ would see volume modification requests fail with:

```
failed to list *v1.VolumeAttributesClass: the server could not find the requested resource
```

To address this, we've patched the [AWS sidecar builds](https://github.com/aws/csi-components) to re-enable v1beta1 in environments where v1 API isn't available. This PR bumps to those patched versions and auto-enables the fallback for clusters in the affected version range.

#### How was this change tested?

```
make update && make verify && make test
```

```
helm upgrade --install aws-ebs-csi-driver --namespace kube-system ./charts/aws-ebs-csi-driver --values ./charts/aws-ebs-csi-driver/values.yam

kubectl describe pod ebs-csi-controller-6ddc76cbd7-9bndj -n kube-system | grep "ENABLE_VAC"

csi-provisioner:
  ENABLE_VAC_FALLBACK:  true

csi-resizer:
  ENABLE_VAC_FALLBACK:  true
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Helm: Enable VAC v1beta1 fallback for K8s 1.31-1.33
```
