### PR TITLE
Improve eksctl config and migrate to pod identities

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -67,6 +67,10 @@ IMAGE_ARCH=${IMAGE_ARCH:-amd64}
 DEPLOY_METHOD=${DEPLOY_METHOD:-"helm"}
 HELM_CT_TEST=${HELM_CT_TEST:-"false"}
 HELM_EXTRA_FLAGS=${HELM_EXTRA_FLAGS:-}
+# When using IRSA, eksctl creates the service account
+if [[ -n "${USE_IRSA:-}" ]]; then
+  HELM_EXTRA_FLAGS="${HELM_EXTRA_FLAGS} --set controller.serviceAccount.create=false"
+fi
 COLLECT_METRICS=${COLLECT_METRICS:-"false"}
 
 TEST_PATH=${TEST_PATH:-"./tests/e2e-kubernetes/..."}

--- a/hack/e2e/eksctl/cluster.yaml
+++ b/hack/e2e/eksctl/cluster.yaml
@@ -19,8 +19,11 @@ metadata:
   region: {{ .Env.REGION }}
   version: "{{ .Env.K8S_VERSION }}"
 availabilityZones: [{{ .Env.ZONES }}]
+autoModeConfig:
+  enabled: false
 iam:
   vpcResourceControllerPolicy: true
+{{- if env.Getenv "USE_IRSA" }}
   withOIDC: true
   serviceAccounts:
     - metadata:
@@ -28,35 +31,15 @@ iam:
         namespace: kube-system
       wellKnownPolicies:
         ebsCSIController: true
-      attachPolicy:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Action:
-              - ec2:CopyVolumes
-            Resource: "arn:aws:ec2:*:*:volume/vol-*"
-          - Effect: Allow
-            Action:
-              - ec2:CopyVolumes
-            Resource: "arn:aws:ec2:*:*:volume/*"
-            Condition:
-              StringLike:
-                "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
-          - Effect: Allow
-            Action:
-              - ec2:CopyVolumes
-            Resource: "arn:aws:ec2:*:*:volume/*"
-            Condition:
-              StringLike:
-                "aws:RequestTag/CSIVolumeName": "*"
-          - Effect: Allow
-            Action:
-              - ec2:CreateTags
-            Resource:
-              - "arn:aws:ec2:*:*:volume/*"
-            Condition:
-              StringEquals:
-                "ec2:CreateAction": "CopyVolumes"
+{{- else }}
+  podIdentityAssociations:
+    - namespace: kube-system
+      serviceAccountName: ebs-csi-controller-sa
+      wellKnownPolicies:
+        ebsCSIController: true
+addons:
+  - name: eks-pod-identity-agent
+{{- end }}
 managedNodeGroups:
   - name: ng-linux
     amiFamily: {{ .Env.AMI_FAMILY }}
@@ -78,6 +61,7 @@ managedNodeGroups:
     instanceTypes: [m5.2xlarge]
     ssh:
       allow: false
+      enableSsm: true
 {{- end }}
 nodeGroups:
 {{- if env.Getenv "OUTPOST_ARN" }}
@@ -93,6 +77,7 @@ nodeGroups:
     instanceType: {{ .Env.OUTPOST_INSTANCE_TYPE }}
     ssh:
       allow: false
+      enableSsm: true
     outpostARN: {{ .Env.OUTPOST_ARN }}
 {{- end }}
 {{- if and (eq .Env.WINDOWS "true") (env.Getenv "WINDOWS_AMI") }}
@@ -105,4 +90,5 @@ nodeGroups:
     instanceType: m5.2xlarge
     ssh:
       allow: false
+      enableSsm: true
 {{- end }}

--- a/hack/e2e/eksctl/values.yaml
+++ b/hack/e2e/eksctl/values.yaml
@@ -14,7 +14,5 @@
 
 controller:
   logLevel: 5
-  serviceAccount:
-    create: false # let eksctl create it
 node:
   logLevel: 5


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Supersedes #2862  and migrates most of its changes:
- Force disables auto mode always
- Removes no longer necessary extra policy
- Ensure SSM is enabled on all nodes to allow debugging
- (NEW in this PR): Change default `eksctl` setup to pod identities which should hopefully speed up cluster creation
  * IRSA is left in under the env variable `USE_IRSA` for situations where Pod Identities cannot be used

#### How was this change tested?

E2E tests + CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
