### PR TITLE
Rename ports to avoid collisions

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -220,7 +220,7 @@ spec:
             {{- . | toYaml | nindent 12 }}
             {{- end }}
           ports:
-            - name: healthz
+            - name: healthz-ndr
               containerPort: {{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
           {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -220,7 +220,7 @@ spec:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
           ports:
-            - name: healthz
+            - name: healthz-ndr
               containerPort: {{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
           {{- with .Values.sidecars.nodeDriverRegistrar.livenessProbe }}
           livenessProbe:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -278,7 +278,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- if .Values.controller.enableMetrics }}
           ports:
-            - name: metrics
+            - name: metrics-prov
               containerPort: 3302
               protocol: TCP
           {{- end }}
@@ -351,7 +351,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- if .Values.controller.enableMetrics }}
           ports:
-            - name: metrics
+            - name: metrics-attach
               containerPort: 3303
               protocol: TCP
           {{- end }}
@@ -411,7 +411,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- if .Values.controller.enableMetrics }}
           ports:
-            - name: metrics
+            - name: metrics-snap
               containerPort: 3306
               protocol: TCP
           {{- end }}
@@ -483,7 +483,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- if .Values.controller.enableMetrics }}
           ports:
-            - name: metrics
+            - name: metrics-volmod
               containerPort: 3307
               protocol: TCP
           {{- end }}
@@ -597,7 +597,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           {{- if .Values.controller.enableMetrics }}
           ports:
-            - name: metrics
+            - name: metrics-resizer
               containerPort: 3304
               protocol: TCP
           {{- end }}
@@ -631,7 +631,7 @@ spec:
               mountPath: /csi
           {{- if .Values.controller.enableMetrics }}
           ports:
-            - name: metrics
+            - name: metrics-lp
               containerPort: 3305
               protocol: TCP
           {{- end }}

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -158,7 +158,7 @@ sidecars:
     livenessProbe:
       httpGet:
         path: /healthz
-        port: healthz
+        port: healthz-ndr
       initialDelaySeconds: 30
       periodSeconds: 90
       timeoutSeconds: 15

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -115,12 +115,12 @@ spec:
             - name: DRIVER_REG_SOCK_PATH
               value: C:\var\lib\kubelet\plugins\ebs.csi.aws.com\csi.sock
           ports:
-            - name: healthz
+            - name: healthz-ndr
               containerPort: 9809
           livenessProbe:
             httpGet:
               path: /healthz
-              port: healthz
+              port: healthz-ndr
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -118,12 +118,12 @@ spec:
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
           ports:
-            - name: healthz
+            - name: healthz-ndr
               containerPort: 9809
           livenessProbe:
             httpGet:
               path: /healthz
-              port: healthz
+              port: healthz-ndr
             initialDelaySeconds: 30
             periodSeconds: 90
             timeoutSeconds: 15


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind cleanup
#### What is this PR about? / Why do we need it?
Fixes #2866 and fixes this for the metrics ports as well 
#### How was this change tested?
CI
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Rename health and metrics ports 
```
