### PR TITLE
Append driver mode to user agent string for metadata labeler container

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -503,6 +503,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - metadataLabeler
+            {{- with .Values.controller.userAgentExtra }}
+            - --user-agent-extra={{ . }}
+            {{- end }}
             - --v={{ .Values.sidecars.metadataLabeler.logLevel }}
             {{- range .Values.sidecars.metadataLabeler.additionalArgs }}
             - {{ . }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,10 +60,10 @@ func main() {
 
 	var (
 		metadataRequiredModes = map[string]struct{}{
-			string(driver.ControllerMode): {},
-			string(driver.NodeMode):       {},
-			string(driver.AllMode):        {},
-			driver.MetadataLabelerMode:    {},
+			string(driver.ControllerMode):      {},
+			string(driver.NodeMode):            {},
+			string(driver.AllMode):             {},
+			string(driver.MetadataLabelerMode): {},
 		}
 	)
 
@@ -192,7 +192,15 @@ func main() {
 				klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 			}
 		}
-		cloud = cloudPkg.NewCloud(region, options.AwsSdkDebugLog, options.UserAgentExtra, options.Batching, options.DeprecatedMetrics)
+		userAgentExtra := options.UserAgentExtra
+		if options.Mode == driver.MetadataLabelerMode {
+			if userAgentExtra != "" {
+				userAgentExtra += "-" + string(driver.MetadataLabelerMode)
+			} else {
+				userAgentExtra = string(driver.MetadataLabelerMode)
+			}
+		}
+		cloud = cloudPkg.NewCloud(region, options.AwsSdkDebugLog, userAgentExtra, options.Batching, options.DeprecatedMetrics)
 	}
 
 	k8sClient, err = cfg.K8sAPIClient()
@@ -214,7 +222,7 @@ func main() {
 		}
 		klog.FlushAndExit(klog.ExitFlushTimeout, 0)
 	case string(driver.ControllerMode), string(driver.NodeMode), string(driver.AllMode):
-	case driver.MetadataLabelerMode:
+	case string(driver.MetadataLabelerMode):
 		err := metadata.ContinuousUpdateLabelsLeaderElection(k8sClient, cloud, metadata.ControllerMetadataLabelerInterval)
 		if err != nil {
 			klog.ErrorS(err, "failed to patch volume/ENI count on node labels")

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -45,7 +45,7 @@ const (
 	AllMode Mode = "all"
 
 	// MetadataLabelerMode is the mode that starts the metadata labeler.
-	MetadataLabelerMode = "metadataLabeler"
+	MetadataLabelerMode Mode = "metadataLabeler"
 )
 
 const (
@@ -108,6 +108,8 @@ func NewDriver(c cloud.Cloud, o *Options, m mounter.Mounter, md metadata.Metadat
 	case AllMode:
 		driver.controller = NewControllerService(c, o)
 		driver.node = NewNodeService(o, md, m, k)
+	case MetadataLabelerMode:
+		return nil, fmt.Errorf("mode %s is not handled by the driver, it is handled separately in main", o.Mode)
 	default:
 		return nil, fmt.Errorf("unknown mode: %s", o.Mode)
 	}
@@ -156,6 +158,8 @@ func (d *Driver) Run() error {
 		csi.RegisterControllerServer(d.srv, d.controller)
 		csi.RegisterNodeServer(d.srv, d.node)
 		rpc.RegisterModifyServer(d.srv, d.controller)
+	case MetadataLabelerMode:
+		return fmt.Errorf("mode %s is not handled by the driver, it is handled separately in main", d.options.Mode)
 	default:
 		return fmt.Errorf("unknown mode: %s", d.options.Mode)
 	}

--- a/pkg/driver/options.go
+++ b/pkg/driver/options.go
@@ -115,14 +115,18 @@ func (o *Options) AddFlags(f *flag.FlagSet) {
 	f.BoolVar(&o.EnableOtelTracing, "enable-otel-tracing", false, "To enable opentelemetry tracing for the driver. The tracing is disabled by default. Configure the exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT and other env variables, see https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration.")
 	f.StringSliceVar(&o.MetadataSources, "metadata-sources", metadata.DefaultMetadataSources, "Dictates which sources are used to retrieve instance metadata. The driver will attempt to rely on each source in order until one succeeds. Valid options include 'imds', 'kubernetes', and (ALPHA) 'metadata-labeler'.")
 
+	// AWS SDK options, shared by all modes that create a cloud client
+	if o.Mode == AllMode || o.Mode == ControllerMode || o.Mode == MetadataLabelerMode {
+		f.StringVar(&o.UserAgentExtra, "user-agent-extra", "", "Extra string appended to user agent.")
+		f.BoolVar(&o.AwsSdkDebugLog, "aws-sdk-debug-log", false, "To enable the aws sdk debug log level (default to false).")
+	}
+
 	// Controller options
 	if o.Mode == AllMode || o.Mode == ControllerMode {
 		f.Var(cliflag.NewMapStringString(&o.ExtraTags), "extra-tags", "Extra tags to attach to each dynamically provisioned resource. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 		f.Var(cliflag.NewMapStringString(&o.ExtraVolumeTags), "extra-volume-tags", "DEPRECATED: Please use --extra-tags instead. Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 		f.StringVar(&o.KubernetesClusterID, "k8s-tag-cluster-id", "", "ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).")
-		f.BoolVar(&o.AwsSdkDebugLog, "aws-sdk-debug-log", false, "To enable the aws sdk debug log level (default to false).")
 		f.BoolVar(&o.WarnOnInvalidTag, "warn-on-invalid-tag", false, "To warn on invalid tags, instead of returning an error")
-		f.StringVar(&o.UserAgentExtra, "user-agent-extra", "", "Extra string appended to user agent.")
 		f.BoolVar(&o.Batching, "batching", false, "To enable batching of API calls. This is especially helpful for improving performance in workloads that are sensitive to EC2 rate limits.")
 		f.DurationVar(&o.ModifyVolumeRequestHandlerTimeout, "modify-volume-request-handler-timeout", DefaultModifyVolumeRequestHandlerTimeout, "Timeout for the window in which volume modification calls must be received in order for them to coalesce into a single volume modification call to AWS. This must be lower than the csi-resizer and volumemodifier timeouts")
 		f.BoolVar(&o.DeprecatedMetrics, "deprecated-metrics", false, "DEPRECATED: To enable deprecated metrics. This parameter is only for backward compatibility and may be removed in a future release.")

--- a/pkg/driver/options_test.go
+++ b/pkg/driver/options_test.go
@@ -129,6 +129,45 @@ func TestAddFlags(t *testing.T) {
 	}
 }
 
+func TestAddFlagsMetadataLabelerMode(t *testing.T) {
+	o := &Options{}
+	o.Mode = MetadataLabelerMode
+
+	f := flag.NewFlagSet("test", flag.ExitOnError)
+	o.AddFlags(f)
+
+	// AWS SDK flags should be registered for metadata labeler mode
+	if err := f.Set("user-agent-extra", "test-agent"); err != nil {
+		t.Errorf("error setting user-agent-extra: %v", err)
+	}
+	if o.UserAgentExtra != "test-agent" {
+		t.Errorf("unexpected UserAgentExtra: got %s, want test-agent", o.UserAgentExtra)
+	}
+
+	if err := f.Set("aws-sdk-debug-log", "true"); err != nil {
+		t.Errorf("error setting aws-sdk-debug-log: %v", err)
+	}
+	if !o.AwsSdkDebugLog {
+		t.Error("unexpected AwsSdkDebugLog: got false, want true")
+	}
+
+	// Controller-only flags should NOT be registered for metadata labeler mode
+	controllerOnlyFlags := []string{"extra-tags", "k8s-tag-cluster-id", "batching", "modify-volume-request-handler-timeout"}
+	for _, name := range controllerOnlyFlags {
+		if fl := f.Lookup(name); fl != nil {
+			t.Errorf("flag --%s should not be registered in MetadataLabelerMode", name)
+		}
+	}
+
+	// Node-only flags should NOT be registered for metadata labeler mode
+	nodeOnlyFlags := []string{"volume-attach-limit", "reserved-volume-attachments"}
+	for _, name := range nodeOnlyFlags {
+		if fl := f.Lookup(name); fl != nil {
+			t.Errorf("flag --%s should not be registered in MetadataLabelerMode", name)
+		}
+	}
+}
+
 func TestValidateAttachmentLimits(t *testing.T) {
 	tests := []struct {
 		name                string


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup


#### What is this PR about? / Why do we need it?

The metadata labeler sidecar makes EC2 API calls via its own cloud client, but its user agent string is identical to the controller's. This appends the driver mode (metadataLabeler) to the user agent so EC2 API calls from the sidecar are
distinguishable.

This PR also refactors `--user-agent-extra` and `--aws-sdk-debug-log` CLI options into a shared flag block for all modes that create a cloud client, and types `MetadataLabelerMode` for consistency with the other mode constants.

#### How was this change tested?

Manually and unit testing:

```
make cluster/create

make cluster/image

HELM_EXTRA_FLAGS="--set=sidecars.metadataLabeler.enabled=true,node.metadataSources='metadata-labeler',sidecars.metadataLabeler.additionalArgs[0]='--aws-sdk-debug-log=true'" \
make cluster/install

kubectl logs ebs-csi-controller-b89cc4f4d-9z26r -n kube-system -c metadata-labeler | grep "User-Agent"
User-Agent: aws-sdk-go-v2/1.41.4 ua/2.1 os/linux lang/go#1.26.1 md/GOOS#linux md/GOARCH#amd64 exec-env/aws-ebs-csi-driver-v1.57.1-helm-metadataLabeler api/ec2#1.296.0 m/z
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Append driver mode to user agent string for metadata labeler container.
```
