### PR TITLE
Update nodeDriverRegistrar livenessProbe

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -187,6 +187,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --http-endpoint=0.0.0.0:9809
           {{- if .Values.node.windowsHostProcess }}
             - --plugin-registration-path=$(PLUGIN_REG_DIR)
           {{- end }}
@@ -218,15 +219,13 @@ spec:
             {{- with .Values.sidecars.nodeDriverRegistrar.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          ports:
+            - name: healthz
+              containerPort: 9809
+          {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:
-            exec:
-              command:
-                - /csi-node-driver-registrar.exe
-                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-                - --mode=kubelet-registration-probe
-            initialDelaySeconds: 30
-            timeoutSeconds: 15
-            periodSeconds: 90
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -195,6 +195,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --http-endpoint=0.0.0.0:9809
             {{- if .Values.debugLogs }}
             - --v=7
             {{- else }}
@@ -218,6 +219,9 @@ spec:
           envFrom:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+          ports:
+            - name: healthz
+              containerPort: 9809
           {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -1141,35 +1141,7 @@
             },
             "livenessProbe": {
               "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "exec": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "command": {
-                      "type": "array",
-                      "default": [
-                        "/csi-node-driver-registrar",
-                        "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)",
-                        "--mode=kubelet-registration-probe"
-                      ]
-                    }
-                  }
-                },
-                "initialDelaySeconds": {
-                  "type": "integer",
-                  "default": 30
-                },
-                "periodSeconds": {
-                  "type": "integer",
-                  "default": 90
-                },
-                "timeoutSeconds": {
-                  "type": "integer",
-                  "default": 15
-                }
-              }
+              "additionalProperties": true
             }
           }
         },

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -154,11 +154,9 @@ sidecars:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
     livenessProbe:
-      exec:
-        command:
-          - /csi-node-driver-registrar
-          - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-          - --mode=kubelet-registration-probe
+      httpGet:
+        path: /healthz
+        port: healthz
       initialDelaySeconds: 30
       periodSeconds: 90
       timeoutSeconds: 15

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -115,21 +115,23 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --http-endpoint=0.0.0.0:9809
             - --v=2
           env:
             - name: ADDRESS
               value: unix:/csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: C:\var\lib\kubelet\plugins\ebs.csi.aws.com\csi.sock
+          ports:
+            - name: healthz
+              containerPort: 9809
           livenessProbe:
-            exec:
-              command:
-                - /csi-node-driver-registrar.exe
-                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-                - --mode=kubelet-registration-probe
+            httpGet:
+              path: /healthz
+              port: healthz
             initialDelaySeconds: 30
-            timeoutSeconds: 15
             periodSeconds: 90
+            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -118,18 +118,20 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --http-endpoint=0.0.0.0:9809
             - --v=2
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
+          ports:
+            - name: healthz
+              containerPort: 9809
           livenessProbe:
-            exec:
-              command:
-              - /csi-node-driver-registrar
-              - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-              - --mode=kubelet-registration-probe
+            httpGet:
+              path: /healthz
+              port: healthz
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What is this PR about? / Why do we need it?
This PR updates the driver registrars liveness probe to use the supported /healthz endpoint so that it can properly monitor container health.

/closes https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2812

#### How was this change tested?

Manually tested by: 
1. Creating cluster and installing driver
2. Deleting `ebs-csi-node` daemonset
3. Deploying two test pods on the same node
4. Deleting one of the pods (simulates duplication recovery behavior)
5. Monitor the remaining pod to ensure that the `ebs-plugin` container restarts after failing liveness probe, followed by `node-driver-registrar` container properly failing a health check and restarting. 

```
   Warning  Unhealthy  20m (x3 over 23m)  kubelet  Liveness probe failed: HTTP probe failed with statuscode: 404
   Normal   Killing    20m                kubelet  Container node-driver-registrar failed liveness probe, will be restarted
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Replaced deprecated node-driver-registrar liveness probe command with /healthz endpoint.
```
