### PR TITLE
feat(chart/aws-ebs-csi-driver): enable choosing between Deployment/DaemonSet Kind for controller service

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -1,6 +1,7 @@
 {{- if not .Values.nodeComponentOnly -}}
 # Controller Service
-kind: Deployment
+{{- $kind := .Values.controller.kind | default "Deployment" }}
+kind: {{ $kind }}
 apiVersion: apps/v1
 metadata:
   name: ebs-csi-controller
@@ -12,6 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if eq $kind "Deployment" }}
   replicas: {{ .Values.controller.replicaCount }}
   {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
@@ -19,6 +21,15 @@ spec:
   {{- with .Values.controller.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else if eq $kind "DaemonSet" }}
+  {{- if or (kindIs "float64" .Values.controller.revisionHistoryLimit) (kindIs "int64" .Values.controller.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.controller.revisionHistoryLimit }}
+  {{- end }}
+  {{- with .Values.controller.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:
@@ -52,7 +63,7 @@ spec:
         {{- with .Values.controller.tolerations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.controller.topologySpreadConstraints }}
+      {{- if and (eq $kind "Deployment") .Values.controller.topologySpreadConstraints }}
       {{- $tscLabelSelector := dict "labelSelector" ( dict "matchLabels" ( dict "app" "ebs-csi-controller" ) ) }}
       {{- $constraints := list }}
       {{- range .Values.controller.topologySpreadConstraints }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -138,6 +138,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Kubernetes resource kind for the controller (Deployment or DaemonSet)",
+          "default": "Deployment",
+          "enum": ["Deployment", "DaemonSet"]
+        },
         "additionalArgs": {
           "type": "array",
           "description": "Additional arguments passed to the controller pod",

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -194,6 +194,7 @@ awsAccessSecret:
   keyId: key_id
   accessKey: access_key
 controller:
+  kind: Deployment
   batching: true
   volumeModificationFeature:
     enabled: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What is this PR about? / Why do we need it?

This feature allows you to change the kind of object used for the controller service. I'm using `DaemonSet` so volume provisioning works on my multi-regional deployment.  

#### How was this change tested?

I've uninstalled the original chart, reinstalled it using `controller.kind=DaemonSet` and successfully provisioned a pvc for a sts that I'm running in a different region than my eks control plane.

#### Does this PR introduce a user-facing change?

```release-note
`controller.kind` value is now configurable (only `Deployment` and `DaemonSet` are allowed).
```
