### PR TITLE
Update CSI sidecar images to address CVE-2025-61726

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -22,7 +22,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-provisioner
-      tag: "v6.1.0-eksbuild.2"
+      tag: "v6.1.0-eksbuild.3"
     logLevel: 2
     # Additional parameters provided by csi-provisioner.
     additionalArgs: []
@@ -49,7 +49,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-attacher
-      tag: "v4.10.0-eksbuild.3"
+      tag: "v4.10.0-eksbuild.4"
     # Tune leader lease election for csi-attacher.
     # Leader election is on by default.
     leaderElection:
@@ -78,7 +78,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-snapshotter
-      tag: "v8.4.0-eksbuild.3"
+      tag: "v8.4.0-eksbuild.4"
     logLevel: 2
     # Additional parameters provided by csi-snapshotter.
     additionalArgs: []
@@ -106,7 +106,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/livenessprobe
-      tag: "v2.17.0-eksbuild.3"
+      tag: "v2.17.0-eksbuild.4"
     # Additional parameters provided by livenessprobe.
     additionalArgs: []
     resources: {}
@@ -118,7 +118,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-resizer
-      tag: "v2.0.0-eksbuild.3"
+      tag: "v2.0.0-eksbuild.4"
     # Tune leader lease election for csi-resizer.
     # Leader election is on by default.
     leaderElection:
@@ -145,7 +145,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-node-driver-registrar
-      tag: "v2.15.0-eksbuild.3"
+      tag: "v2.15.0-eksbuild.4"
     logLevel: 2
     # Additional parameters provided by node-driver-registrar.
     additionalArgs: []

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -140,7 +140,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-provisioner
-          image: public.ecr.aws/csi-components/csi-provisioner:v6.1.0-eksbuild.2
+          image: public.ecr.aws/csi-components/csi-provisioner:v6.1.0-eksbuild.3
           imagePullPolicy: IfNotPresent
           args:
             - --timeout=60s
@@ -175,7 +175,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-attacher
-          image: public.ecr.aws/csi-components/csi-attacher:v4.10.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-attacher:v4.10.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --timeout=6m
@@ -206,7 +206,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-snapshotter
-          image: public.ecr.aws/csi-components/csi-snapshotter:v8.4.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-snapshotter:v8.4.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -236,7 +236,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-resizer
-          image: public.ecr.aws/csi-components/csi-resizer:v2.0.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-resizer:v2.0.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --timeout=60s
@@ -270,7 +270,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.17.0-eksbuild.3
+          image: public.ecr.aws/csi-components/livenessprobe:v2.17.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -102,7 +102,7 @@ spec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
           terminationMessagePolicy: FallbackToLogsOnError
         - name: node-driver-registrar
-          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.15.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.15.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -139,7 +139,7 @@ spec:
               memory: 40Mi
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.17.0-eksbuild.3
+          image: public.ecr.aws/csi-components/livenessprobe:v2.17.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=unix:/csi/csi.sock

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -105,7 +105,7 @@ spec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
           terminationMessagePolicy: FallbackToLogsOnError
         - name: node-driver-registrar
-          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.15.0-eksbuild.3
+          image: public.ecr.aws/csi-components/csi-node-driver-registrar:v2.15.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -145,7 +145,7 @@ spec:
             readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: public.ecr.aws/csi-components/livenessprobe:v2.17.0-eksbuild.3
+          image: public.ecr.aws/csi-components/livenessprobe:v2.17.0-eksbuild.4
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

This PR bumps up to latest CSI sidecar builds to address CVE-2025-61726

#### How was this change tested?

```
make update && make verify && make test
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Update CSI sidecar images to address CVE-2025-61726
```
