### PR TITLE
helm: make healthPort configurable

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -187,7 +187,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --http-endpoint=0.0.0.0:9809
+            - --http-endpoint=0.0.0.0:{{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
           {{- if .Values.node.windowsHostProcess }}
             - --plugin-registration-path=$(PLUGIN_REG_DIR)
           {{- end }}
@@ -221,7 +221,7 @@ spec:
             {{- end }}
           ports:
             - name: healthz
-              containerPort: 9809
+              containerPort: {{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
           {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -195,7 +195,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --http-endpoint=0.0.0.0:9809
+            - --http-endpoint=0.0.0.0:{{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
             {{- if .Values.debugLogs }}
             - --v=7
             {{- else }}
@@ -221,7 +221,7 @@ spec:
           {{- end }}
           ports:
             - name: healthz
-              containerPort: 9809
+              containerPort: {{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
           {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -1090,6 +1090,11 @@
                 "type": "string"
               }
             },
+            "healthPort": {
+              "type": "integer",
+              "description": "The port the health probe is bound to",
+              "default": 9809
+            },
             "logLevel": {
               "type": "integer",
               "description": "Set the level of verbosity of the logs",

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -147,6 +147,8 @@ sidecars:
       repository: public.ecr.aws/csi-components/csi-node-driver-registrar
       tag: "v2.15.0-eksbuild.4"
     logLevel: 2
+    # The port the health probe is bound to.
+    healthPort: 9809
     # Additional parameters provided by node-driver-registrar.
     additionalArgs: []
     resources: {}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What is this PR about? / Why do we need it?
Adds the ability to configure the port that gets used in the new healthz port added via https://github.com/kubernetes-sigs/aws-ebs-csi-driver/commit/452e23ea548d53c655c2af6f51eb3e375534de70 which is hardcoded as 9809

#### How was this change tested?
helm template

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
  Allow overriding node-driver-registrar liveness probe /healthz endpoint.
```

Fixes #2864
