### PR TITLE
Succeed CreateDisk (and thus CreateVolume CSI RPC) for in-use volumes

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -2382,11 +2382,9 @@ func (c *cloud) waitForVolume(ctx context.Context, volumeID string) (*types.Volu
 		if err != nil {
 			return true, err
 		}
-		if vol.State != "" {
-			if vol.State == types.VolumeStateAvailable {
-				volume = vol
-				return true, nil
-			}
+		if vol.State == types.VolumeStateAvailable || vol.State == types.VolumeStateInUse {
+			volume = vol
+			return true, nil
 		}
 		return false, nil
 	})

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -855,6 +855,22 @@ func TestCreateDisk(t *testing.T) {
 			expErr: nil,
 		},
 		{
+			name:       "success: volume in-use state",
+			volumeName: "vol-test-name",
+			volState:   "in-use",
+			diskOptions: &DiskOptions{
+				CapacityBytes: util.GiBToBytes(1),
+				Tags:          map[string]string{VolumeNameTagKey: "vol-test", AwsEbsDriverTagKey: "true"},
+			},
+			expCreateVolumeInput: &ec2.CreateVolumeInput{},
+			expDisk: &Disk{
+				VolumeID:         "vol-test",
+				CapacityGiB:      1,
+				AvailabilityZone: defaultZone,
+			},
+			expErr: nil,
+		},
+		{
 			name:       "success: normal clone",
 			volumeName: "vol-test-name",
 			diskOptions: &DiskOptions{


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

There are some cases where the CO will re-call `CreateVolume` for volumes already attached (or in the process of being attached). Because CSI RPCs should be idempotent, we should correctly treat those volumes as created and return their volume ID.

However, our existing `waitForVolume` only looks for `available` state, but attached volumes will have an `in-use` state. Because `in-use` is a similar state to `available` that represents a volume that has succeeded creation, add that to the list of allowed states in `waitForVolume`.

None of the other states make sense to add, because they either indicate a volume is deleting/deleted, or too early in the create process it can still asynchronously fail to create.

#### How was this change tested?

Added unit test

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Handle duplicate CreateVolume RPCs for in-use volumes
```
