### PR TITLE
Downgrade to k8s 1.34 for kOps tests

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -42,7 +42,7 @@ FIPS_TEST=${FIPS_TEST:-"false"}
 
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
-K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.35.0}
+K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.34.1}
 K8S_VERSION_EKSCTL=${K8S_VERSION_EKSCTL:-1.34}
 
 # Override AMI - eksctl clusters only

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -37,7 +37,7 @@ HELM_VERSION="v4.1.0"
 # https://github.com/kubernetes/kops
 # Commit is preferred over version if non-empty, and can
 # be used to test new Kubernetes releases earlier
-KOPS_VERSION="v1.35.0-alpha.1"
+KOPS_VERSION="v1.34.1"
 KOPS_COMMIT=""
 # https://pkg.go.dev/sigs.k8s.io/kubetest2?tab=versions
 KUBETEST2_VERSION="v0.0.0-20260121084538-081dafe259d7"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Temporarily downgrade kops k8s version 1.34.3 because 1.35 breaks the helm test environment.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
