### PR TITLE
Reduce memory requests and limits for node-driver-registrar and liveness-probe containers

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -233,9 +233,16 @@ spec:
               mountPath: C:\registration
             - name: probe-dir
               mountPath: C:\var\lib\kubelet\plugins\ebs.csi.aws.com
-          {{- with default .Values.node.resources .Values.sidecars.nodeDriverRegistrar.resources }}
+          {{- with .Values.sidecars.nodeDriverRegistrar.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 150Mi
+            limits:
+              memory: 150Mi
           {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
@@ -254,9 +261,16 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: C:\csi
-          {{- with default .Values.node.resources .Values.sidecars.livenessProbe.resources }}
+          {{- with .Values.sidecars.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 150Mi
+            limits:
+              memory: 150Mi
           {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
       {{- if .Values.imagePullSecrets }}

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -233,9 +233,16 @@ spec:
               mountPath: /registration
             - name: probe-dir
               mountPath: {{ printf "%s/plugins/ebs.csi.aws.com/" (trimSuffix "/" .Values.node.kubeletPath) }}
-          {{- with default .Values.node.resources .Values.sidecars.nodeDriverRegistrar.resources }}
+          {{- with .Values.sidecars.nodeDriverRegistrar.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 32Mi
           {{- end }}
           {{- with .Values.sidecars.nodeDriverRegistrar.securityContext }}
           securityContext:
@@ -257,9 +264,16 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
-          {{- with default .Values.node.resources .Values.sidecars.livenessProbe.resources }}
+          {{- with .Values.sidecars.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 32Mi
           {{- end }}
           {{- with .Values.sidecars.livenessProbe.securityContext }}
           securityContext:

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -635,9 +635,16 @@ spec:
               containerPort: 3305
               protocol: TCP
           {{- end }}
-          {{- with default .Values.controller.resources .Values.sidecars.livenessProbe.resources }}
+          {{- with .Values.sidecars.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 32Mi
           {{- end }}
           {{- with .Values.sidecars.livenessProbe.securityContext }}
           securityContext:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -279,11 +279,11 @@ spec:
             - name: socket-dir
               mountPath: /csi
           resources:
-            limits:
-              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: 32Mi
+            limits:
+              memory: 32Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -132,11 +132,11 @@ spec:
             - name: probe-dir
               mountPath: C:\var\lib\kubelet\plugins\ebs.csi.aws.com
           resources:
-            limits:
-              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: 150Mi
+            limits:
+              memory: 150Mi
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
           image: public.ecr.aws/csi-components/livenessprobe:v2.18.0-eksbuild.1
@@ -147,11 +147,11 @@ spec:
             - name: plugin-dir
               mountPath: C:\csi
           resources:
-            limits:
-              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: 150Mi
+            limits:
+              memory: 150Mi
           terminationMessagePolicy: FallbackToLogsOnError
       volumes:
         - name: kubelet-dir

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -135,11 +135,11 @@ spec:
             - name: probe-dir
               mountPath: /var/lib/kubelet/plugins/ebs.csi.aws.com/
           resources:
-            limits:
-              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: 32Mi
+            limits:
+              memory: 32Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -153,11 +153,11 @@ spec:
             - name: plugin-dir
               mountPath: /csi
           resources:
-            limits:
-              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 40Mi
+              memory: 32Mi
+            limits:
+              memory: 32Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR reduces the default memory requests and limits for the node-driver-registrar and liveness-probe sidecar containers from 256Mi/40Mi to 32Mi/32Mi. Unlike the ebs-plugin and other controller containers, these sidecars don't scale with volume operations, they're simple gRPC/HTTP servers that mostly sit idle after initial registration. 

The 256Mi limit is inherited from node.resources (the ebs-plugin's config), and was not chosen intentionally, which couples the sidecar limits to the ebs-plugin's limits and makes it impossible to set different defaults per OS. So i've also updated the chart to be able to set OS appropriate defaults, users can still configure via `sidecars.livenessProbe.resources` and `sidecars.nodeDriverRegistrar.resources`.

closes #2872

#### How was this change tested?

I benchmarked the actual memory usage on a kops cluster running volume lifecycle operations (concurrent volumes operations with several rounds) and recorded that peak memory usage never exceeded 10 Mi for these containers, so the new 32Mi request/limit default is safe, more appropriate, and provides a bit of headroom for future proofing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Reduced default memory for node-driver-registrar and liveness-probe sidecars from 256Mi/40Mi to 32Mi/32Mi on Linux and 150Mi/150Mi on Windows. Sidecar resource defaults are now independent of node.resources and controller.resources.
```
