### PR TITLE
Update MV documentation to remove references to 6-hour cooldown

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -368,9 +368,9 @@ Blindly return:
 
 ### EC2 ModifyVolume and Request Coalescing
 
-AWS exposes one unified ModifyVolume API to change the size, volume-type, IOPS, or throughput of your volume. AWS imposes a 6-hour cooldown after a successful volume modification.
+AWS exposes one unified ModifyVolume API to change the size, volume-type, IOPS, or throughput of your volume. AWS imposes a cooldown after a set number of volume modifications.
 
-However, the CSI Specification exposes two separate RPCs that rely on ebs-plugin calling this EC2 ModifyVolume API: ControllerExpandVolume, for increasing volume size, and ControllerModifyVolume, for all other volume modifications. To avoid the 6-hour cooldown, we coalesce these separate expansion and modification requests by waiting for up to two seconds, and then perform one merged EC2 ModifyVolume API Call.
+However, the CSI Specification exposes two separate RPCs that rely on ebs-plugin calling this EC2 ModifyVolume API: ControllerExpandVolume, for increasing volume size, and ControllerModifyVolume, for all other volume modifications. To avoid unnecessary `ModifyVolume` calls (potentially hitting the cooldown), we coalesce these separate expansion and modification requests by waiting for up to two seconds, and then perform one merged EC2 ModifyVolume API Call.
 
 Here is an overview of what may happen when you patch a PVC's size and VolumeAttributesClassName at the same time:
 

--- a/docs/modify-volume.md
+++ b/docs/modify-volume.md
@@ -40,8 +40,8 @@ The EBS CSI Driver also supports modifying tags of existing volumes (only availa
 
 ## Considerations
 
-- Keep in mind the [6-hour cooldown period](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVolume.html) for EBS ModifyVolume. Multiple ModifyVolume calls for the same volume within a 6-hour period will fail.
-  - Note: If your volume modification only creates/modifies AWS resource tags, EBS ModifyVolume will not be called and this 6-hour cooldown period does not apply.  
+- Keep in mind the [EBS volume modification considerations and limitations](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html#elastic-volumes-considerations) from the AWS documentation. Modifications initiated during a cooldown period will not progress until the cooldown is over.
+  - Tag-only modifications to PVCs do not call the AWS `ModifyVolume` API and thus are not subject to these limitations.
 - Ensure that the desired volume properties are permissible. The driver does minimum client side validation. 
 
 ## Example


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind documentation

#### What is this PR about? / Why do we need it?

Update docs to remove references to 6-hour cooldown and use evergreen wording instead.

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
