### PR TITLE
Upgrade to volume-modifier-for-k8s 0.9.2

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -165,7 +165,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
-      tag: "v0.9.1"
+      tag: "v0.9.2"
     leaderElection:
       enabled: true
       # Optional values to tune lease behavior.


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Upgrades volume-modifier-for-k8s to 0.9.2 to address CVE.

#### How was this change tested?

```
docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro public.ecr.aws/aquasecurity/trivy:latest image -q public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.9.2

Report Summary

┌──────────────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                                Target                                │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s:v0.9.2 (amazon │  amazon  │        0        │    -    │
│ 2023.10.20260120 (Amazon Linux))                                     │          │                 │         │
├──────────────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/bin/volume-modifier-for-k8s                                      │ gobinary │        0        │    -    │
└──────────────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
