### PR TITLE
Remove a1compat image and references to it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,6 @@ FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:lat
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al2@sha256:1c6fc8e4810d495f9ca3722b81d922785eb509cffed802fd4228874fef3b63bb AS linux-al2
-COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
-ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
-
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:1809@sha256:517651cbf291f9e38da7e06a415dbd71860a77977ff127b32be856e7594e2052 AS windows-ltsc2019
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENV PATH="C:\\Windows\\System32\\WindowsPowerShell\\v1.0;${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,6 @@ e2e/external: bin/helm bin/kubetest2
 	COLLECT_METRICS="true" \
 	./hack/e2e/run.sh
 
-.PHONY: e2e/external-a1
-e2e/external-a1: bin/helm bin/kubetest2
-	HELM_EXTRA_FLAGS="--set=a1CompatibilityDaemonSet=true" \
-	./hack/e2e/run.sh
-
 .PHONY: e2e/external-eks-bottlerocket
 e2e/external-eks-bottlerocket: bin/helm bin/kubetest2
 	GINKGO_SKIP=$(GINKGO_BOTTLEROCKET_SKIP) \
@@ -242,12 +237,8 @@ sub-push: all-image-registry push-manifest
 sub-push-fips:
 	$(MAKE) FIPS=true TAG=$(TAG)-fips sub-push
 
-.PHONY: sub-push-a1compat
-sub-push-a1compat:
-	$(MAKE) DOCKER_EXTRA_ARGS="-t=$(IMAGE):$(TAG)-a1compat" sub-image-linux-arm64-al2
-
 .PHONY: all-push
-all-push: sub-push sub-push-fips sub-push-a1compat
+all-push: sub-push sub-push-fips
 
 test-e2e-%:
 	./hack/prow-e2e.sh test-e2e-$*

--- a/charts/aws-ebs-csi-driver/templates/NOTES.txt
+++ b/charts/aws-ebs-csi-driver/templates/NOTES.txt
@@ -2,5 +2,5 @@ To verify that aws-ebs-csi-driver has started, run:
 
     kubectl get pod -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "aws-ebs-csi-driver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
-EBS CSI Driver Helm Chart versions 2.55.0 and later will not support the "a1CompatibilityDaemonSet" parameter. For more information see the EBS CSI Helm Chart changelog:
+The "a1CompatibilityDaemonSet" parameter is no longer supported. For more information see the EBS CSI Helm Chart changelog:
 https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/CHANGELOG.md#2540

--- a/charts/aws-ebs-csi-driver/templates/node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/node.yaml
@@ -11,39 +11,3 @@
 }}
 {{- include "node" (deepCopy $ | mustMerge $args) -}}
 {{- end }}
-{{- if .Values.a1CompatibilityDaemonSet }}
-{{- if .Values.fips -}}
-{{- fail "FIPS mode not supported for A1 instance family compatibility image" -}}
-{{- end -}}
-{{$args := dict
-  "NodeName" "ebs-csi-node-a1compat"
-  "Values" (dict
-    "image" (dict
-      "tag" (printf "%s-a1compat" (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)))
-    )
-    "node" (dict
-      "affinity" (dict
-        "nodeAffinity" (dict
-          "requiredDuringSchedulingIgnoredDuringExecution" (dict
-            "nodeSelectorTerms" (list
-              (dict "matchExpressions" (list
-                (dict
-                  "key" "eks.amazonaws.com/compute-type"
-                  "operator" "NotIn"
-                  "values" (list "fargate" "auto" "hybrid")
-                )
-                (dict
-                  "key" "node.kubernetes.io/instance-type"
-                  "operator" "In"
-                  "values" (list "a1.medium" "a1.large" "a1.xlarge" "a1.2xlarge" "a1.4xlarge")
-                )
-              ))
-            )
-          )
-        )
-      )
-    )
-  )
-}}
-{{- include "node" (deepCopy $ | mustMerge $args) -}}
-{{- end }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -13,11 +13,6 @@
       "type": ["boolean", "null"],
       "description": "No effect - reserved for use in sub-charting"
     },
-    "a1CompatibilityDaemonSet": {
-      "type": "boolean",
-      "description": "Enable compatibility for the A1 instance family via use of an AL2-based image in a separate DaemonSet",
-      "default": false
-    },
     "additionalDaemonSets": {
       "type": ["object", "null"],
       "additionalProperties": false,
@@ -520,17 +515,6 @@
                         "key": "eks.amazonaws.com/compute-type",
                         "operator": "NotIn",
                         "values": ["fargate", "auto", "hybrid"]
-                      },
-                      {
-                        "key": "node.kubernetes.io/instance-type",
-                        "operator": "NotIn",
-                        "values": [
-                          "a1.medium",
-                          "a1.large",
-                          "a1.xlarge",
-                          "a1.2xlarge",
-                          "a1.4xlarge"
-                        ]
                       }
                     ]
                   }

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -396,14 +396,6 @@ node:
                   - fargate
                   - auto
                   - hybrid
-              - key: node.kubernetes.io/instance-type
-                operator: NotIn
-                values:
-                  - a1.medium
-                  - a1.large
-                  - a1.xlarge
-                  - a1.2xlarge
-                  - a1.4xlarge
   nodeSelector: {}
   daemonSetAnnotations: {}
   podAnnotations: {}
@@ -505,8 +497,6 @@ additionalDaemonSets:
 #     node.kubernetes.io/instance-type: c5.large
 #   volumeAttachLimit: 15
 
-# Enable compatibility for the A1 instance family via use of an AL2-based image in a separate DaemonSet
-# a1CompatibilityDaemonSet: true
 storageClasses: []
 # Add StorageClass resources like:
 # - name: ebs-sc

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -33,14 +33,6 @@ spec:
                 - fargate
                 - auto
                 - hybrid
-              - key: node.kubernetes.io/instance-type
-                operator: NotIn
-                values:
-                - a1.medium
-                - a1.large
-                - a1.xlarge
-                - a1.2xlarge
-                - a1.4xlarge
       nodeSelector:
         kubernetes.io/os: windows
       serviceAccountName: ebs-csi-node-sa

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -33,14 +33,6 @@ spec:
                 - fargate
                 - auto
                 - hybrid
-              - key: node.kubernetes.io/instance-type
-                operator: NotIn
-                values:
-                - a1.medium
-                - a1.large
-                - a1.xlarge
-                - a1.2xlarge
-                - a1.4xlarge
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: ebs-csi-node-sa

--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -70,10 +70,6 @@ function build_and_push() {
 
   PUSH_TYPE="sub-push"
 
-  if [[ "$INSTANCE_TYPE" == "a1.xlarge" ]]; then
-    # In the case of a1compat image we need both controller image and a1 compat node image
-    PUSH_TYPE="sub-push sub-push-a1compat"
-  fi
   if [[ "${FIPS_TEST}" == "true" ]]; then
     PUSH_TYPE="sub-push-fips"
   fi

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -24,20 +24,6 @@ spec:
   kubeScheduler:
     featureGates:
       VolumeAttributesClass: "true"
-{{- if hasPrefix "a1." (env.Getenv "INSTANCE_TYPE") }}
-  containerd:
-    version: "1.7.28"
-    runc:
-      version: "1.3.0"
-  networking:
-    cilium: null
-    flannel:
-      backend: vxlan
-    podCIDR: 100.96.0.0/11
-    serviceClusterIPRange: 100.64.0.0/13
-  kubeProxy:
-    enabled: true
-{{- end }}
   additionalPolicies:
     node: |
       [

--- a/hack/e2e/test-images.sh
+++ b/hack/e2e/test-images.sh
@@ -65,7 +65,7 @@ build_and_push "${AWS_REGION}" \
   "${IMAGE_TAG}" \
   "${IMAGE_ARCH}"
 
-imageSuffixes=("a1compat fips-windows-amd64-ltsc2022 fips-windows-amd64-ltsc2019 windows-amd64-ltsc2019 windows-amd64-ltsc2022 fips-linux-amd64-al2023 fips-linux-arm64-al2023 linux-amd64-al2023 linux-arm64-al2023 linux-arm64-al2")
+imageSuffixes=("fips-windows-amd64-ltsc2022 fips-windows-amd64-ltsc2019 windows-amd64-ltsc2019 windows-amd64-ltsc2022 fips-linux-amd64-al2023 fips-linux-arm64-al2023 linux-amd64-al2023 linux-arm64-al2023")
 
 loudecho "Ensuring all images are present"
 

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -49,14 +49,6 @@ test-e2e-external-eks)
   TEST="external"
   export CLUSTER_TYPE="eksctl"
   ;;
-test-e2e-external-a1)
-  TEST="external-a1"
-  export AWS_AVAILABILITY_ZONES="us-west-2b,us-west-2c"
-  export INSTANCE_TYPE="a1.xlarge"
-  export IMAGE_ARCH="arm64"
-  export AMI_PARAMETER="/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-arm64-gp2"
-  export CLUSTER_TYPE="kops"
-  ;;
 test-e2e-external-eks-bottlerocket)
   TEST="external-eks-bottlerocket"
   export CLUSTER_TYPE="eksctl"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

We're no longer supporting the a1compat image as of the next release, prepare the repo for that.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Removed a1compat - TODO: Release author copy the warning from last release and tweak it
```
