### PR TITLE
security: Update trivy-action to use sha for v0.35.0

### DIFF
--- a/.github/workflows/trivy-containers.yaml
+++ b/.github/workflows/trivy-containers.yaml
@@ -53,7 +53,7 @@ jobs:
         run: docker pull public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:${{ steps.image.outputs.tag }}
 
       - name: Scan container image
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
         with:


### PR DESCRIPTION
## Description

This PR updates `aquasecurity/trivy-action` to address security vulnerabilities.

## Changes

- Updates from mutable reference (`@master`/`@main`/old tags) to SHA-pinned version
- Now using: `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)

## References

- Issue: https://github.com/aquasecurity/trivy/discussions/10425
- Release: https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0