### PR TITLE
Tag volumes and snapshots with cluster identity

### DIFF
--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -7,6 +7,7 @@ To help manage volumes in the aws account, CSI driver will automatically add tag
 | CSIVolumeSnapshotName  | volumeSnapshotContentName | CSIVolumeSnapshotName = snapcontent-69477690-803b-4d3e-a61a-03c7b2592a76 | add to all snapshots, for recording associated VolumeSnapshot id and checking if a given snapshot was already created                                    |
 | ebs.csi.aws.com/cluster| true                      | ebs.csi.aws.com/cluster = true                                      | add to all volumes and snapshots, for allowing users to use a policy to limit csi driver's permission to just the resources it manages.                      |
 | kubernetes.io/cluster/X| owned                     | kubernetes.io/cluster/aws-cluster-id-1 = owned                      | add to all volumes and snapshots if k8s-tag-cluster-id argument is set to X.|
+| ebs.csi.aws.com/cluster-name | cluster-name | ebs.csi.aws.com/cluster-name = my-cluster | add to all volumes and snapshots if k8s-tag-cluster-id argument is set, for cluster-scoped IAM policies.|
 | extra-key              | extra-value               | extra-key = extra-value                                             | add to all volumes and snapshots if extraTags argument is set|
 
 # StorageClass Tagging

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -181,6 +181,9 @@ const (
 	// the external provisioner sidecar is started with --extra-create-metadata=true and
 	// thus provides such metadata to the CSI driver.
 	PVNameTag = "kubernetes.io/created-for/pv/name"
+
+	// ClusterNameTagKey is the resource tag key for cluster-scoped IAM policies.
+	ClusterNameTagKey = "ebs.csi.aws.com/cluster-name"
 )
 
 // constants for default command line flag values.

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -285,6 +285,7 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		volumeTags[resourceLifecycleTag] = ResourceLifecycleOwned
 		volumeTags[NameTag] = d.options.KubernetesClusterID + "-dynamic-" + volName
 		volumeTags[KubernetesClusterTag] = d.options.KubernetesClusterID
+		volumeTags[ClusterNameTagKey] = d.options.KubernetesClusterID
 	}
 
 	maps.Copy(volumeTags, addTags)
@@ -930,6 +931,7 @@ func (d *ControllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		resourceLifecycleTag := ResourceLifecycleTagPrefix + d.options.KubernetesClusterID
 		snapshotTags[resourceLifecycleTag] = ResourceLifecycleOwned
 		snapshotTags[NameTag] = d.options.KubernetesClusterID + "-dynamic-" + snapshotName
+		snapshotTags[ClusterNameTagKey] = d.options.KubernetesClusterID
 	}
 	maps.Copy(snapshotTags, d.options.ExtraTags)
 

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -2440,6 +2440,7 @@ func TestCreateVolume(t *testing.T) {
 						expectedOwnerTag:             expectedOwnerTagValue,
 						expectedNameTag:              expectedNameTagValue,
 						expectedKubernetesClusterTag: expectedKubernetesClusterTagValue,
+						ClusterNameTagKey:            clusterID,
 					},
 				}
 
@@ -2760,6 +2761,7 @@ func TestCreateVolume(t *testing.T) {
 					ResourceLifecycleTagPrefix + clusterID: ResourceLifecycleOwned,
 					NameTag:                                userNameTag, // User tag overrides cluster tag
 					KubernetesClusterTag:                   clusterID,
+					ClusterNameTagKey:                      clusterID,
 				}
 
 				diskOptions := &cloud.DiskOptions{
@@ -3744,6 +3746,7 @@ func TestCreateSnapshot(t *testing.T) {
 						cloud.AwsEbsDriverTagKey: "true",
 						expectedOwnerTag:         expectedOwnerTagValue,
 						expectedNameTag:          expectedNameTagValue,
+						ClusterNameTagKey:        clusterID,
 					},
 				}
 				mockCtl := gomock.NewController(t)
@@ -4146,6 +4149,7 @@ func TestCreateSnapshot(t *testing.T) {
 						cloud.AwsEbsDriverTagKey:               isManagedByDriver,
 						NameTag:                                nameTagValue,
 						ResourceLifecycleTagPrefix + clusterID: ResourceLifecycleOwned,
+						ClusterNameTagKey:                      clusterID,
 					},
 				}
 

--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -30,6 +30,7 @@ var (
 		cloud.VolumeNameTagKey:           "",
 		cloud.AwsEbsDriverTagKey:         "",
 		cloud.SnapshotNameTagKey:         "",
+		ClusterNameTagKey:                "",
 		IopsPerGBKey:                     "",
 		AllowAutoIOPSIncreaseOnModifyKey: "",
 	}

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -67,6 +67,13 @@ func TestValidateExtraTags(t *testing.T) {
 			},
 			expErr: fmt.Errorf("tag key prefix '%s' is reserved", cloud.KubernetesTagKeyPrefix),
 		},
+		{
+			name: "invalid tag: reserved cluster name key",
+			tags: map[string]string{
+				ClusterNameTagKey: "my-cluster",
+			},
+			expErr: fmt.Errorf("tag key '%s' is reserved", ClusterNameTagKey),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tests/e2e/requires_aws_api.go
+++ b/tests/e2e/requires_aws_api.go
@@ -882,4 +882,57 @@ var _ = Describe("[ebs-csi-e2e] [single-az] [requires-aws-api] Dynamic Provision
 		}
 		test.Run(cs, ns)
 	})
+
+	It("should tag a volume with cluster identity when k8s-tag-cluster-id is set", func() {
+		testTag := generateTagName()
+		pods := []testsuites.PodDetails{
+			{
+				Cmd: testsuites.PodCmdWriteToVolume("/mnt/test-1"),
+				Volumes: []testsuites.VolumeDetails{
+					{
+						CreateVolumeParameters: map[string]string{
+							ebscsidriver.VolumeTypeKey: awscloud.VolumeTypeGP3,
+							ebscsidriver.FSTypeKey:     ebscsidriver.FSTypeExt4,
+							ebscsidriver.TagKeyPrefix:  fmt.Sprintf("%s=%s", testTag, testTagValue),
+						},
+						ClaimSize:   driver.MinimumSizeForVolumeType(awscloud.VolumeTypeGP3),
+						VolumeMount: testsuites.DefaultGeneratedVolumeMount,
+					},
+				},
+			},
+		}
+		test := testsuites.DynamicallyProvisionedCmdVolumeTest{
+			CSIDriver: ebsDriver,
+			Pods:      pods,
+			ValidateFunc: func() {
+				result, err := ec2Client.DescribeVolumes(context.Background(), &ec2.DescribeVolumesInput{
+					Filters: []types.Filter{
+						{
+							Name:   aws.String("tag:" + testTag),
+							Values: []string{testTagValue},
+						},
+					},
+				})
+				if err != nil {
+					Fail(fmt.Sprintf("failed to describe volume: %v", err))
+				}
+
+				if len(result.Volumes) != 1 {
+					Fail(fmt.Sprintf("expected 1 volume, got %d", len(result.Volumes)))
+				}
+
+				found := false
+				for _, tag := range result.Volumes[0].Tags {
+					if aws.ToString(tag.Key) == ebscsidriver.ClusterNameTagKey && aws.ToString(tag.Value) != "" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					Fail(fmt.Sprintf("expected volume to have non-empty %s tag", ebscsidriver.ClusterNameTagKey))
+				}
+			},
+		}
+		test.Run(cs, ns)
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

When --k8s-tag-cluster-id is set, the driver now also writes an `ebs.csi.aws.com/cluster-name` tag on volumes and snapshots, enabling cluster-scoped IAM policies.

#### How was this change tested?

e2e test / unit test

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
When --k8s-tag-cluster-id is set, tag volumes and snapshots with `ebs.csi.aws.com/cluster-name` to support cluster-scoped IAM policies.
```
