### PR TITLE
Scope container image scanning to driver image only

### DIFF
--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -22,29 +22,17 @@ permissions:
   security-events: write # Update findings in security tab
 
 jobs:
-  build-matrix:
+  trivy-scan:
     runs-on: ubuntu-latest
-    outputs:
-      images: ${{ steps.set-matrix.outputs.result }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - id: set-matrix
-        uses: mikefarah/yq@v4
-        with:
-          # Dynamically build the matrix of images to scan
-          cmd: "yq '[{\"repository\": .image.repository, \"tag\": \"v'$(yq '.appVersion' charts/aws-ebs-csi-driver/Chart.yaml)'\"}] + (.sidecars | map(.image)) | map(.repository + \":\" + .tag) | . style=\"flow\"' charts/aws-ebs-csi-driver/values.yaml"
-  
-  trivy-scan:
-    needs: build-matrix
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image: ${{ fromJson(needs.build-matrix.outputs.images) }}
-    
-    steps:
+      - name: Get driver image tag
+        id: image
+        run: echo "tag=v$(yq '.appVersion' charts/aws-ebs-csi-driver/Chart.yaml)" >> "$GITHUB_OUTPUT"
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -60,21 +48,21 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
-          
+
       - name: Pull container image
-        run: docker pull ${{ matrix.image }}
+        run: docker pull public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:${{ steps.image.outputs.tag }}
 
       - name: Scan container image
         uses: aquasecurity/trivy-action@0.33.1
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:
-          image-ref: '${{ matrix.image }}'
+          image-ref: 'public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:${{ steps.image.outputs.tag }}'
           output: 'results.sarif'
           format: 'sarif'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
-      
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
         with:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

The trivy-containers workflow currently scans the driver image and all sidecar images, but those sidecars are built and published by [csi-components](https://github.com/aws/csi-components), which already runs its own hourly Trivy scan against them. So we're doing redundant work and duplicating findings in the Security tab.

This PR trims the workflow down to only scan the driver image, which is the one image this repo actually builds and owns. The build-matrix job and dynamic yq parsing are no longer needed since we're scanning a single image, so the whole thing gets a lot simpler.

`volume-modifier-for-k8s` is being onboarded to csi-components, so that'll be covered there too.

#### How was this change tested?

CI

```
make update && make verify
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE.
```
