### PR TITLE
Add support for windows 2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,8 @@ FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:ltsc2022@sh
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENV PATH="C:\\Windows\\System32\\WindowsPowerShell\\v1.0;${PATH}"
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]
+
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:ltsc2025@sha256:e93d0945e886786631cf0c02e53a89431a5075ee15ee51b887a05aeb0ffb8398 AS windows-ltsc2025
+COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
+ENV PATH="C:\\Windows\\System32\\WindowsPowerShell\\v1.0;${PATH}"
+ENTRYPOINT ["/aws-ebs-csi-driver.exe"]

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ALL_OSVERSION_linux?=al2023
 ALL_OS_ARCH_OSVERSION_linux=$(foreach arch, $(ALL_ARCH_linux), $(foreach osversion, ${ALL_OSVERSION_linux}, linux-$(arch)-${osversion}))
 
 ALL_ARCH_windows?=amd64
-ALL_OSVERSION_windows?=ltsc2019 ltsc2022
+ALL_OSVERSION_windows?=ltsc2019 ltsc2022 ltsc2025
 ALL_OS_ARCH_OSVERSION_windows=$(foreach arch, $(ALL_ARCH_windows), $(foreach osversion, ${ALL_OSVERSION_windows}, windows-$(arch)-${osversion}))
 ALL_OS_ARCH_OSVERSION=$(foreach os, $(ALL_OS), ${ALL_OS_ARCH_OSVERSION_${os}})
 

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -43,7 +43,7 @@ FIPS_TEST=${FIPS_TEST:-"false"}
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
 K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.35.0}
-K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-1.34}
+K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-1.35}
 
 # Override AMI - eksctl clusters only
 LINUX_AMI=${LINUX_AMI:-}

--- a/hack/e2e/eksctl/cluster.yaml
+++ b/hack/e2e/eksctl/cluster.yaml
@@ -72,7 +72,7 @@ managedNodeGroups:
       allow: false
 {{- if and (eq .Env.WINDOWS "true") (not (env.Getenv "WINDOWS_AMI")) }}
   - name: ng-windows
-    amiFamily: WindowsServer2022CoreContainer
+    amiFamily: WindowsServer2025CoreContainer
     desiredCapacity: 3
     disablePodIMDS: true
     instanceTypes: [m5.2xlarge]

--- a/hack/e2e/test-images.sh
+++ b/hack/e2e/test-images.sh
@@ -65,7 +65,7 @@ build_and_push "${AWS_REGION}" \
   "${IMAGE_TAG}" \
   "${IMAGE_ARCH}"
 
-imageSuffixes=("fips-windows-amd64-ltsc2022 fips-windows-amd64-ltsc2019 windows-amd64-ltsc2019 windows-amd64-ltsc2022 fips-linux-amd64-al2023 fips-linux-arm64-al2023 linux-amd64-al2023 linux-arm64-al2023")
+imageSuffixes=("fips-windows-amd64-ltsc2022 fips-windows-amd64-ltsc2019 fips-windows-amd64-ltsc2025 windows-amd64-ltsc2019 windows-amd64-ltsc2022 windows-amd64-ltsc2025 fips-linux-amd64-al2023 fips-linux-arm64-al2023 linux-amd64-al2023 linux-arm64-al2023")
 
 loudecho "Ensuring all images are present"
 

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -23,7 +23,7 @@ AWSCLI_VERSION="2.33.5"
 # https://github.com/helm/chart-testing
 CT_VERSION="v3.14.0"
 # https://github.com/eksctl-io/eksctl
-EKSCTL_VERSION="v0.221.0"
+EKSCTL_VERSION="v0.222.0"
 # https://github.com/onsi/ginkgo
 GINKGO_VERSION="v2.27.5"
 # https://github.com/golangci/golangci-lint


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What is this PR about? / Why do we need it?
This PR adds support for windows 2025
#### How was this change tested?
[image e2e test](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/2831/pull-aws-ebs-csi-driver-image-test/2013695348454723584#1:build-log.txt%3A151)

And Windows e2e tests
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add support for Windows Server 2025
```

