### PR TITLE
Fix VAC fallback on 1.33 and before

### DIFF
--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Helm chart
 
+## 2.54.1
+
+### Bugfix
+
+- Fix VAC fallback on 1.33 and before by not explicitly enabling feature gate ([#2815](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2815), [@ConnorJC3](https://github.com/ConnorJC3))
+
 ## 2.54.0
 
 ### `a1CompatibilityDaemonSet` Deprecation Warning

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.54.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.54.0
+version: 2.54.1
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -249,8 +249,8 @@ spec:
             {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.provisioner.additionalArgs)) }}
             - --retry-interval-max=30m
             {{- end }}
-            {{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass" }}
-            - --feature-gates=VolumeAttributesClass=true
+            {{- if not (or (.Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass") (.Capabilities.APIVersions.Has "storage.k8s.io/v1/VolumeAttributesClass")) }}
+            - --feature-gates=VolumeAttributesClass=false
             {{- end }}
             {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.provisioner.additionalArgs))) }}
             - --http-endpoint=0.0.0.0:3302
@@ -565,8 +565,8 @@ spec:
             {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.resizer.additionalArgs)) }}
             - --retry-interval-max=30m
             {{- end }}
-            {{- if .Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass" }}
-            - --feature-gates=VolumeAttributesClass=true
+            {{- if not (or (.Capabilities.APIVersions.Has "storage.k8s.io/v1beta1/VolumeAttributesClass") (.Capabilities.APIVersions.Has "storage.k8s.io/v1/VolumeAttributesClass")) }}
+            - --feature-gates=VolumeAttributesClass=false
             {{- end }}
             {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.resizer.additionalArgs))) }}
             - --http-endpoint=0.0.0.0:3304

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -154,7 +154,6 @@ spec:
             - --kube-api-burst=100
             - --worker-threads=100
             - --retry-interval-max=30m
-            - --feature-gates=VolumeAttributesClass=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -249,7 +248,6 @@ spec:
             - --kube-api-burst=100
             - --workers=100
             - --retry-interval-max=30m
-            - --feature-gates=VolumeAttributesClass=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes #2813 by not explicitly enabling VAC (which forces V1 API). Explicitly disables VAC on clusters where neither API is available.

#### How was this change tested?

Manually tested on 1.33/1.29, CI for 1.34

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
