### PR TITLE
Initialize name-dependent variables in metadata-labaler node path

### DIFF
--- a/pkg/cloud/metadata/k8s.go
+++ b/pkg/cloud/metadata/k8s.go
@@ -145,6 +145,9 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface, metadataLabeler b
 	}
 
 	if metadataLabeler && !sageMakerLabels {
+		// Initialize ENIsLabel and VolumesLabel globals.
+		initVariables()
+
 		backoff := wait.Backoff{
 			Duration: 1 * time.Second,
 			Factor:   1.5,

--- a/pkg/cloud/metadata/labels.go
+++ b/pkg/cloud/metadata/labels.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -49,6 +50,9 @@ const (
 
 // Initialized in ContinuousUpdateLabelsLeaderElection (depends on driver name).
 var (
+	// Prevent races in initialization.
+	once sync.Once
+
 	// VolumesLabel is the label name for the number of volumes on a node.
 	VolumesLabel string
 
@@ -64,8 +68,10 @@ type enisVolumes struct {
 // initVariables initializes variables that depend on driver name.
 // Separated into a spearate function from ContinuousUpdateLabelsLeaderElection so it can be called in tests.
 func initVariables() {
-	VolumesLabel = util.GetDriverName() + "/non-csi-ebs-volumes-count"
-	ENIsLabel = util.GetDriverName() + "/enis-count"
+	once.Do(func() {
+		VolumesLabel = util.GetDriverName() + "/non-csi-ebs-volumes-count"
+		ENIsLabel = util.GetDriverName() + "/enis-count"
+	})
 }
 
 // ContinuousUpdateLabelsLeaderElection uses leader election so that only one controller pod calls continuousUpdateLabels().

--- a/pkg/plugin/plugin_common.go
+++ b/pkg/plugin/plugin_common.go
@@ -69,6 +69,7 @@ type EbsCsiPlugin interface {
 	// GetSageMakerClient replaces the AWS EC2 client the driver uses
 	GetSageMakerClient(cfg aws.Config, optFns ...func(*sagemaker.Options)) util.SageMakerAPI
 	// GetDriverName replaces the driver name in use (normally "ebs.csi.aws.com")
+	// This function can be called before Init and should not depend on it
 	GetDriverName() string
 }
 

--- a/tests/e2e/metadata-labeler.go
+++ b/tests/e2e/metadata-labeler.go
@@ -28,7 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/metadata"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -205,8 +205,8 @@ func getVolENIs(resp *ec2.DescribeInstancesOutput) map[string]*instanceMetadata 
 // checkVolENI compares `expectedMetadata` and `labeledMetadata` to have the same number of volumes and ENIs attached to each node in `nodes`
 func checkVolENI(expectedMetadata, labeledMetadata map[string]*instanceMetadata, nodes *corev1.NodeList) {
 	for _, node := range nodes.Items {
-		vol, _ := strconv.Atoi(node.GetLabels()[metadata.VolumesLabel])
-		enis, _ := strconv.Atoi(node.GetLabels()[metadata.ENIsLabel])
+		vol, _ := strconv.Atoi(node.GetLabels()[util.GetDriverName()+"/non-csi-ebs-volumes-count"])
+		enis, _ := strconv.Atoi(node.GetLabels()[util.GetDriverName()+"/enis-count"])
 		id := parseProviderID(node.Spec.ProviderID)
 		labeledMetadata[id] = &instanceMetadata{}
 		labeledMetadata[id].ENIs = enis
@@ -278,8 +278,8 @@ func checkLabelsUpdated(cs kubernetes.Interface, labeledMetadata, expectedMetada
 
 		for _, node := range updatedNodes.Items {
 			id := parseProviderID(node.Spec.ProviderID)
-			vol, _ := strconv.Atoi(node.Labels[metadata.VolumesLabel])
-			eni, _ := strconv.Atoi(node.Labels[metadata.ENIsLabel])
+			vol, _ := strconv.Atoi(node.Labels[util.GetDriverName()+"/non-csi-ebs-volumes-count"])
+			eni, _ := strconv.Atoi(node.Labels[util.GetDriverName()+"/enis-count"])
 			labeledMetadata[id].Volumes = vol
 			labeledMetadata[id].ENIs = eni
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes a regression introduced in https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2786 that breaks the node path for the alpha `metadata-labeler` feature. The globals being relied upon in this code path were not initialized because the node does not call `ContinuousUpdateLabelsLeaderElection`.

#### How was this change tested?

`make test-e2e-disruptive`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Prevent startup crash when alpha `metadata-labeler` feature is enabled by initializing name-dependent variables in node path
```
