### PR TITLE
Enable MutableCSINodeAllocatableCount feature gate in external-attacher

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -324,6 +324,9 @@ spec:
             {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.attacher.additionalArgs)) }}
             - --retry-interval-max=5m
             {{- end }}
+            {{- if semverCompare ">=1.33.0-0" .Capabilities.KubeVersion.Version }}
+            - --feature-gates=MutableCSINodeAllocatableCount=true
+            {{- end }}
             {{- if and (.Values.controller.enableMetrics) (not (regexMatch "(-http-endpoint)" (join " " .Values.sidecars.attacher.additionalArgs))) }}
             - --http-endpoint=0.0.0.0:3303
             {{- end}}

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -186,6 +186,7 @@ spec:
             - --kube-api-burst=100
             - --worker-threads=100
             - --retry-interval-max=5m
+            - --feature-gates=MutableCSINodeAllocatableCount=true
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

This PR sets `--feature-gates=MutableCSINodeAllocatableCount=true`  in external-attacher controller config.

#### How was this change tested?

```
make test && make verify
```

```
kubectl describe pod ebs-csi-controller-57b89486f4-8vsx5 -n kube-system | grep "feature"

--feature-gates=MutableCSINodeAllocatableCount=true
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Helm: Enable MutableCSINodeAllocatableCount feature gate in external-attacher.
```
