### PR TITLE
Remove instances of gomock Any/AssignableToTypeOf/AnyTimes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,16 @@ linters:
     - noinlineerr # We use inline errors
     - embeddedstructfieldcheck # We have a few instances of this
   settings:
+    forbidigo:
+      forbid:
+        # Forbid testing anti-patterns Any/AssignableToTypeOf
+        - pattern: ^gomock\.Any$
+          msg: gomock.Any() is forbidden. Use gomock.Eq() or testutil matchers instead.
+        - pattern: ^gomock\.AssignableToTypeOf$
+          msg: gomock.AssignableToTypeOf() is forbidden. Use gomock.Eq() or testutil matchers instead.
+        # Default pattern, keep it enabled
+        - pattern: ^(fmt\.Print(|f|ln)|print|println)$
+          msg: Printing using fmt is forbidden. Use klog instead.
     revive:
       rules:
         # Using += 1 instead of ++ is fine

--- a/pkg/cloud/metadata/labels_test.go
+++ b/pkg/cloud/metadata/labels_test.go
@@ -447,7 +447,7 @@ func TestPatchNewNodes(t *testing.T) {
 			pvInformer := setupPVInformer(t, nil)
 
 			instances := []*types.Instance{makeInstance("i-001", tt.metadata["i-001"].ENIs, []string{"vol-001", "vol-002"})}
-			mockCloud.EXPECT().GetInstancesPatching(ctx, []string{"i-001"}).Return(instances, nil).AnyTimes()
+			mockCloud.EXPECT().GetInstancesPatching(ctx, []string{"i-001"}).Return(instances, nil).MinTimes(1)
 
 			patched := make(chan struct{})
 			clientset.PrependReactor("patch", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2024 The Kubernetes Authors.
 
@@ -31,6 +33,7 @@ import (
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/metadata"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver/internal"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/mounter"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/testutil"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -103,11 +106,11 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().NeedResize(gomock.Any(), gomock.Any()).Return(false, nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
+				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -259,12 +262,12 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(false, nil)
-				m.EXPECT().MakeDir(gomock.Any()).Return(nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 0, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), defaultFsType, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().NeedResize(gomock.Any(), gomock.Any()).Return(false, nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(false, nil)
+				m.EXPECT().MakeDir(gomock.Eq("/staging/path")).Return(nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 0, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq(defaultFsType), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
+				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -562,11 +565,11 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), "1", gomock.Any()).Return("/dev/xvdba1", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().NeedResize(gomock.Any(), gomock.Any()).Return(false, nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq("1"), gomock.Eq("us-west-2")).Return("/dev/xvdba1", nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba1"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
+				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba1"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -600,11 +603,11 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), "", gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().NeedResize(gomock.Any(), gomock.Any()).Return(false, nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
+				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -666,7 +669,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(false, errors.New("path exists error"))
 				return m
 			},
@@ -698,7 +701,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(false, nil)
 				m.EXPECT().MakeDir(gomock.Eq("/staging/path")).Return(errors.New("make dir error"))
 				return m
@@ -731,7 +734,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 0, errors.New("get device name error"))
 				return m
@@ -764,7 +767,7 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("/dev/xvdba", 1, nil)
 				return m
@@ -797,10 +800,10 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("format and mount error"))
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(errors.New("format and mount error"))
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -831,10 +834,10 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
 				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, errors.New("need resize error"))
 				return m
 			},
@@ -866,10 +869,10 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
 				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().Resize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, errors.New("resize error"))
 				return m
@@ -910,10 +913,10 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Any(), gomock.Any(), gomock.Eq([]string{"-b", "4096", "-I", "512", "-i", "16384", "-N", "1000000", "-O", "bigalloc", "-C", "65536"})).Return(nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{"-b", "4096", "-I", "512", "-i", "16384", "-N", "1000000", "-O", "bigalloc", "-C", "65536"})).Return(nil)
 				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
@@ -987,10 +990,10 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("xfs"), gomock.Any(), gomock.Any(), gomock.Eq([]string{"-b", "size=4096", "-i", "size=512"})).Return(nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("xfs"), gomock.Eq([]string{"nouuid"}), gomock.Nil(), gomock.Eq([]string{"-b", "size=4096", "-i", "size=512"})).Return(nil)
 				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
@@ -1025,10 +1028,10 @@ func TestNodeStageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
 				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
 				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("xfs"), gomock.Any(), gomock.Any(), gomock.Eq([]string{"-i", "size=512", "-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"})).Return(nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("xfs"), gomock.Eq([]string{"nouuid"}), gomock.Nil(), gomock.Eq([]string{"-i", "size=512", "-m", "bigtime=0,inobtcount=0,reflink=0", "-i", "nrext64=0"})).Return(nil)
 				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
@@ -1063,10 +1066,10 @@ func TestNodeStageVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-real"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-				m.EXPECT().NeedResize(gomock.Any(), gomock.Any()).Return(false, nil)
+				m.EXPECT().PathExists(gomock.Eq("/staging/path")).Return(true, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().FormatAndMountSensitiveWithFormatOptions(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path"), gomock.Eq("ext4"), gomock.Nil(), gomock.Nil(), gomock.Eq([]string{})).Return(nil)
+				m.EXPECT().NeedResize(gomock.Eq("/dev/xvdba"), gomock.Eq("/staging/path")).Return(false, nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1466,11 +1469,11 @@ func TestNodePublishVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().MakeFile(gomock.Any()).Return(nil)
-				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
-				m.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/target")).Return(true, nil)
+				m.EXPECT().MakeFile(gomock.Eq("/target/path")).Return(nil)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Eq("/target/path")).Return(true, nil)
+				m.EXPECT().Mount(gomock.Eq("/dev/xvdba"), gomock.Eq("/target/path"), gomock.Eq(""), gomock.Eq([]string{"bind"})).Return(nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1499,9 +1502,9 @@ func TestNodePublishVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().PreparePublishTarget(gomock.Any()).Return(nil)
-				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
-				m.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().PreparePublishTarget(gomock.Eq("/target/path")).Return(nil)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Eq("/target/path")).Return(true, nil)
+				m.EXPECT().Mount(gomock.Eq("/staging/path"), gomock.Eq("/target/path"), gomock.Eq("ext4"), gomock.Eq([]string{"bind"})).Return(nil)
 				return m
 			},
 		},
@@ -1637,11 +1640,11 @@ func TestNodePublishVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().MakeFile(gomock.Any()).Return(nil)
-				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
-				m.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/target")).Return(true, nil)
+				m.EXPECT().MakeFile(gomock.Eq("/target/path")).Return(nil)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Eq("/target/path")).Return(true, nil)
+				m.EXPECT().Mount(gomock.Eq("/dev/xvdba"), gomock.Eq("/target/path"), gomock.Eq(""), gomock.Eq([]string{"bind", "ro"})).Return(nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1714,11 +1717,11 @@ func TestNodePublishVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().MakeFile(gomock.Any()).Return(nil)
-				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
-				m.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
+				m.EXPECT().PathExists(gomock.Eq("/target")).Return(true, nil)
+				m.EXPECT().MakeFile(gomock.Eq("/target/path")).Return(nil)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Eq("/target/path")).Return(true, nil)
+				m.EXPECT().Mount(gomock.Eq("/dev/xvdba"), gomock.Eq("/target/path"), gomock.Eq(""), gomock.Eq([]string{"bind"})).Return(nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1751,11 +1754,11 @@ func TestNodePublishVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().MakeFile(gomock.Any()).Return(nil)
-				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
-				m.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq("1"), gomock.Eq("us-west-2")).Return("/dev/xvdba1", nil)
+				m.EXPECT().PathExists(gomock.Eq("/target")).Return(true, nil)
+				m.EXPECT().MakeFile(gomock.Eq("/target/path")).Return(nil)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Eq("/target/path")).Return(true, nil)
+				m.EXPECT().Mount(gomock.Eq("/dev/xvdba1"), gomock.Eq("/target/path"), gomock.Eq(""), gomock.Eq([]string{"bind"})).Return(nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1785,7 +1788,7 @@ func TestNodePublishVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 
-				m.EXPECT().FindDevicePath(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("device path error"))
+				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-test"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("", errors.New("device path error"))
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1817,10 +1820,10 @@ func TestNodePublishVolume(t *testing.T) {
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
 				m.EXPECT().FindDevicePath(gomock.Eq("/dev/xvdba"), gomock.Eq("vol-real"), gomock.Eq(""), gomock.Eq("us-west-2")).Return("/dev/xvdba", nil)
-				m.EXPECT().PathExists(gomock.Any()).Return(true, nil)
-				m.EXPECT().MakeFile(gomock.Any()).Return(nil)
-				m.EXPECT().IsLikelyNotMountPoint(gomock.Any()).Return(true, nil)
-				m.EXPECT().Mount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				m.EXPECT().PathExists(gomock.Eq("/target")).Return(true, nil)
+				m.EXPECT().MakeFile(gomock.Eq("/target/path")).Return(nil)
+				m.EXPECT().IsLikelyNotMountPoint(gomock.Eq("/target/path")).Return(true, nil)
+				m.EXPECT().Mount(gomock.Eq("/dev/xvdba"), gomock.Eq("/target/path"), gomock.Eq(""), gomock.Eq([]string{"bind"})).Return(nil)
 				return m
 			},
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
@@ -1899,8 +1902,8 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("dev-test", 1, nil)
-				m.EXPECT().Unstage(gomock.Any()).Return(nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("dev-test", 1, nil)
+				m.EXPECT().Unstage(gomock.Eq("/staging/path")).Return(nil)
 				return m
 			},
 		},
@@ -1926,8 +1929,8 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 1, nil)
-				m.EXPECT().Unstage(gomock.Any()).Return(errors.New("unstage failed"))
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 1, nil)
+				m.EXPECT().Unstage(gomock.Eq("/staging/path")).Return(errors.New("unstage failed"))
 				return m
 			},
 			expectedErr: status.Errorf(codes.Internal, "Could not unmount target %q: %v", "/staging/path", errors.New("unstage failed")),
@@ -1940,7 +1943,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 0, nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 0, nil)
 				return m
 			},
 		},
@@ -1952,7 +1955,7 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("", 0, errors.New("failed to get device name"))
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("", 0, errors.New("failed to get device name"))
 				return m
 			},
 			expectedErr: status.Error(codes.Internal, "failed to check if target \"/staging/path\" is a mount point: failed to get device name"),
@@ -1965,8 +1968,8 @@ func TestNodeUnstageVolume(t *testing.T) {
 			},
 			mounterMock: func(ctrl *gomock.Controller) *mounter.MockMounter {
 				m := mounter.NewMockMounter(ctrl)
-				m.EXPECT().GetDeviceNameFromMount(gomock.Any()).Return("dev-test", 2, nil)
-				m.EXPECT().Unstage(gomock.Any()).Return(nil)
+				m.EXPECT().GetDeviceNameFromMount(gomock.Eq("/staging/path")).Return("dev-test", 2, nil)
+				m.EXPECT().Unstage(gomock.Eq("/staging/path")).Return(nil)
 				return m
 			},
 		},
@@ -2664,13 +2667,13 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 
 				mockClient := NewMockKubernetesClient(mockCtl)
 				storageV1Mock := NewMockStorageV1Interface(mockCtl)
-				mockClient.EXPECT().StorageV1().Return(storageV1Mock).AnyTimes()
+				mockClient.EXPECT().StorageV1().Return(storageV1Mock).MinTimes(1)
 
 				csiNodesMock := NewMockCSINodeInterface(mockCtl)
 				storageV1Mock.EXPECT().CSINodes().Return(csiNodesMock).Times(1)
 
 				csiNodesMock.EXPECT().
-					Get(gomock.Any(), gomock.Eq(nodeName), gomock.Any()).
+					Get(testutil.AnyContext(), gomock.Eq(nodeName), gomock.Eq(metav1.GetOptions{})).
 					Return(nil, errors.New("failed to get CSINode")).
 					Times(1)
 
@@ -2703,7 +2706,7 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 
 				mockClient := NewMockKubernetesClient(mockCtl)
 				storageV1Mock := NewMockStorageV1Interface(mockCtl)
-				mockClient.EXPECT().StorageV1().Return(storageV1Mock).AnyTimes()
+				mockClient.EXPECT().StorageV1().Return(storageV1Mock).MinTimes(1)
 
 				csiNodesMock := NewMockCSINodeInterface(mockCtl)
 				storageV1Mock.EXPECT().CSINodes().Return(csiNodesMock).Times(1)
@@ -2726,7 +2729,7 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 				}
 
 				csiNodesMock.EXPECT().
-					Get(gomock.Any(), gomock.Eq(nodeName), gomock.Any()).
+					Get(testutil.AnyContext(), gomock.Eq(nodeName), gomock.Eq(metav1.GetOptions{})).
 					Return(mockCSINode, nil).
 					Times(1)
 
@@ -2759,7 +2762,7 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 				mockClient := NewMockKubernetesClient(mockCtl)
 
 				storageV1Mock := NewMockStorageV1Interface(mockCtl)
-				mockClient.EXPECT().StorageV1().Return(storageV1Mock).AnyTimes()
+				mockClient.EXPECT().StorageV1().Return(storageV1Mock).MinTimes(1)
 
 				csiNodesMock := NewMockCSINodeInterface(mockCtl)
 				storageV1Mock.EXPECT().CSINodes().Return(csiNodesMock).Times(1)
@@ -2782,23 +2785,24 @@ func TestRemoveNotReadyTaint(t *testing.T) {
 				}
 
 				csiNodesMock.EXPECT().
-					Get(gomock.Any(), gomock.Eq(nodeName), gomock.Any()).
+					Get(testutil.AnyContext(), gomock.Eq(nodeName), gomock.Eq(metav1.GetOptions{})).
 					Return(mockCSINode, nil).
 					Times(1)
 
 				coreV1Mock := NewMockCoreV1Interface(mockCtl)
-				mockClient.EXPECT().CoreV1().Return(coreV1Mock).AnyTimes()
+				mockClient.EXPECT().CoreV1().Return(coreV1Mock).MinTimes(1)
 
 				nodesMock := NewMockNodeInterface(mockCtl)
 				coreV1Mock.EXPECT().Nodes().Return(nodesMock).Times(1)
 
+				const expectedPatch = `[{"op":"test","path":"/spec/taints","value":[{"key":"test.ebs.csi.aws.com/agent-not-ready","effect":"NoSchedule"},{"key":"some-other-taint","effect":"NoExecute"}]},{"op":"replace","path":"/spec/taints","value":[{"key":"some-other-taint","effect":"NoExecute"}]}]`
 				nodesMock.EXPECT().
 					Patch(
-						gomock.Any(),
+						testutil.AnyContext(),
 						gomock.Eq(nodeName),
 						gomock.Eq(k8stypes.JSONPatchType),
-						gomock.Any(),
-						gomock.Any(),
+						gomock.Eq([]byte(expectedPatch)),
+						gomock.Eq(metav1.PatchOptions{}),
 					).
 					Return(node, nil).
 					Times(1)

--- a/pkg/testutil/matchers.go
+++ b/pkg/testutil/matchers.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/golang/mock/gomock"
+)
+
+type contextMatcher struct{}
+
+func (m contextMatcher) Matches(x any) bool {
+	_, ok := x.(context.Context)
+	return ok
+}
+
+func (m contextMatcher) String() string {
+	return "is context"
+}
+
+func AnyContext() gomock.Matcher {
+	return contextMatcher{}
+}
+
+type typeMatcher struct {
+	t reflect.Type
+}
+
+func (m typeMatcher) Matches(x any) bool {
+	if x == nil {
+		return false
+	}
+	return reflect.TypeOf(x) == m.t
+}
+
+func (m typeMatcher) String() string {
+	return "is type " + m.t.String()
+}
+
+func OfType(example any) gomock.Matcher {
+	return typeMatcher{t: reflect.TypeOf(example)}
+}
+
+type ec2OptionsMatcher struct{}
+
+func (m ec2OptionsMatcher) Matches(x any) bool {
+	// Check if it's a single function
+	if fn, ok := x.(func(*ec2.Options)); ok {
+		return fn != nil
+	}
+	// Check if it's a slice of functions
+	v := reflect.ValueOf(x)
+	if v.Kind() != reflect.Slice {
+		return false
+	}
+	sliceType := reflect.TypeOf(x)
+	return sliceType.Elem() == reflect.TypeFor[func(*ec2.Options)]()
+}
+
+func (m ec2OptionsMatcher) String() string {
+	return "is EC2 options function or slice"
+}
+
+func EC2Options() gomock.Matcher {
+	return ec2OptionsMatcher{}
+}
+
+type ec2InputMatcher struct {
+	expectedType reflect.Type
+}
+
+func (m ec2InputMatcher) Matches(x any) bool {
+	if x == nil {
+		return false
+	}
+	return reflect.TypeOf(x) == m.expectedType
+}
+
+func (m ec2InputMatcher) String() string {
+	return "is " + m.expectedType.String()
+}
+
+func EC2Input(example any) gomock.Matcher {
+	return ec2InputMatcher{expectedType: reflect.TypeOf(example)}
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Greatly improves the robustness of unit tests by removing all instances of `gomock.Any()` and `.AnyTimes()` from the code.

A few edge cases:
- Some values (contexts and EC2 option functions), are nearly impossible to match on with `gomock.Eq()`. I created custom matchers for these cases. A new `testutil` package was created so these matchers can be reused in all tests.
- In some cases we are mocking a value passed in by non-driver code (primarily, the List and Watch calls from informers). To avoid testing Kubernetes code, we use `gomock.AssignableToTypeOf()` in those cases.
- In the request coalescing test, the input doesn't matter much and the parts that do are validated in the `DoAndReturn`, so I used `AssignableToTypeOf`
- A few instances of `AnyTimes` are left in that are exceptionally difficult to remove without major refactoring of the tests
- EC2 Inputs are difficult to match because of tag ordering, the EC2 Input matcher will be made to match more strictly at a later date.

#### How was this change tested?

`make test` and `make verify`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```