### PR TITLE
Adding Helm Parameter CI Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,22 @@ cluster/uninstall: bin/helm bin/aws
 ## E2E targets
 # Targets to run e2e tests
 
+.PHONY: test/helm-template
+test/helm-template: bin/helm
+	cd tests/helm-template && go test -v -count=1 ./...
+
+## e2e/parameters and e2e/parameters-all are Parameter-specific e2e tests
+# Usage: make e2e/parameters PARAM_SET=<name> or make e2e/parameters-all
+# See hack/e2e/param-sets.sh for available sets and their definitions.
+ 
+.PHONY: e2e/parameters
+e2e/parameters: bin/helm bin/ginkgo
+	./hack/e2e/param-sets.sh run $(PARAM_SET)
+
+.PHONY: e2e/parameters-all
+e2e/parameters-all: bin/helm bin/ginkgo test/helm-template
+	./hack/e2e/param-sets.sh run-all
+
 .PHONY: e2e/single-az
 e2e/single-az: bin/helm bin/ginkgo
 	AWS_AVAILABILITY_ZONES=us-west-2a \

--- a/hack/e2e/param-sets.sh
+++ b/hack/e2e/param-sets.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Parameter set definitions for e2e parameter tests that require a live cluster.
+# Tests that only assert on rendered Kubernetes object specs run via
+# `go test ./tests/helm-template/...` and do not need a cluster.
+#
+# Each set only needs to set GINKGO_FOCUS. By default, Helm values come from
+# tests/helm-template/testdata/e2e-<set>.yaml (or a file pointed at by
+# VALUES_FILE), shared with the helm-template Go tests as a single source
+# of truth. A set may override HELM_EXTRA_FLAGS directly when the set only
+# needs one or two flags and a values file isn't worth it.
+#
+# Sets in PARAM_SETS_ALL:
+#   standard            - Volume tagging (EC2 API) and defaultFsType (mount check)
+#   miscellaneous       - Metadata labeler node labels and additional DaemonSet scheduling
+#   node-component-only - Deploys only node DaemonSet without controller
+#   fips                - Builds FIPS image then validates it is deployed
+#   legacy-compat       - legacyXFS behavior
+
+set -euo pipefail
+
+BASE_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+VALUES_DIR="${BASE_DIR}/../../tests/helm-template/testdata"
+
+PARAM_SETS_ALL="standard miscellaneous node-component-only fips legacy-compat"
+
+param_set_standard() {
+  GINKGO_FOCUS="\[param:(extraCreateMetadata|k8sTagClusterId|extraVolumeTags|defaultFsType)\]"
+  # Opt out of install_driver()'s hardcoded --set controller.k8sTagClusterId=$CLUSTER_NAME
+  # so the value from e2e-standard.yaml takes effect (otherwise --set would beat --values).
+  HELM_OVERRIDE_K8S_TAG_CLUSTER_ID=true
+}
+
+param_set_miscellaneous() {
+  GINKGO_FOCUS="\[param:(metadataLabeler|additionalDaemonSets)\]"
+}
+
+param_set_node-component-only() {
+  GINKGO_FOCUS="\[param:nodeComponentOnly\]"
+  # Shares values with the helm-template TestNodeComponentOnly (identical content).
+  VALUES_FILE="${VALUES_DIR}/node-component-only.yaml"
+}
+
+param_set_legacy-compat() {
+  GINKGO_FOCUS="\[param:legacyXFS\]"
+  HELM_EXTRA_FLAGS="--set=node.legacyXFS=true"
+}
+
+param_set_fips() {
+  GINKGO_FOCUS="\[param:fips\]"
+  # Single flag; inlined instead of maintaining a one-line values file.
+  HELM_EXTRA_FLAGS="--set=fips=true"
+  FIPS_TEST=true
+}
+
+# Load a parameter set by name, exporting GINKGO_FOCUS and HELM_EXTRA_FLAGS.
+# By default HELM_EXTRA_FLAGS is derived from a values file convention
+# (e2e-<name>.yaml). A per-set function may override HELM_EXTRA_FLAGS or
+# VALUES_FILE directly when the values-file convention doesn't fit.
+load_param_set() {
+  local name="$1"
+  local func="param_set_${name}"
+  if ! declare -f "$func" >/dev/null 2>&1; then
+    echo "Unknown parameter set: ${name}" >&2
+    echo "Available sets: ${PARAM_SETS_ALL}" >&2
+    exit 1
+  fi
+  HELM_EXTRA_FLAGS=""
+  VALUES_FILE="${VALUES_DIR}/e2e-${name}.yaml"
+  # Clear state that a previous set's param_set_* function may have set,
+  # so sets are independent of run order.
+  unset HELM_OVERRIDE_K8S_TAG_CLUSTER_ID
+  unset FIPS_TEST
+  "$func"
+  if [[ -z "$HELM_EXTRA_FLAGS" ]]; then
+    HELM_EXTRA_FLAGS="--values=${VALUES_FILE}"
+  fi
+  export GINKGO_FOCUS HELM_EXTRA_FLAGS
+  export GINKGO_PARALLEL="${GINKGO_PARALLEL:-5}"
+  export AWS_AVAILABILITY_ZONES="${AWS_AVAILABILITY_ZONES:-us-west-2a}"
+  export TEST_PATH="${TEST_PATH:-./tests/e2e/...}"
+  export JUNIT_REPORT="${REPORT_DIR:-/logs/artifacts}/junit-params-${name}.xml"
+  if [[ -n "${EBS_INSTALL_SNAPSHOT+x}" ]]; then export EBS_INSTALL_SNAPSHOT; fi
+  if [[ -n "${FIPS_TEST+x}" ]]; then export FIPS_TEST; fi
+  if [[ -n "${HELM_OVERRIDE_K8S_TAG_CLUSTER_ID+x}" ]]; then export HELM_OVERRIDE_K8S_TAG_CLUSTER_ID; fi
+}
+
+# Run a single parameter set
+run_param_set() {
+  load_param_set "$1"
+  if [[ "${FIPS_TEST:-}" == "true" ]]; then
+    echo "### Building FIPS image for param set: $1"
+    FIPS_TEST=true make cluster/image || {
+      echo "FIPS image build failed!" >&2
+      return 1
+    }
+  fi
+  echo "### Running parameter set: $1"
+  ./hack/e2e/run.sh
+}
+
+# Run all standard parameter sets sequentially
+run_all_param_sets() {
+  echo "Running all parameter sets sequentially..."
+  local failed_sets=()
+  for set in $PARAM_SETS_ALL; do
+    run_param_set "$set" || failed_sets+=("$set")
+  done
+  if [[ ${#failed_sets[@]} -gt 0 ]]; then
+    echo "Failed parameter sets: ${failed_sets[*]}" >&2
+    return 1
+  fi
+  echo "All parameter sets completed successfully!"
+}
+
+# Allow direct invocation: ./hack/e2e/param-sets.sh run <name> or ./hack/e2e/param-sets.sh run-all
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+  run)
+    [[ -z "${2:-}" ]] && {
+      echo "Usage: $0 run <param-set-name>" >&2
+      exit 1
+    }
+    run_param_set "$2"
+    ;;
+  run-all)
+    run_all_param_sets
+    ;;
+  *)
+    echo "Usage: $0 {run <param-set-name>|run-all}" >&2
+    exit 1
+    ;;
+  esac
+fi

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -203,7 +203,7 @@ else
     "${BIN}/ginkgo" -p -nodes="${GINKGO_PARALLEL}" \
       --focus="${GINKGO_FOCUS}" \
       --skip="${GINKGO_SKIP}" \
-      --junit-report="${REPORT_DIR}/junit.xml" \
+      --junit-report="${JUNIT_REPORT:-${REPORT_DIR}/junit.xml}" \
       "${TEST_PATH}" \
       -- \
       -kubeconfig="${KUBECONFIG}" \

--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -29,12 +29,17 @@ function install_driver() {
       --namespace kube-system
       --set node.enableWindows="${WINDOWS}"
       --set node.windowsHostProcess="${WINDOWS_HOSTPROCESS}"
-      --set controller.k8sTagClusterId="${CLUSTER_NAME}"
       --set image.pullPolicy="Always"
       --set controller.userAgentExtra="dev"
       --timeout 10m0s
       --wait
       --kubeconfig "${KUBECONFIG}")
+    # Only set k8sTagClusterId from CLUSTER_NAME if HELM_EXTRA_FLAGS or
+    # HELM_OVERRIDE_K8S_TAG_CLUSTER_ID doesn't override it, so test configurations
+    # (e.g., param-sets.sh) can set their own cluster ID via a values file.
+    if [[ "${HELM_EXTRA_FLAGS:-}" != *k8sTagClusterId* ]] && [[ -z "${HELM_OVERRIDE_K8S_TAG_CLUSTER_ID:-}" ]]; then
+      HELM_ARGS+=(--set controller.k8sTagClusterId="${CLUSTER_NAME}")
+    fi
     if [ -n "${HELM_VALUES_FILE:-}" ]; then
       HELM_ARGS+=(-f "${HELM_VALUES_FILE}")
     fi

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -96,6 +96,9 @@ test-helm-chart)
   TEST="helm-ct"
   export INSTANCE_TYPE="c5.2xlarge"
   ;;
+test-e2e-parameters)
+  TEST="parameters-all"
+  ;;
 *)
   echo "Unknown e2e test ${1}" >&2
   exit 1

--- a/tests/e2e/go.mod
+++ b/tests/e2e/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v1.5.2
 	k8s.io/kubernetes v1.36.1
 	k8s.io/pod-security-admission v0.36.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -142,7 +143,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace (

--- a/tests/e2e/parameter_tests.go
+++ b/tests/e2e/parameter_tests.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	awscloud "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	ebscsidriver "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/driver"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/e2e/testsuites"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+	"sigs.k8s.io/yaml"
+)
+
+// Parameter e2e tests that require a live cluster (AWS API calls, volume provisioning, runtime checks).
+// Tests that only assert on rendered Kubernetes object specs are in tests/helm-template/.
+//
+// Expected values are loaded from the shared values YAML files in tests/helm-template/testdata/
+// so that the same file drives both helm install (via param-sets.sh) and test assertions.
+
+const (
+	controllerLabel    = "app=ebs-csi-controller"
+	ebsPluginContainer = "ebs-plugin"
+	ebsNamespace       = "kube-system"
+)
+
+// standardValues holds the subset of Helm values we assert on from standard.yaml.
+type standardValues struct {
+	Controller struct {
+		K8sTagClusterId string            `json:"k8sTagClusterId"`
+		ExtraVolumeTags map[string]string `json:"extraVolumeTags"`
+	} `json:"controller"`
+}
+
+// loadValues reads a values YAML file from tests/helm-template/testdata/.
+func loadValues(name string, out interface{}) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(thisFile), "..", "helm-template", "testdata", name+".yaml")
+	data, err := os.ReadFile(path)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to read values file %s", path)
+	ExpectWithOffset(1, yaml.Unmarshal(data, out)).NotTo(HaveOccurred(), "failed to parse values file %s", path)
+}
+
+func defaultGP3Pods() []testsuites.PodDetails {
+	return []testsuites.PodDetails{{
+		Cmd: testsuites.PodCmdWriteToVolume("/mnt/test-1"),
+		Volumes: []testsuites.VolumeDetails{{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+				ebscsidriver.FSTypeKey:     ebscsidriver.FSTypeExt4,
+			},
+			ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+			VolumeMount: testsuites.DefaultGeneratedVolumeMount,
+		}},
+	}}
+}
+
+func defaultGP3PodsNoFsType() []testsuites.PodDetails {
+	return []testsuites.PodDetails{{
+		Cmd: testsuites.PodCmdWriteToVolume("/mnt/test-1"),
+		Volumes: []testsuites.VolumeDetails{{
+			CreateVolumeParameters: map[string]string{
+				ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+			},
+			ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+			VolumeMount: testsuites.DefaultGeneratedVolumeMount,
+		}},
+	}}
+}
+
+var _ = Describe("[ebs-csi-e2e] [param:extraCreateMetadata]", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		ebsDriver driver.PVTestDriver
+		ec2Client *ec2.Client
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		ebsDriver = driver.InitEbsCSIDriver()
+		cfg, err := config.LoadDefaultConfig(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		ec2Client = ec2.NewFromConfig(cfg)
+	})
+
+	It("should add PVC namespace tag to provisioned volume", func() {
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: ebsDriver,
+			Pods:      defaultGP3Pods(),
+			ValidateFunc: func() {
+				result, err := ec2Client.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+					Filters: []types.Filter{{
+						Name:   aws.String("tag:kubernetes.io/created-for/pvc/namespace"),
+						Values: []string{ns.Name},
+					}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Volumes).NotTo(BeEmpty(), "Should find volume with PVC namespace tag")
+			},
+		}
+		test.Run(cs, ns)
+	})
+})
+
+var _ = Describe("[ebs-csi-e2e] [param:k8sTagClusterId]", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		ebsDriver driver.PVTestDriver
+		ec2Client *ec2.Client
+		vals      standardValues
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		ebsDriver = driver.InitEbsCSIDriver()
+		cfg, err := config.LoadDefaultConfig(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		ec2Client = ec2.NewFromConfig(cfg)
+		loadValues("e2e-standard", &vals)
+	})
+
+	It("should tag volume with cluster ID", func() {
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: ebsDriver,
+			Pods:      defaultGP3PodsNoFsType(),
+			ValidateFunc: func() {
+				result, err := ec2Client.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+					Filters: []types.Filter{{
+						Name:   aws.String("tag:kubernetes.io/cluster/" + vals.Controller.K8sTagClusterId),
+						Values: []string{"owned"},
+					}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Volumes).NotTo(BeEmpty(), "Should find volume with cluster ID tag")
+			},
+		}
+		test.Run(cs, ns)
+	})
+})
+
+var _ = Describe("[ebs-csi-e2e] [param:extraVolumeTags]", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var (
+		cs        clientset.Interface
+		ns        *v1.Namespace
+		ebsDriver driver.PVTestDriver
+		ec2Client *ec2.Client
+		vals      standardValues
+	)
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+		ns = f.Namespace
+		ebsDriver = driver.InitEbsCSIDriver()
+		cfg, err := config.LoadDefaultConfig(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		ec2Client = ec2.NewFromConfig(cfg)
+		loadValues("e2e-standard", &vals)
+	})
+
+	It("should add extra volume tags from Helm values", func() {
+		for key, value := range vals.Controller.ExtraVolumeTags {
+			test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+				CSIDriver: ebsDriver,
+				Pods:      defaultGP3PodsNoFsType(),
+				ValidateFunc: func() {
+					result, err := ec2Client.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+						Filters: []types.Filter{{
+							Name:   aws.String("tag:" + key),
+							Values: []string{value},
+						}},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Volumes).NotTo(BeEmpty(), "Should find volume with extra tag %s=%s", key, value)
+				},
+			}
+			test.Run(cs, ns)
+		}
+	})
+})
+
+var _ = Describe("[ebs-csi-e2e] Live Cluster Parameter Tests", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var cs clientset.Interface
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	It("[param:defaultFsType] should use xfs as default filesystem when not specified in StorageClass", func() {
+		pods := []testsuites.PodDetails{{
+			Cmd: "mount | grep /mnt/test-1 | grep xfs",
+			Volumes: []testsuites.VolumeDetails{{
+				CreateVolumeParameters: map[string]string{
+					ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+				},
+				ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+				VolumeMount: testsuites.DefaultGeneratedVolumeMount,
+			}},
+		}}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: driver.InitEbsCSIDriver(),
+			Pods:      pods,
+		}
+		test.Run(cs, f.Namespace)
+	})
+
+	It("[param:legacyXFS] should format XFS volumes with reflink disabled when legacyXFS is enabled", func() {
+		// node.legacyXFS=true makes the driver pass `-m reflink=0` to
+		// mkfs.xfs. FICLONE returns EOPNOTSUPP on a filesystem formatted without reflink, so
+		// `cp --reflink=always` exits non-zero with "Operation not
+		// supported". busybox's cp has no --reflink, so use amazonlinux.
+		const reflinkProbe = `set -e
+dd if=/dev/zero of=/mnt/test-1/src bs=4k count=4 status=none
+if cp --reflink=always /mnt/test-1/src /mnt/test-1/dst 2>/tmp/cp.err; then
+  echo "FAIL: cp --reflink=always succeeded; expected reflink to be disabled" >&2
+  exit 1
+fi
+if ! grep -qi "not supported" /tmp/cp.err; then
+  echo "FAIL: cp --reflink=always failed for an unexpected reason:" >&2
+  cat /tmp/cp.err >&2
+  exit 1
+fi
+echo "PASS: reflink is disabled on /mnt/test-1"
+`
+		pods := []testsuites.PodDetails{{
+			Cmd:   reflinkProbe,
+			Image: "public.ecr.aws/amazonlinux/amazonlinux:2023",
+			Volumes: []testsuites.VolumeDetails{{
+				CreateVolumeParameters: map[string]string{
+					ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+					ebscsidriver.FSTypeKey:     ebscsidriver.FSTypeXfs,
+				},
+				ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+				VolumeMount: testsuites.DefaultGeneratedVolumeMount,
+			}},
+		}}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: driver.InitEbsCSIDriver(),
+			Pods:      pods,
+		}
+		test.Run(cs, f.Namespace)
+	})
+
+	It("[param:nodeComponentOnly] should deploy only node DaemonSet without controller", func() {
+		_, err := cs.AppsV1().Deployments(ebsNamespace).Get(context.Background(), "ebs-csi-controller", metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Controller deployment should not exist, but got error: %v", err)
+
+		ds, err := cs.AppsV1().DaemonSets(ebsNamespace).Get(context.Background(), "ebs-csi-node", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.Status.DesiredNumberScheduled).To(BeNumerically(">", 0))
+	})
+
+	It("[param:fips] should use FIPS-compliant image", func() {
+		pods, err := cs.CoreV1().Pods(ebsNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: controllerLabel,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pods.Items).NotTo(BeEmpty())
+		for _, pod := range pods.Items {
+			for _, c := range pod.Spec.Containers {
+				if c.Name == ebsPluginContainer {
+					Expect(c.Image).To(ContainSubstring("fips"), "Controller should use FIPS image")
+				}
+			}
+		}
+	})
+
+	It("[param:metadataLabeler] should label nodes with EBS volume and ENI counts", func() {
+		nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodes.Items).NotTo(BeEmpty())
+
+		var foundVolumeLabel, foundENILabel bool
+		for _, node := range nodes.Items {
+			if _, ok := node.Labels["ebs.csi.aws.com/non-csi-ebs-volumes-count"]; ok {
+				foundVolumeLabel = true
+			}
+			if _, ok := node.Labels["ebs.csi.aws.com/enis-count"]; ok {
+				foundENILabel = true
+			}
+		}
+		Expect(foundVolumeLabel).To(BeTrue(), "At least one node should have volume count label")
+		Expect(foundENILabel).To(BeTrue(), "At least one node should have ENI count label")
+	})
+
+	It("[param:additionalDaemonSets] should create additional node DaemonSet with scheduled pods", func() {
+		ds, err := cs.AppsV1().DaemonSets(ebsNamespace).Get(context.Background(), "ebs-csi-node-extra", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.Status.DesiredNumberScheduled).To(BeNumerically(">", 0))
+	})
+})

--- a/tests/e2e/testsuites/specs.go
+++ b/tests/e2e/testsuites/specs.go
@@ -27,6 +27,7 @@ import (
 
 type PodDetails struct {
 	Cmd     string
+	Image   string // Optional; overrides the default busybox image from NewTestPod.
 	Volumes []VolumeDetails
 }
 
@@ -84,6 +85,9 @@ type DataSource struct {
 
 func (pod *PodDetails) SetupWithDynamicVolumes(client clientset.Interface, namespace *v1.Namespace, csiDriver driver.DynamicPVTestDriver) (*TestPod, []func()) {
 	tpod := NewTestPod(client, namespace, pod.Cmd)
+	if pod.Image != "" {
+		tpod.SetImage(pod.Image)
+	}
 	cleanupFuncs := make([]func(), 0)
 	for n, v := range pod.Volumes {
 		tpvc, funcs := v.SetupDynamicPersistentVolumeClaim(client, namespace, csiDriver)

--- a/tests/e2e/testsuites/testsuites.go
+++ b/tests/e2e/testsuites/testsuites.go
@@ -765,6 +765,15 @@ func (t *TestPod) SetNodeSelector(nodeSelector map[string]string) {
 	t.pod.Spec.NodeSelector = nodeSelector
 }
 
+// SetImage overrides the default busybox image used by NewTestPod. This is
+// needed by tests whose command requires tools not present in busybox (for
+// example GNU coreutils' `cp --reflink`, or xfsprogs).
+func (t *TestPod) SetImage(image string) {
+	for i := range t.pod.Spec.Containers {
+		t.pod.Spec.Containers[i].Image = image
+	}
+}
+
 func (t *TestPod) Cleanup() {
 	cleanupPodOrFail(t.client, t.pod.Name, t.namespace.Name)
 }

--- a/tests/helm-template/go.mod
+++ b/tests/helm-template/go.mod
@@ -1,0 +1,7 @@
+module github.com/kubernetes-sigs/aws-ebs-csi-driver/tests/helm-template
+
+go 1.26.1
+
+require sigs.k8s.io/yaml v1.6.0
+
+require go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/tests/helm-template/go.sum
+++ b/tests/helm-template/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
+go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
+go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
+sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/tests/helm-template/infra_test.go
+++ b/tests/helm-template/infra_test.go
@@ -1,0 +1,662 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helmtemplate
+
+import (
+	"testing"
+)
+
+func TestInfra(t *testing.T) {
+	resources := renderChart(t, "infra")
+	want := loadValuesMap(t, "infra")
+	deploy := mustFind(t, resources, "Deployment", "ebs-csi-controller")
+	dSpec := nested(t, deploy, "spec")
+	cPS := podSpec(t, deploy)
+	ebsPlugin := findContainer(t, cPS, "ebs-plugin")
+
+	ds := mustFind(t, resources, "DaemonSet", "ebs-csi-node")
+	dsSpec := nested(t, ds, "spec")
+	nPS := podSpec(t, ds)
+	nodePlugin := findContainer(t, nPS, "ebs-plugin")
+
+	t.Run("controllerReplicaCount", func(t *testing.T) {
+		wantReplicas, _ := nestedFloat(want, "controller", "replicaCount")
+		replicas, ok := nestedFloat(dSpec, "replicas")
+		if !ok || replicas != wantReplicas {
+			t.Errorf("replicas: got %v, want %v", replicas, wantReplicas)
+		}
+	})
+
+	t.Run("controllerPriorityClassName", func(t *testing.T) {
+		wantPC, _ := nestedString(want, "controller", "priorityClassName")
+		if cPS["priorityClassName"] != wantPC {
+			t.Errorf("controller priorityClassName: got %v, want %s", cPS["priorityClassName"], wantPC)
+		}
+	})
+
+	t.Run("controllerResources", func(t *testing.T) {
+		wantCPU, _ := nestedString(want, "controller", "resources", "requests", "cpu")
+		wantMem, _ := nestedString(want, "controller", "resources", "limits", "memory")
+		res := nested(t, ebsPlugin, "resources")
+		cpu, _ := nestedString(res, "requests", "cpu")
+		mem, _ := nestedString(res, "limits", "memory")
+		if cpu != wantCPU {
+			t.Errorf("controller cpu request: got %s, want %s", cpu, wantCPU)
+		}
+		if mem != wantMem {
+			t.Errorf("controller memory limit: got %s, want %s", mem, wantMem)
+		}
+	})
+
+	t.Run("controllerPodAnnotations", func(t *testing.T) {
+		wantAnns, _ := want["controller"].(obj)["podAnnotations"].(obj)
+		tmpl := nested(t, deploy, "spec", "template", "metadata")
+		ann := tmpl["annotations"].(obj)
+		for k, v := range wantAnns {
+			if ann[k] != v {
+				t.Errorf("controller pod annotation %q: got %v, want %v", k, ann[k], v)
+			}
+		}
+	})
+
+	t.Run("controllerPodLabels", func(t *testing.T) {
+		wantLabels, _ := want["controller"].(obj)["podLabels"].(obj)
+		tmpl := nested(t, deploy, "spec", "template", "metadata")
+		labels := tmpl["labels"].(obj)
+		for k, v := range wantLabels {
+			if labels[k] != v {
+				t.Errorf("controller pod label %q: got %v, want %v", k, labels[k], v)
+			}
+		}
+	})
+
+	t.Run("controllerDeploymentAnnotations", func(t *testing.T) {
+		wantAnns, _ := want["controller"].(obj)["deploymentAnnotations"].(obj)
+		meta := nested(t, deploy, "metadata")
+		ann := meta["annotations"].(obj)
+		for k, v := range wantAnns {
+			if ann[k] != v {
+				t.Errorf("deployment annotation %q: got %v, want %v", k, ann[k], v)
+			}
+		}
+	})
+
+	t.Run("controllerRevisionHistoryLimit", func(t *testing.T) {
+		wantRHL, _ := nestedFloat(want, "controller", "revisionHistoryLimit")
+		rhl, ok := nestedFloat(dSpec, "revisionHistoryLimit")
+		if !ok || rhl != wantRHL {
+			t.Errorf("revisionHistoryLimit: got %v, want %v", rhl, wantRHL)
+		}
+	})
+
+	t.Run("controllerTopologySpreadConstraints", func(t *testing.T) {
+		wantTSCs, _ := want["controller"].(obj)["topologySpreadConstraints"].([]interface{})
+		if len(wantTSCs) == 0 {
+			t.Fatal("values file has no topologySpreadConstraints")
+		}
+		wantKey := wantTSCs[0].(obj)["topologyKey"]
+		tscs := nestedSlice(t, cPS, "topologySpreadConstraints")
+		if len(tscs) == 0 {
+			t.Fatal("no topologySpreadConstraints in render")
+		}
+		if got := tscs[0].(obj)["topologyKey"]; got != wantKey {
+			t.Errorf("topologyKey: got %v, want %v", got, wantKey)
+		}
+	})
+
+	t.Run("controllerSecurityContext", func(t *testing.T) {
+		wantSC, _ := want["controller"].(obj)["securityContext"].(obj)
+		sc := nested(t, cPS, "securityContext")
+		for k, v := range wantSC {
+			if sc[k] != v {
+				t.Errorf("controller securityContext.%s: got %v, want %v", k, sc[k], v)
+			}
+		}
+	})
+
+	t.Run("controllerContainerSecurityContext", func(t *testing.T) {
+		wantSC, _ := want["controller"].(obj)["containerSecurityContext"].(obj)
+		sc := nested(t, ebsPlugin, "securityContext")
+		for k, v := range wantSC {
+			if sc[k] != v {
+				t.Errorf("ebs-plugin securityContext.%s: got %v, want %v", k, sc[k], v)
+			}
+		}
+	})
+
+	t.Run("controllerUpdateStrategy", func(t *testing.T) {
+		wantType, _ := nestedString(want, "controller", "updateStrategy", "type")
+		strategy := nested(t, dSpec, "strategy")
+		if strategy["type"] != wantType {
+			t.Errorf("strategy type: got %v, want %s", strategy["type"], wantType)
+		}
+	})
+
+	t.Run("controllerEnv", func(t *testing.T) {
+		wantEnvs, _ := want["controller"].(obj)["env"].([]interface{})
+		envs := nestedSlice(t, ebsPlugin, "env")
+		for _, we := range wantEnvs {
+			wm := we.(obj)
+			var found bool
+			for _, e := range envs {
+				em := e.(obj)
+				if em["name"] == wm["name"] && em["value"] == wm["value"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("controller should have env %v=%v", wm["name"], wm["value"])
+			}
+		}
+	})
+
+	t.Run("controllerVolumes", func(t *testing.T) {
+		wantVols, _ := want["controller"].(obj)["volumes"].([]interface{})
+		vols := nestedSlice(t, cPS, "volumes")
+		for _, wv := range wantVols {
+			wantName := wv.(obj)["name"]
+			var found bool
+			for _, v := range vols {
+				if v.(obj)["name"] == wantName {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("controller should have volume %v", wantName)
+			}
+		}
+	})
+
+	t.Run("controllerVolumeMounts", func(t *testing.T) {
+		wantMounts, _ := want["controller"].(obj)["volumeMounts"].([]interface{})
+		mounts := nestedSlice(t, ebsPlugin, "volumeMounts")
+		for _, wm := range wantMounts {
+			wmObj := wm.(obj)
+			var found bool
+			for _, m := range mounts {
+				mm := m.(obj)
+				if mm["name"] == wmObj["name"] && mm["mountPath"] == wmObj["mountPath"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("controller should have mount %v at %v", wmObj["name"], wmObj["mountPath"])
+			}
+		}
+	})
+
+	t.Run("controllerDnsConfig", func(t *testing.T) {
+		wantNS, _ := want["controller"].(obj)["dnsConfig"].(obj)["nameservers"].([]interface{})
+		dns := nested(t, cPS, "dnsConfig")
+		got := dns["nameservers"].([]interface{})
+		for _, wn := range wantNS {
+			var found bool
+			for _, n := range got {
+				if n == wn {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("controller dnsConfig should have nameserver %v", wn)
+			}
+		}
+	})
+
+	t.Run("controllerInitContainers", func(t *testing.T) {
+		wantInits, _ := want["controller"].(obj)["initContainers"].([]interface{})
+		inits := nestedSlice(t, cPS, "initContainers")
+		for _, wi := range wantInits {
+			wantName := wi.(obj)["name"]
+			var found bool
+			for _, c := range inits {
+				if c.(obj)["name"] == wantName {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("controller should have init container %v", wantName)
+			}
+		}
+	})
+
+	t.Run("controllerTolerations", func(t *testing.T) {
+		wantTols, _ := want["controller"].(obj)["tolerations"].([]interface{})
+		tols := nestedSlice(t, cPS, "tolerations")
+		for _, wt := range wantTols {
+			wtObj := wt.(obj)
+			var found bool
+			for _, tol := range tols {
+				tm := tol.(obj)
+				if tm["key"] == wtObj["key"] && tm["value"] == wtObj["value"] && tm["effect"] == wtObj["effect"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("controller should have toleration key=%v value=%v effect=%v",
+					wtObj["key"], wtObj["value"], wtObj["effect"])
+			}
+		}
+	})
+
+	t.Run("controllerAdditionalArgs", func(t *testing.T) {
+		wantArgs, _ := want["controller"].(obj)["additionalArgs"].([]interface{})
+		for _, a := range wantArgs {
+			if !hasArg(ebsPlugin, a.(string)) {
+				t.Errorf("controller should have arg %q", a)
+			}
+		}
+	})
+
+	t.Run("nameOverride", func(t *testing.T) {
+		wantName, _ := nestedString(want, "nameOverride")
+		meta := nested(t, deploy, "metadata")
+		labels := meta["labels"].(obj)
+		if labels["app.kubernetes.io/name"] != wantName {
+			t.Errorf("app.kubernetes.io/name: got %v, want %s", labels["app.kubernetes.io/name"], wantName)
+		}
+	})
+
+	t.Run("imagePullPolicy", func(t *testing.T) {
+		wantPolicy, _ := nestedString(want, "image", "pullPolicy")
+		if ebsPlugin["imagePullPolicy"] != wantPolicy {
+			t.Errorf("ebs-plugin imagePullPolicy: got %v, want %s", ebsPlugin["imagePullPolicy"], wantPolicy)
+		}
+	})
+
+	t.Run("customLabels/controller", func(t *testing.T) {
+		wantLabels, _ := want["customLabels"].(obj)
+		meta := nested(t, deploy, "metadata")
+		labels := meta["labels"].(obj)
+		for k, v := range wantLabels {
+			if labels[k] != v {
+				t.Errorf("controller label %q: got %v, want %v", k, labels[k], v)
+			}
+		}
+	})
+
+	// --- Node DaemonSet assertions ---
+
+	t.Run("nodePriorityClassName", func(t *testing.T) {
+		wantPC, _ := nestedString(want, "node", "priorityClassName")
+		if nPS["priorityClassName"] != wantPC {
+			t.Errorf("node priorityClassName: got %v, want %s", nPS["priorityClassName"], wantPC)
+		}
+	})
+
+	t.Run("nodeResources", func(t *testing.T) {
+		wantCPU, _ := nestedString(want, "node", "resources", "requests", "cpu")
+		wantMem, _ := nestedString(want, "node", "resources", "limits", "memory")
+		res := nested(t, nodePlugin, "resources")
+		cpu, _ := nestedString(res, "requests", "cpu")
+		mem, _ := nestedString(res, "limits", "memory")
+		if cpu != wantCPU {
+			t.Errorf("node cpu request: got %s, want %s", cpu, wantCPU)
+		}
+		if mem != wantMem {
+			t.Errorf("node memory limit: got %s, want %s", mem, wantMem)
+		}
+	})
+
+	t.Run("nodePodAnnotations", func(t *testing.T) {
+		wantAnns, _ := want["node"].(obj)["podAnnotations"].(obj)
+		tmpl := nested(t, ds, "spec", "template", "metadata")
+		ann := tmpl["annotations"].(obj)
+		for k, v := range wantAnns {
+			if ann[k] != v {
+				t.Errorf("node pod annotation %q: got %v, want %v", k, ann[k], v)
+			}
+		}
+	})
+
+	t.Run("nodeDaemonSetAnnotations", func(t *testing.T) {
+		wantAnns, _ := want["node"].(obj)["daemonSetAnnotations"].(obj)
+		meta := nested(t, ds, "metadata")
+		ann := meta["annotations"].(obj)
+		for k, v := range wantAnns {
+			if ann[k] != v {
+				t.Errorf("daemonset annotation %q: got %v, want %v", k, ann[k], v)
+			}
+		}
+	})
+
+	t.Run("nodeRevisionHistoryLimit", func(t *testing.T) {
+		wantRHL, _ := nestedFloat(want, "node", "revisionHistoryLimit")
+		rhl, ok := nestedFloat(dsSpec, "revisionHistoryLimit")
+		if !ok || rhl != wantRHL {
+			t.Errorf("node revisionHistoryLimit: got %v, want %v", rhl, wantRHL)
+		}
+	})
+
+	t.Run("nodeSecurityContext", func(t *testing.T) {
+		// infra.yaml doesn't set node.securityContext, just assert it renders.
+		if nPS["securityContext"] == nil {
+			t.Error("node should have securityContext")
+		}
+	})
+
+	t.Run("nodeUpdateStrategy", func(t *testing.T) {
+		wantType, _ := nestedString(want, "node", "updateStrategy", "type")
+		strategy := nested(t, dsSpec, "updateStrategy")
+		if strategy["type"] != wantType {
+			t.Errorf("node updateStrategy: got %v, want %s", strategy["type"], wantType)
+		}
+	})
+
+	t.Run("nodeEnv", func(t *testing.T) {
+		wantEnvs, _ := want["node"].(obj)["env"].([]interface{})
+		envs := nestedSlice(t, nodePlugin, "env")
+		for _, we := range wantEnvs {
+			wm := we.(obj)
+			var found bool
+			for _, e := range envs {
+				em := e.(obj)
+				if em["name"] == wm["name"] && em["value"] == wm["value"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node should have env %v=%v", wm["name"], wm["value"])
+			}
+		}
+	})
+
+	t.Run("nodeVolumes", func(t *testing.T) {
+		wantVols, _ := want["node"].(obj)["volumes"].([]interface{})
+		vols := nestedSlice(t, nPS, "volumes")
+		for _, wv := range wantVols {
+			wantName := wv.(obj)["name"]
+			var found bool
+			for _, v := range vols {
+				if v.(obj)["name"] == wantName {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node should have volume %v", wantName)
+			}
+		}
+	})
+
+	t.Run("nodeVolumeMounts", func(t *testing.T) {
+		wantMounts, _ := want["node"].(obj)["volumeMounts"].([]interface{})
+		mounts := nestedSlice(t, nodePlugin, "volumeMounts")
+		for _, wm := range wantMounts {
+			wmObj := wm.(obj)
+			var found bool
+			for _, m := range mounts {
+				mm := m.(obj)
+				if mm["name"] == wmObj["name"] && mm["mountPath"] == wmObj["mountPath"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node should have mount %v at %v", wmObj["name"], wmObj["mountPath"])
+			}
+		}
+	})
+
+	t.Run("nodeAdditionalArgs", func(t *testing.T) {
+		wantArgs, _ := want["node"].(obj)["additionalArgs"].([]interface{})
+		for _, a := range wantArgs {
+			if !hasArg(nodePlugin, a.(string)) {
+				t.Errorf("node should have arg %q", a)
+			}
+		}
+	})
+
+	t.Run("nodeDnsConfig", func(t *testing.T) {
+		wantNS, _ := want["node"].(obj)["dnsConfig"].(obj)["nameservers"].([]interface{})
+		dns := nested(t, nPS, "dnsConfig")
+		got := dns["nameservers"].([]interface{})
+		for _, wn := range wantNS {
+			var found bool
+			for _, n := range got {
+				if n == wn {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node dnsConfig should have nameserver %v", wn)
+			}
+		}
+	})
+
+	t.Run("nodeInitContainers", func(t *testing.T) {
+		wantInits, _ := want["node"].(obj)["initContainers"].([]interface{})
+		inits := nestedSlice(t, nPS, "initContainers")
+		for _, wi := range wantInits {
+			wantName := wi.(obj)["name"]
+			var found bool
+			for _, c := range inits {
+				if c.(obj)["name"] == wantName {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node should have init container %v", wantName)
+			}
+		}
+	})
+
+	t.Run("nodeTolerations", func(t *testing.T) {
+		wantTols, _ := want["node"].(obj)["tolerations"].([]interface{})
+		tols := nestedSlice(t, nPS, "tolerations")
+		for _, wt := range wantTols {
+			wtObj := wt.(obj)
+			var found bool
+			for _, tol := range tols {
+				tm := tol.(obj)
+				if tm["key"] == wtObj["key"] && tm["value"] == wtObj["value"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node should have toleration key=%v value=%v", wtObj["key"], wtObj["value"])
+			}
+		}
+	})
+
+	t.Run("customLabels/node", func(t *testing.T) {
+		wantLabels, _ := want["customLabels"].(obj)
+		meta := nested(t, ds, "metadata")
+		labels := meta["labels"].(obj)
+		for k, v := range wantLabels {
+			if labels[k] != v {
+				t.Errorf("node label %q: got %v, want %v", k, labels[k], v)
+			}
+		}
+	})
+
+	// Sidecar resource tests. expectedCPU is looked up from infra.yaml so
+	// values stay in one place.
+	sidecarTests := []struct {
+		name      string
+		resKind   string
+		resName   string
+		container string
+		valuesKey string // key under sidecars in infra.yaml
+	}{
+		{"provisionerResources", "Deployment", "ebs-csi-controller", "csi-provisioner", "provisioner"},
+		{"attacherResources", "Deployment", "ebs-csi-controller", "csi-attacher", "attacher"},
+		{"snapshotterResources", "Deployment", "ebs-csi-controller", "csi-snapshotter", "snapshotter"},
+		{"resizerResources", "Deployment", "ebs-csi-controller", "csi-resizer", "resizer"},
+		{"nodeDriverRegistrarResources", "DaemonSet", "ebs-csi-node", "node-driver-registrar", "nodeDriverRegistrar"},
+		{"livenessProbeResources", "DaemonSet", "ebs-csi-node", "liveness-probe", "livenessProbe"},
+	}
+	for _, tc := range sidecarTests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantCPU, _ := nestedString(want, "sidecars", tc.valuesKey, "resources", "requests", "cpu")
+			r := mustFind(t, resources, tc.resKind, tc.resName)
+			ps := podSpec(t, r)
+			c := findContainer(t, ps, tc.container)
+			res := nested(t, c, "resources")
+			cpu, _ := nestedString(res, "requests", "cpu")
+			if cpu != wantCPU {
+				t.Errorf("%s cpu request: got %s, want %s", tc.container, cpu, wantCPU)
+			}
+		})
+	}
+
+	t.Run("provisionerAdditionalArgs", func(t *testing.T) {
+		wantArgs, _ := want["sidecars"].(obj)["provisioner"].(obj)["additionalArgs"].([]interface{})
+		provisioner := findContainer(t, cPS, "csi-provisioner")
+		for _, a := range wantArgs {
+			if !hasArg(provisioner, a.(string)) {
+				t.Errorf("provisioner should have arg %q", a)
+			}
+		}
+	})
+}
+
+func TestDebug(t *testing.T) {
+	resources := renderChart(t, "debug")
+	controller := mustFind(t, resources, "Deployment", "ebs-csi-controller")
+	cPS := podSpec(t, controller)
+	ebsPlugin := findContainer(t, cPS, "ebs-plugin")
+
+	t.Run("debugLogs", func(t *testing.T) {
+		if !hasArgAny(ebsPlugin, "-v=7", "--v=7") {
+			t.Error("controller ebs-plugin should have -v=7 when debugLogs=true")
+		}
+	})
+
+	t.Run("sdkDebugLog", func(t *testing.T) {
+		if !hasArg(ebsPlugin, "--aws-sdk-debug-log=true") {
+			t.Error("controller should have --aws-sdk-debug-log=true")
+		}
+	})
+}
+
+func TestMiscellaneous(t *testing.T) {
+	resources := renderChart(t, "miscellaneous")
+	controller := mustFind(t, resources, "Deployment", "ebs-csi-controller")
+	cPS := podSpec(t, controller)
+
+	ds := mustFind(t, resources, "DaemonSet", "ebs-csi-node")
+	nPS := podSpec(t, ds)
+	nodePlugin := findContainer(t, nPS, "ebs-plugin")
+
+	t.Run("volumeModification", func(t *testing.T) {
+		if !hasContainer(cPS, "volumemodifier") {
+			t.Error("controller should have volumemodifier sidecar")
+		}
+	})
+
+	t.Run("volumemodifierLogLevel", func(t *testing.T) {
+		c := findContainer(t, cPS, "volumemodifier")
+		if !hasArgAny(c, "-v=5", "--v=5") {
+			t.Error("volumemodifier should have -v=5")
+		}
+	})
+
+	t.Run("volumemodifierLeaderElection", func(t *testing.T) {
+		c := findContainer(t, cPS, "volumemodifier")
+		if !hasArg(c, "--leader-election=false") {
+			t.Error("volumemodifier should have --leader-election=false")
+		}
+	})
+
+	t.Run("volumeAttachLimit", func(t *testing.T) {
+		if !hasArg(nodePlugin, "--volume-attach-limit=25") {
+			t.Error("node should have --volume-attach-limit=25")
+		}
+	})
+
+	t.Run("metadataLabeler", func(t *testing.T) {
+		if !hasContainer(cPS, "metadata-labeler") {
+			t.Error("controller should have metadata-labeler sidecar")
+		}
+	})
+
+	t.Run("metadataLabelerLogLevel", func(t *testing.T) {
+		c := findContainer(t, cPS, "metadata-labeler")
+		if !hasArgAny(c, "-v=5", "--v=5") {
+			t.Error("metadata-labeler should have -v=5")
+		}
+	})
+
+	t.Run("additionalDaemonSets", func(t *testing.T) {
+		extraDS := mustFind(t, resources, "DaemonSet", "ebs-csi-node-extra")
+		extraPS := podSpec(t, extraDS)
+		c := findContainer(t, extraPS, "ebs-plugin")
+		if !hasArg(c, "--volume-attach-limit=15") {
+			t.Error("additional DaemonSet should have --volume-attach-limit=15")
+		}
+	})
+}
+
+func TestNodeComponentOnly(t *testing.T) {
+	resources := renderChart(t, "node-component-only")
+
+	t.Run("noController", func(t *testing.T) {
+		_, found := find(resources, "Deployment", "ebs-csi-controller")
+		if found {
+			t.Error("controller Deployment should not exist when nodeComponentOnly=true")
+		}
+	})
+
+	t.Run("nodeExists", func(t *testing.T) {
+		mustFind(t, resources, "DaemonSet", "ebs-csi-node")
+	})
+}
+
+// TestUseOldCSIDriver verifies that setting useOldCSIDriver=true omits
+// fsGroupPolicy from the rendered CSIDriver object.
+func TestUseOldCSIDriver(t *testing.T) {
+	resources := renderChartWithSet(t, "useOldCSIDriver=true")
+	csiDriver := mustFind(t, resources, "CSIDriver", "ebs.csi.aws.com")
+
+	t.Run("fsGroupPolicyAbsent", func(t *testing.T) {
+		spec := nested(t, csiDriver, "spec")
+		if _, ok := spec["fsGroupPolicy"]; ok {
+			t.Error("CSIDriver spec should not have fsGroupPolicy when useOldCSIDriver=true")
+		}
+	})
+}
+
+// TestSelinux verifies that setting node.selinux=true sets seLinuxMount on the
+// CSIDriver and adds the SELinux host mounts to the node ebs-plugin container.
+// Skips the live cluster by asserting on rendered templates, so no
+// SELinux-enabled nodes are required.
+func TestSelinux(t *testing.T) {
+	resources := renderChartWithSet(t, "node.selinux=true")
+	csiDriver := mustFind(t, resources, "CSIDriver", "ebs.csi.aws.com")
+	ds := mustFind(t, resources, "DaemonSet", "ebs-csi-node")
+	nodePlugin := findContainer(t, podSpec(t, ds), "ebs-plugin")
+
+	t.Run("seLinuxMountSet", func(t *testing.T) {
+		spec := nested(t, csiDriver, "spec")
+		if spec["seLinuxMount"] != true {
+			t.Errorf("CSIDriver spec.seLinuxMount: got %v, want true", spec["seLinuxMount"])
+		}
+	})
+
+	for _, wantPath := range []string{"/sys/fs/selinux", "/etc/selinux/config"} {
+		t.Run("nodeMount/"+wantPath, func(t *testing.T) {
+			mounts, _ := nodePlugin["volumeMounts"].([]interface{})
+			var found bool
+			for _, m := range mounts {
+				if m.(obj)["mountPath"] == wantPath {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("node ebs-plugin should mount %s", wantPath)
+			}
+		})
+	}
+}

--- a/tests/helm-template/parameter_test.go
+++ b/tests/helm-template/parameter_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package helmtemplate tests Helm chart parameter rendering without a live cluster.
+package helmtemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+const releaseName = "ebs-csi"
+
+// chartPath returns the absolute path to the helm chart.
+func chartPath() string {
+	_, f, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(f), "..", "..", "charts", "aws-ebs-csi-driver")
+}
+
+// helmBin returns the path to the helm binary.
+func helmBin() string {
+	_, f, _, _ := runtime.Caller(0)
+	bin := filepath.Join(filepath.Dir(f), "..", "..", "bin", ".helm")
+	if _, err := os.Stat(bin); err == nil {
+		return bin
+	}
+	return "helm"
+}
+
+// testdataPath returns the absolute path to a testdata values file.
+func testdataPath(name string) string {
+	_, f, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(f), "testdata", name+".yaml")
+}
+
+// obj is a generic JSON-like object parsed from YAML.
+type obj = map[string]interface{}
+
+// loadValuesMap reads a testdata values YAML file as a generic map so tests can
+// read expected values from the same file they pass to `helm template`.
+// This avoids hardcoding values in assertions that would silently drift when
+// the YAML is updated.
+func loadValuesMap(t *testing.T, name string) obj {
+	t.Helper()
+	data, err := os.ReadFile(testdataPath(name))
+	if err != nil {
+		t.Fatalf("read values %s: %v", name, err)
+	}
+	j, err := yaml.YAMLToJSON(data)
+	if err != nil {
+		t.Fatalf("yaml to json: %v", err)
+	}
+	var m obj
+	if err := json.Unmarshal(j, &m); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	return m
+}
+
+// renderChart runs helm template and returns parsed resources as generic maps.
+func renderChart(t *testing.T, valuesFile string) []obj {
+	t.Helper()
+	cmd := exec.Command(helmBin(), "template", releaseName, chartPath(), "-f", testdataPath(valuesFile))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("helm template failed: %v\nstderr: %s", err, stderr.String())
+	}
+	return parseYAMLDocs(t, stdout.Bytes())
+}
+
+// renderChartWithSet runs helm template with inline --set flags instead of a
+// values file. Useful for one- or two-flag render-time tests where a dedicated
+// testdata YAML would be overkill.
+func renderChartWithSet(t *testing.T, sets ...string) []obj {
+	t.Helper()
+	args := []string{"template", releaseName, chartPath()}
+	for _, s := range sets {
+		args = append(args, "--set", s)
+	}
+	cmd := exec.Command(helmBin(), args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("helm template failed: %v\nstderr: %s", err, stderr.String())
+	}
+	return parseYAMLDocs(t, stdout.Bytes())
+}
+
+// parseYAMLDocs splits multi-doc YAML and converts each to a JSON-like map via sigs.k8s.io/yaml.
+func parseYAMLDocs(t *testing.T, data []byte) []obj {
+	t.Helper()
+	var out []obj
+	for _, doc := range bytes.Split(data, []byte("\n---")) {
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+		j, err := yaml.YAMLToJSON(doc)
+		if err != nil {
+			t.Fatalf("yaml to json: %v", err)
+		}
+		var m obj
+		if err := json.Unmarshal(j, &m); err != nil {
+			t.Fatalf("json unmarshal: %v", err)
+		}
+		if m["kind"] != nil {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// find returns the first resource matching kind and name.
+func find(resources []obj, kind, name string) (obj, bool) {
+	for _, r := range resources {
+		if r["kind"] == kind {
+			if meta, ok := r["metadata"].(obj); ok && meta["name"] == name {
+				return r, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// mustFind returns a resource or fails the test.
+func mustFind(t *testing.T, resources []obj, kind, name string) obj {
+	t.Helper()
+	r, ok := find(resources, kind, name)
+	if !ok {
+		t.Fatalf("resource %s/%s not found", kind, name)
+	}
+	return r
+}
+
+// podSpec extracts .spec.template.spec from a Deployment or DaemonSet.
+func podSpec(t *testing.T, r obj) obj {
+	t.Helper()
+	spec := nested(t, r, "spec", "template", "spec")
+	return spec
+}
+
+// findContainer finds a container by name in a pod spec.
+func findContainer(t *testing.T, ps obj, name string) obj {
+	t.Helper()
+	for _, c := range nestedSlice(t, ps, "containers") {
+		cm := c.(obj)
+		if cm["name"] == name {
+			return cm
+		}
+	}
+	t.Fatalf("container %q not found", name)
+	return nil
+}
+
+// hasContainer returns true if the pod spec has a container with the given name.
+func hasContainer(ps obj, name string) bool {
+	containers, ok := ps["containers"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, c := range containers {
+		if cm, ok := c.(obj); ok && cm["name"] == name {
+			return true
+		}
+	}
+	return false
+}
+
+// containerArgs returns the args slice for a container.
+func containerArgs(c obj) []string {
+	args, ok := c["args"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, a := range args {
+		out = append(out, fmt.Sprint(a))
+	}
+	return out
+}
+
+// hasArg checks if a container has a specific arg.
+func hasArg(c obj, arg string) bool {
+	for _, a := range containerArgs(c) {
+		if a == arg {
+			return true
+		}
+	}
+	return false
+}
+
+// hasArgAny checks if a container has any of the given args.
+func hasArgAny(c obj, args ...string) bool {
+	for _, arg := range args {
+		if hasArg(c, arg) {
+			return true
+		}
+	}
+	return false
+}
+
+// nested traverses a map by keys and returns the nested map.
+func nested(t *testing.T, m obj, keys ...string) obj {
+	t.Helper()
+	cur := m
+	for _, k := range keys {
+		val, ok := cur[k]
+		if !ok {
+			t.Fatalf("key %q not found in path %v", k, keys)
+		}
+		cur, ok = val.(obj)
+		if !ok {
+			t.Fatalf("key %q is not a map in path %v", k, keys)
+		}
+	}
+	return cur
+}
+
+// nestedSlice traverses a map by keys and returns the nested slice.
+func nestedSlice(t *testing.T, m obj, keys ...string) []interface{} {
+	t.Helper()
+	cur := m
+	for i, k := range keys {
+		val, ok := cur[k]
+		if !ok {
+			t.Fatalf("key %q not found", k)
+		}
+		if i == len(keys)-1 {
+			s, ok := val.([]interface{})
+			if !ok {
+				t.Fatalf("key %q is not a slice", k)
+			}
+			return s
+		}
+		cur, ok = val.(obj)
+		if !ok {
+			t.Fatalf("key %q is not a map", k)
+		}
+	}
+	return nil
+}
+
+// nestedString traverses a map by keys and returns the string value.
+func nestedString(m obj, keys ...string) (string, bool) {
+	cur := m
+	for i, k := range keys {
+		val, ok := cur[k]
+		if !ok {
+			return "", false
+		}
+		if i == len(keys)-1 {
+			s, ok := val.(string)
+			return s, ok
+		}
+		cur, ok = val.(obj)
+		if !ok {
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// nestedFloat traverses a map by keys and returns the float64 value.
+func nestedFloat(m obj, keys ...string) (float64, bool) {
+	cur := m
+	for i, k := range keys {
+		val, ok := cur[k]
+		if !ok {
+			return 0, false
+		}
+		if i == len(keys)-1 {
+			f, ok := val.(float64)
+			return f, ok
+		}
+		cur, ok = val.(obj)
+		if !ok {
+			return 0, false
+		}
+	}
+	return 0, false
+}

--- a/tests/helm-template/standard_test.go
+++ b/tests/helm-template/standard_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helmtemplate
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestStandard validates the "standard" param set rendering.
+func TestStandard(t *testing.T) {
+	resources := renderChart(t, "standard")
+	want := loadValuesMap(t, "standard")
+	controller := mustFind(t, resources, "Deployment", "ebs-csi-controller")
+	cPS := podSpec(t, controller)
+	ebsPlugin := findContainer(t, cPS, "ebs-plugin")
+
+	nodeDSObj := mustFind(t, resources, "DaemonSet", "ebs-csi-node")
+	nPS := podSpec(t, nodeDSObj)
+	nodePlugin := findContainer(t, nPS, "ebs-plugin")
+
+	t.Run("controllerMetrics", func(t *testing.T) {
+		svc := mustFind(t, resources, "Service", "ebs-csi-controller")
+		assertServiceHasPort(t, svc, "metrics", 3301)
+	})
+
+	t.Run("nodeMetrics", func(t *testing.T) {
+		svc := mustFind(t, resources, "Service", "ebs-csi-node")
+		assertServiceHasPort(t, svc, "metrics", 3302)
+	})
+
+	t.Run("batching", func(t *testing.T) {
+		wantArg := fmt.Sprintf("--batching=%v", want["controller"].(obj)["batching"])
+		if !hasArg(ebsPlugin, wantArg) {
+			t.Errorf("controller should have %s", wantArg)
+		}
+	})
+
+	t.Run("controllerLoggingFormat", func(t *testing.T) {
+		wantFmt, _ := nestedString(want, "controller", "loggingFormat")
+		wantArg := "--logging-format=" + wantFmt
+		if !hasArg(ebsPlugin, wantArg) {
+			t.Errorf("controller should have %s", wantArg)
+		}
+	})
+
+	t.Run("nodeLoggingFormat", func(t *testing.T) {
+		wantFmt, _ := nestedString(want, "node", "loggingFormat")
+		wantArg := "--logging-format=" + wantFmt
+		if !hasArg(nodePlugin, wantArg) {
+			t.Errorf("node should have %s", wantArg)
+		}
+	})
+
+	t.Run("controllerUserAgentExtra", func(t *testing.T) {
+		wantUA, _ := nestedString(want, "controller", "userAgentExtra")
+		wantArg := "--user-agent-extra=" + wantUA
+		if !hasArg(ebsPlugin, wantArg) {
+			t.Errorf("controller should have %s", wantArg)
+		}
+	})
+
+	t.Run("reservedVolumeAttachments", func(t *testing.T) {
+		wantN, _ := nestedFloat(want, "node", "reservedVolumeAttachments")
+		wantArg := fmt.Sprintf("--reserved-volume-attachments=%d", int(wantN))
+		if !hasArg(nodePlugin, wantArg) {
+			t.Errorf("node should have %s", wantArg)
+		}
+	})
+
+	t.Run("hostNetwork", func(t *testing.T) {
+		hn, ok := nPS["hostNetwork"].(bool)
+		if !ok || !hn {
+			t.Error("node pod should use hostNetwork")
+		}
+	})
+
+	t.Run("nodeTerminationGracePeriod", func(t *testing.T) {
+		wantTGP, _ := nestedFloat(want, "node", "terminationGracePeriodSeconds")
+		tgp, ok := nestedFloat(nPS, "terminationGracePeriodSeconds")
+		if !ok || tgp != wantTGP {
+			t.Errorf("node terminationGracePeriodSeconds: got %v, want %v", tgp, wantTGP)
+		}
+	})
+
+	t.Run("nodeTolerateAllTaints", func(t *testing.T) {
+		tolerations := nestedSlice(t, nPS, "tolerations")
+		var found bool
+		for _, tol := range tolerations {
+			tm := tol.(obj)
+			if tm["operator"] == "Exists" && (tm["key"] == nil || tm["key"] == "") {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("node should have tolerate-all toleration")
+		}
+	})
+
+	t.Run("nodeKubeletPath", func(t *testing.T) {
+		wantPath, _ := nestedString(want, "node", "kubeletPath")
+		mounts, ok := nodePlugin["volumeMounts"].([]interface{})
+		if !ok {
+			t.Fatal("no volumeMounts on node ebs-plugin")
+		}
+		var found bool
+		for _, m := range mounts {
+			mm := m.(obj)
+			if mm["mountPath"] == wantPath {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("node should mount kubelet path at %s", wantPath)
+		}
+	})
+
+	t.Run("controllerPodDisruptionBudget", func(t *testing.T) {
+		mustFind(t, resources, "PodDisruptionBudget", "ebs-csi-controller")
+	})
+
+	t.Run("snapshotterForceEnable", func(t *testing.T) {
+		if !hasContainer(cPS, "csi-snapshotter") {
+			t.Error("controller should have csi-snapshotter when forceEnable=true")
+		}
+	})
+
+	t.Run("nodeDisableMutation", func(t *testing.T) {
+		cr := mustFind(t, resources, "ClusterRole", "ebs-csi-node-role")
+		rules, ok := cr["rules"].([]interface{})
+		if !ok {
+			t.Fatal("no rules in ClusterRole")
+		}
+		for _, rule := range rules {
+			rm := rule.(obj)
+			res, _ := rm["resources"].([]interface{})
+			for _, r := range res {
+				if r == "nodes" {
+					verbs, _ := rm["verbs"].([]interface{})
+					for _, v := range verbs {
+						if v == "patch" || v == "update" {
+							t.Errorf("node role should not have %s on nodes when disableMutation=true", v)
+						}
+					}
+				}
+			}
+		}
+	})
+
+	t.Run("storageClasses", func(t *testing.T) {
+		wantSCs, _ := want["storageClasses"].([]interface{})
+		if len(wantSCs) == 0 {
+			t.Fatal("values file has no storageClasses")
+		}
+		wantSC := wantSCs[0].(obj)
+		wantName, _ := wantSC["name"].(string)
+		wantType, _ := wantSC["parameters"].(obj)["type"]
+		sc := mustFind(t, resources, "StorageClass", wantName)
+		params := nested(t, sc, "parameters")
+		if params["type"] != wantType {
+			t.Errorf("StorageClass type: got %v, want %v", params["type"], wantType)
+		}
+	})
+
+	t.Run("volumeSnapshotClasses", func(t *testing.T) {
+		wantVSCs, _ := want["volumeSnapshotClasses"].([]interface{})
+		if len(wantVSCs) == 0 {
+			t.Fatal("values file has no volumeSnapshotClasses")
+		}
+		wantVSC := wantVSCs[0].(obj)
+		wantName, _ := wantVSC["name"].(string)
+		wantDP, _ := wantVSC["deletionPolicy"].(string)
+		vsc := mustFind(t, resources, "VolumeSnapshotClass", wantName)
+		dp, ok := nestedString(vsc, "deletionPolicy")
+		if !ok || dp != wantDP {
+			t.Errorf("VolumeSnapshotClass deletionPolicy: got %v, want %s", dp, wantDP)
+		}
+	})
+
+	t.Run("defaultStorageClass", func(t *testing.T) {
+		sc := mustFind(t, resources, "StorageClass", "ebs-csi-default-sc")
+		meta := nested(t, sc, "metadata")
+		ann := meta["annotations"].(obj)
+		if ann["storageclass.kubernetes.io/is-default-class"] != "true" {
+			t.Error("default StorageClass should have is-default-class=true annotation")
+		}
+	})
+
+	t.Run("nodeAllocatableUpdatePeriodSeconds", func(t *testing.T) {
+		wantVal, _ := nestedFloat(want, "nodeAllocatableUpdatePeriodSeconds")
+		csiDriver := mustFind(t, resources, "CSIDriver", "ebs.csi.aws.com")
+		val, ok := nestedFloat(csiDriver, "spec", "nodeAllocatableUpdatePeriodSeconds")
+		if !ok || val != wantVal {
+			t.Errorf("nodeAllocatableUpdatePeriodSeconds: got %v, want %v", val, wantVal)
+		}
+	})
+
+	// Log level tests. logLevelPath walks the YAML to the expected log level
+	// for that sidecar or plugin; keeping it as []string so the lookup stays
+	// in lockstep with the values file.
+	logLevelTests := []struct {
+		name         string
+		container    string
+		podType      string // "controller" or "node"
+		logLevelPath []string
+	}{
+		{"controllerLogLevel", "ebs-plugin", "controller", []string{"controller", "logLevel"}},
+		{"provisionerLogLevel", "csi-provisioner", "controller", []string{"sidecars", "provisioner", "logLevel"}},
+		{"attacherLogLevel", "csi-attacher", "controller", []string{"sidecars", "attacher", "logLevel"}},
+		{"snapshotterLogLevel", "csi-snapshotter", "controller", []string{"sidecars", "snapshotter", "logLevel"}},
+		{"resizerLogLevel", "csi-resizer", "controller", []string{"sidecars", "resizer", "logLevel"}},
+		{"nodeDriverRegistrarLogLevel", "node-driver-registrar", "node", []string{"sidecars", "nodeDriverRegistrar", "logLevel"}},
+		{"nodeLogLevel", "ebs-plugin", "node", []string{"node", "logLevel"}},
+	}
+	for _, tc := range logLevelTests {
+		t.Run(tc.name, func(t *testing.T) {
+			wantLvl, ok := nestedFloat(want, tc.logLevelPath...)
+			if !ok {
+				t.Fatalf("values file missing %v", tc.logLevelPath)
+			}
+			var ps obj
+			if tc.podType == "controller" {
+				ps = cPS
+			} else {
+				ps = nPS
+			}
+			c := findContainer(t, ps, tc.container)
+			want := fmt.Sprintf("%d", int(wantLvl))
+			if !hasArgAny(c, "-v="+want, "--v="+want) {
+				t.Errorf("%s should have -v=%s", tc.container, want)
+			}
+		})
+	}
+
+	// Leader election tests. Each row names the sidecar key under
+	// standard.yaml's sidecars map and asserts the corresponding flag.
+	leaderTests := []struct {
+		name      string
+		container string
+		valuesKey string
+	}{
+		{"provisionerLeaderElection", "csi-provisioner", "provisioner"},
+		{"attacherLeaderElection", "csi-attacher", "attacher"},
+		{"resizerLeaderElection", "csi-resizer", "resizer"},
+	}
+	for _, tc := range leaderTests {
+		t.Run(tc.name, func(t *testing.T) {
+			enabled := want["sidecars"].(obj)[tc.valuesKey].(obj)["leaderElection"].(obj)["enabled"]
+			c := findContainer(t, cPS, tc.container)
+			expected := fmt.Sprintf("--leader-election=%v", enabled)
+			if !hasArg(c, expected) {
+				t.Errorf("%s should have %s", tc.container, expected)
+			}
+		})
+	}
+
+	// Prometheus annotations
+	for _, svcName := range []string{"ebs-csi-controller", "ebs-csi-node"} {
+		t.Run("prometheusAnnotations/"+svcName, func(t *testing.T) {
+			svc := mustFind(t, resources, "Service", svcName)
+			meta := nested(t, svc, "metadata")
+			ann, ok := meta["annotations"].(obj)
+			if !ok {
+				t.Fatal("no annotations on service")
+			}
+			if ann["prometheus.io/scrape"] != "true" {
+				t.Error("service should have prometheus.io/scrape=true")
+			}
+		})
+	}
+}
+
+// assertServiceHasPort checks that a Service has a port with the given name and number.
+func assertServiceHasPort(t *testing.T, svc obj, name string, port int) {
+	t.Helper()
+	ports := nestedSlice(t, svc, "spec", "ports")
+	for _, p := range ports {
+		pm := p.(obj)
+		pNum, _ := pm["port"].(float64)
+		if pm["name"] == name && int(pNum) == port {
+			return
+		}
+	}
+	t.Errorf("service should have port %s/%d", name, port)
+}

--- a/tests/helm-template/testdata/debug.yaml
+++ b/tests/helm-template/testdata/debug.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+debugLogs: true
+controller:
+  sdkDebugLog: true

--- a/tests/helm-template/testdata/e2e-miscellaneous.yaml
+++ b/tests/helm-template/testdata/e2e-miscellaneous.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sidecars:
+  metadataLabeler:
+    enabled: true
+node:
+  metadataSources: metadata-labeler
+additionalDaemonSets:
+  extra:
+    volumeAttachLimit: 15

--- a/tests/helm-template/testdata/e2e-standard.yaml
+++ b/tests/helm-template/testdata/e2e-standard.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+controller:
+  extraCreateMetadata: true
+  k8sTagClusterId: e2e-param-test
+  extraVolumeTags:
+    TestKey: TestValue
+  defaultFsType: xfs

--- a/tests/helm-template/testdata/infra.yaml
+++ b/tests/helm-template/testdata/infra.yaml
@@ -1,0 +1,135 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nameOverride: custom-ebs-name
+image:
+  pullPolicy: Always
+customLabels:
+  custom-label: custom-value
+controller:
+  replicaCount: 3
+  priorityClassName: system-node-critical
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 256Mi
+  podAnnotations:
+    test-annotation: test-value
+  podLabels:
+    test-label: test-value
+  deploymentAnnotations:
+    deploy-annotation: deploy-value
+  revisionHistoryLimit: 5
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+  securityContext:
+    runAsNonRoot: true
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+  volumes:
+    - name: extra-volume
+      configMap:
+        name: kube-root-ca.crt
+  volumeMounts:
+    - name: extra-volume
+      mountPath: /extra
+  dnsConfig:
+    nameservers:
+      - "8.8.8.8"
+  initContainers:
+    - name: init-container
+      image: busybox
+      command: ["echo", "init"]
+  updateStrategy:
+    type: Recreate
+    rollingUpdate: null
+  tolerations:
+    - key: test-key
+      value: test-value
+      effect: NoSchedule
+      operator: Equal
+  env:
+    - name: TEST_ENV
+      value: test-value
+  additionalArgs:
+    - --warn-on-invalid-tag
+node:
+  priorityClassName: system-node-critical
+  resources:
+    requests:
+      cpu: 50m
+    limits:
+      memory: 128Mi
+  podAnnotations:
+    node-annotation: node-value
+  daemonSetAnnotations:
+    ds-annotation: ds-value
+  revisionHistoryLimit: 3
+  volumes:
+    - name: node-extra-volume
+      configMap:
+        name: kube-root-ca.crt
+  volumeMounts:
+    - name: node-extra-volume
+      mountPath: /node-extra
+  dnsConfig:
+    nameservers:
+      - "8.8.4.4"
+  initContainers:
+    - name: node-init-container
+      image: busybox
+      command: ["echo", "node-init"]
+  updateStrategy:
+    type: OnDelete
+  tolerateAllTaints: false
+  tolerations:
+    - key: node-key
+      value: node-value
+      operator: Equal
+  env:
+    - name: NODE_ENV
+      value: node-value
+  additionalArgs:
+    - --logtostderr
+sidecars:
+  snapshotter:
+    forceEnable: true
+    resources:
+      requests:
+        cpu: 15m
+  provisioner:
+    resources:
+      requests:
+        cpu: 20m
+    additionalArgs:
+      - --retry-interval-start=10s
+  attacher:
+    resources:
+      requests:
+        cpu: 15m
+  resizer:
+    resources:
+      requests:
+        cpu: 15m
+  nodeDriverRegistrar:
+    resources:
+      requests:
+        cpu: 10m
+  livenessProbe:
+    resources:
+      requests:
+        cpu: 5m

--- a/tests/helm-template/testdata/miscellaneous.yaml
+++ b/tests/helm-template/testdata/miscellaneous.yaml
@@ -1,0 +1,37 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+controller:
+  volumeModificationFeature:
+    enabled: true
+node:
+  volumeAttachLimit: 25
+  metadataSources: metadata-labeler
+sidecars:
+  provisioner:
+    additionalArgs:
+      - "--feature-gates=VolumeAttributesClass=true"
+  resizer:
+    additionalArgs:
+      - "--feature-gates=VolumeAttributesClass=true"
+  volumemodifier:
+    logLevel: 5
+    leaderElection:
+      enabled: false
+  metadataLabeler:
+    enabled: true
+    logLevel: 5
+additionalDaemonSets:
+  extra:
+    volumeAttachLimit: 15

--- a/tests/helm-template/testdata/node-component-only.yaml
+++ b/tests/helm-template/testdata/node-component-only.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nodeComponentOnly: true

--- a/tests/helm-template/testdata/standard.yaml
+++ b/tests/helm-template/testdata/standard.yaml
@@ -1,0 +1,68 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+controller:
+  extraCreateMetadata: true
+  k8sTagClusterId: e2e-param-test
+  extraVolumeTags:
+    TestKey: TestValue
+  enableMetrics: true
+  batching: true
+  defaultFsType: xfs
+  loggingFormat: json
+  logLevel: 5
+  userAgentExtra: e2e-test
+  enablePrometheusAnnotations: true
+  podDisruptionBudget:
+    enabled: true
+  sdkDebugLog: false
+node:
+  enableMetrics: true
+  loggingFormat: json
+  logLevel: 5
+  kubeletPath: /var/lib/kubelet
+  tolerateAllTaints: true
+  reservedVolumeAttachments: 2
+  hostNetwork: true
+  serviceAccount:
+    disableMutation: true
+  terminationGracePeriodSeconds: 60
+nodeAllocatableUpdatePeriodSeconds: 30
+defaultStorageClass:
+  enabled: true
+storageClasses:
+  - name: test-sc
+    parameters:
+      type: gp3
+volumeSnapshotClasses:
+  - name: test-vsc
+    deletionPolicy: Delete
+sidecars:
+  provisioner:
+    logLevel: 5
+    leaderElection:
+      enabled: true
+  attacher:
+    logLevel: 5
+    leaderElection:
+      enabled: true
+  snapshotter:
+    logLevel: 5
+    forceEnable: true
+  resizer:
+    logLevel: 5
+    leaderElection:
+      enabled: true
+  nodeDriverRegistrar:
+    logLevel: 5


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What is this PR about? / Why do we need it?

This PR adds individual tests for the various helm parameters that can be configured when deploying the driver. 

#### How was this change tested?

Tested manually by running:

```
mkdir -p /tmp/e2e-results && export REPORT_DIR=/tmp/e2e-results  && make e2e/parameters-all
```

Also ran in CI under the existing single-az testing grid. It will have it's own test grid after this merges but put under single-az for reviewers to see results and JUnit outputs.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
