### PR TITLE
Detect and disallow use of IMDS as a metadata source on Hyperpod Nodes

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1152,7 +1152,7 @@ func (c *cloud) batchDescribeInstances(request *ec2.DescribeInstancesInput) (*ty
 }
 
 func (c *cloud) AttachDisk(ctx context.Context, volumeID, nodeID string) (string, error) {
-	if isHyperPodNode(nodeID) {
+	if util.IsHyperPodNode(nodeID) {
 		return c.attachDiskHyperPod(ctx, volumeID, nodeID)
 	}
 
@@ -1272,7 +1272,7 @@ func (c *cloud) attachDiskHyperPod(ctx context.Context, volumeID, nodeID string)
 }
 
 func (c *cloud) DetachDisk(ctx context.Context, volumeID, nodeID string) error {
-	if isHyperPodNode(nodeID) {
+	if util.IsHyperPodNode(nodeID) {
 		return c.detachDiskHyperPod(ctx, volumeID, nodeID)
 	}
 	instance, err := c.getInstance(ctx, nodeID)
@@ -1515,7 +1515,7 @@ func (c *cloud) describeVolumeStatus(volumeID string, callASAP bool) (*types.Vol
 // WaitForAttachmentState polls until the attachment status is the expected value.
 func (c *cloud) WaitForAttachmentState(ctx context.Context, expectedState types.VolumeAttachmentState, volumeID string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*types.VolumeAttachment, error) {
 	var attachment *types.VolumeAttachment
-	isHyperPod := isHyperPodNode(expectedInstance)
+	isHyperPod := util.IsHyperPodNode(expectedInstance)
 
 	verifyVolumeFunc := func(ctx context.Context) (bool, error) {
 		request := &ec2.DescribeVolumesInput{
@@ -1689,10 +1689,6 @@ func (c *cloud) GetVolumeIDByNodeAndDevice(ctx context.Context, nodeID string, d
 	}
 
 	return "", fmt.Errorf("volume not found at device %s on node %s: %w", deviceName, nodeID, ErrNotFound)
-}
-
-func isHyperPodNode(nodeID string) bool {
-	return strings.HasPrefix(nodeID, "hyperpod-")
 }
 
 // Only for hyperpod node, getInstanceIDFromHyperPodNode extracts the EC2 instance ID from a HyperPod node ID.

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -2923,38 +2923,6 @@ func TestGetDiskByID(t *testing.T) {
 	}
 }
 
-func TestIsHyperPodNode(t *testing.T) {
-	tests := []struct {
-		name     string
-		nodeID   string
-		expected bool
-	}{
-		{
-			name:     "success: valid hyperpod node ID",
-			nodeID:   "hyperpod-abc123-i-0123456789abcdef0",
-			expected: true,
-		},
-		{
-			name:     "success: regular EC2 instance ID",
-			nodeID:   "i-0123456789abcdef0",
-			expected: false,
-		},
-		{
-			name:     "success: empty string",
-			nodeID:   "",
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := isHyperPodNode(tt.nodeID); got != tt.expected {
-				t.Errorf("isHyperPodNode() = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}
-
 func TestGetInstanceIDFromHyperPodNode(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -219,3 +219,7 @@ func WaitUntilTimeOrContext(ctx context.Context, wakeup time.Time) {
 	case <-time.After(time.Until(wakeup)):
 	}
 }
+
+func IsHyperPodNode(nodeID string) bool {
+	return strings.HasPrefix(nodeID, "hyperpod-")
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -318,3 +318,35 @@ func TestWaitUntilTimeOrContext(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHyperPodNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeID   string
+		expected bool
+	}{
+		{
+			name:     "success: valid hyperpod node ID",
+			nodeID:   "hyperpod-abc123-i-0123456789abcdef0",
+			expected: true,
+		},
+		{
+			name:     "success: regular EC2 instance ID",
+			nodeID:   "i-0123456789abcdef0",
+			expected: false,
+		},
+		{
+			name:     "success: empty string",
+			nodeID:   "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsHyperPodNode(tt.nodeID); got != tt.expected {
+				t.Errorf("isHyperPodNode() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What is this PR about? / Why do we need it?

#### How was this change tested?
Spun up a HyperPod cluster
installed modified driver 
observed we no longer use IMDS on HyperPod nodes

```
 │ I0107 20:03:42.352667       1 main.go:164] "Initializing metadata"                                                                                                                                                 │
│ I0107 20:03:42.353237       1 metadata.go:70] "HyperPod node detected. Will not rely on IMDS for instance metadata"                                                                                                │
│ I0107 20:03:42.353328       1 metadata.go:92] "Attempting to retrieve instance metadata from Kubernetes API"                                                                                                       │
│ I0107 20:03:42.353820       1 envvar.go:172] "Feature gate default state" feature="InOrderInformers" enabled=true                                                                                                  │
│ I0107 20:03:42.354032       1 envvar.go:172] "Feature gate default state" feature="InformerResourceVersion" enabled=false                                                                                          │
│ I0107 20:03:42.354112       1 envvar.go:172] "Feature gate default state" feature="WatchListClient" enabled=false                                                                                                  │
│ I0107 20:03:42.354182       1 envvar.go:172] "Feature gate default state" feature="ClientsAllowCBOR" enabled=false                                                                                                 │
│ I0107 20:03:42.354266       1 envvar.go:172] "Feature gate default state" feature="ClientsPreferCBOR" enabled=false                                                                                                │
│ I0107 20:03:42.365509       1 k8s.go:127] "Using ENI count from SageMaker label" count=2                                                                                                                           │
│ I0107 20:03:42.365549       1 k8s.go:138] "Using block device mapping count from SageMaker label" count=1
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Automatically detect and prevent use of IMDS on Hyper-pod nodes
```
