### PR TITLE
Rescan disks before resize operations on Windows

### DIFF
--- a/pkg/mounter/mount_windows.go
+++ b/pkg/mounter/mount_windows.go
@@ -21,9 +21,10 @@ package mounter
 import (
 	"errors"
 	"fmt"
+	"regexp"
+
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	"golang.org/x/sys/windows"
-	"regexp"
 
 	"k8s.io/klog/v2"
 	mountutils "k8s.io/mount-utils"
@@ -200,8 +201,15 @@ func (m *NodeMounter) PathExists(path string) (bool, error) {
 func (m *NodeMounter) Resize(devicePath, deviceMountPath string) (bool, error) {
 	switch proxyMounter := m.SafeFormatAndMount.Interface.(type) {
 	case *CSIProxyMounterV2:
+		// Refresh the host storage cache before resizing to ensure Windows has an updated view of disk geometry.
+		if err := proxyMounter.Rescan(); err != nil {
+			klog.ErrorS(err, "Rescan failed during Resize")
+		}
 		return proxyMounter.ResizeVolume(deviceMountPath)
 	case *CSIProxyMounter:
+		if err := proxyMounter.Rescan(); err != nil {
+			klog.ErrorS(err, "Rescan failed during Resize")
+		}
 		return proxyMounter.ResizeVolume(deviceMountPath)
 	default:
 		return false, ErrUnsupportedMounter
@@ -215,6 +223,9 @@ func (m *NodeMounter) NeedResize(devicePath, deviceMountPath string) (bool, erro
 
 	switch proxyMounter := m.SafeFormatAndMount.Interface.(type) {
 	case *CSIProxyMounterV2:
+		if err := proxyMounter.Rescan(); err != nil {
+			klog.ErrorS(err, "Rescan failed during NeedResize")
+		}
 		deviceSize, err = proxyMounter.GetDeviceSize(devicePath)
 		if err != nil {
 			return false, fmt.Errorf("failed to get device size: %w", err)
@@ -224,6 +235,9 @@ func (m *NodeMounter) NeedResize(devicePath, deviceMountPath string) (bool, erro
 			return false, fmt.Errorf("failed to get filesystem size: %w", err)
 		}
 	case *CSIProxyMounter:
+		if err := proxyMounter.Rescan(); err != nil {
+			klog.ErrorS(err, "Rescan failed during NeedResize")
+		}
 		deviceSize, err = proxyMounter.GetDeviceSize(devicePath)
 		if err != nil {
 			return false, fmt.Errorf("failed to get device size: %w", err)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Both CSI proxy mounters have had a `Rescan()` method in the interface since they were written, but it was never actually called anywhere. This wires it up before Resize operations on Windows so the host storage cache is refreshed (see https://learn.microsoft.com/en-us/powershell/module/storage/update-hoststoragecache) before we query disk sizes or extend a filesystem. Today, resize works without rescanning but this adds a safety margin against any edge case where the cache might be stale and its also a cheap call to make, so I consider it a defensive best practice.

Rescan errors are logged and not treated as fatal since the resize and size check operations that follow are what actually matter.

#### How was this change tested?

```
make update && make verify && make test
```

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Rescan disks before resize operations on Windows.
```
