### PR TITLE
Append -dev to non-release user agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,12 @@
 ## Variables/Functions
 
 VERSION?=v1.56.0
+RELEASE_BUILD?=false
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 BUILD_DATE?=$(shell date -u -Iseconds)
-LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
+LDFLAGS?="-X ${PKG}/pkg/driver.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.driverVersion=${VERSION} -X ${PKG}/pkg/cloud.releaseBuild=${RELEASE_BUILD} -X ${PKG}/pkg/driver.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/driver.buildDate=${BUILD_DATE} -s -w"
 
 OS?=$(shell go env GOHOSTOS)
 ARCH?=$(shell go env GOHOSTARCH)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,6 +19,7 @@ steps:
     env:
       - GIT_TAG=${_GIT_TAG}
       - PULL_BASE_REF=${_PULL_BASE_REF}
+      - RELEASE_BUILD=true
       - HOME=/root
 options:
   machineType: E2_HIGHCPU_32

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -206,6 +206,7 @@ var (
 
 // Set during build time via -ldflags.
 var driverVersion string
+var releaseBuild string
 
 // AWS error codes.
 const (
@@ -437,14 +438,15 @@ func NewCloud(region string, awsSdkDebugLog bool, userAgentExtra string, batchin
 	}
 
 	// Set the env var so that the session appends custom user agent string
+	userAgent := "aws-ebs-csi-driver-" + driverVersion
 	if userAgentExtra != "" {
-		if err := os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion+"-"+userAgentExtra); err != nil {
-			klog.ErrorS(err, "Failed to set AWS_EXECUTION_ENV")
-		}
-	} else {
-		if err := os.Setenv("AWS_EXECUTION_ENV", "aws-ebs-csi-driver-"+driverVersion); err != nil {
-			klog.ErrorS(err, "Failed to set AWS_EXECUTION_ENV")
-		}
+		userAgent += "-" + userAgentExtra
+	}
+	if releaseBuild != "true" {
+		userAgent += "-dev"
+	}
+	if err := os.Setenv("AWS_EXECUTION_ENV", userAgent); err != nil {
+		klog.ErrorS(err, "Failed to set AWS_EXECUTION_ENV")
 	}
 
 	ec2Options := func(o *ec2.Options) {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Append `-dev` to UA of all non-release containers (CI, local dev environments, etc), add build release containers with `RELEASE_BUILD=true` to disable that.

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
