### PR TITLE
test(e2e): Allow alternative helm charts in E2E test suite

### DIFF
--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -65,11 +65,21 @@ IMAGE_TAG=${IMAGE_TAG:-$(md5sum <<<"${CLUSTER_NAME}.${CLUSTER_TYPE}" | awk '{ pr
 IMAGE_ARCH=${IMAGE_ARCH:-amd64}
 
 DEPLOY_METHOD=${DEPLOY_METHOD:-"helm"}
+HELM_CHART_REPOSITORY=${HELM_CHART_REPOSITORY:-"${BASE_DIR}/../../charts/aws-ebs-csi-driver"}
+HELM_CHART_TAG=${HELM_CHART_TAG:-}
+REGISTRY_SERVER=${REGISTRY_SERVER:-}
+REGISTRY_USERNAME=${REGISTRY_USERNAME:-}
+REGISTRY_PASSWORD=${REGISTRY_PASSWORD:-}
+IMAGE_PULL_SECRET_NAME=${IMAGE_PULL_SECRET_NAME:-"registry-pull-secret"}
 HELM_CT_TEST=${HELM_CT_TEST:-"false"}
 HELM_EXTRA_FLAGS=${HELM_EXTRA_FLAGS:-}
 # When using IRSA, eksctl creates the service account
 if [[ -n "${USE_IRSA:-}" ]]; then
-  HELM_EXTRA_FLAGS="${HELM_EXTRA_FLAGS} --set controller.serviceAccount.create=false"
+  HELM_EXTRA_FLAGS="${HELM_EXTRA_FLAGS:+${HELM_EXTRA_FLAGS} }--set=controller.serviceAccount.create=false"
+fi
+# When registry credentials are provided, configure the image pull secret for Helm
+if [ -n "${REGISTRY_SERVER:-}" ] && [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
+  HELM_EXTRA_FLAGS="${HELM_EXTRA_FLAGS:+${HELM_EXTRA_FLAGS} }--set=imagePullSecrets[0]=${IMAGE_PULL_SECRET_NAME}"
 fi
 COLLECT_METRICS=${COLLECT_METRICS:-"false"}
 

--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -55,9 +55,9 @@ function install_driver() {
       HELM_ARGS+=(--set image.repository="${IMAGE_NAME}")
       HELM_ARGS+=(--set image.tag="${IMAGE_TAG}")
     fi
-    eval "EXPANDED_HELM_EXTRA_FLAGS=$HELM_EXTRA_FLAGS"
-    if [[ -n "$EXPANDED_HELM_EXTRA_FLAGS" ]]; then
-      HELM_ARGS+=("${EXPANDED_HELM_EXTRA_FLAGS}")
+    eval "EXPANDED_HELM_EXTRA_FLAGS=(${HELM_EXTRA_FLAGS})"
+    if [[ -n "${EXPANDED_HELM_EXTRA_FLAGS[*]}" ]]; then
+      HELM_ARGS+=("${EXPANDED_HELM_EXTRA_FLAGS[@]}")
     fi
     set -x
     "${BIN}/helm" "${HELM_ARGS[@]}"

--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -24,6 +24,10 @@ function loudecho() {
 
 function install_driver() {
   if [ -n "${REGISTRY_SERVER:-}" ] && [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
+    loudecho "Logging into OCI registry ${REGISTRY_SERVER}"
+    echo "${REGISTRY_PASSWORD}" | "${BIN}/helm" registry login "${REGISTRY_SERVER}" \
+      --username "${REGISTRY_USERNAME}" --password-stdin
+
     loudecho "Creating image pull secret ${IMAGE_PULL_SECRET_NAME} in kube-system"
     kubectl create secret docker-registry "${IMAGE_PULL_SECRET_NAME}" \
       --docker-server="${REGISTRY_SERVER}" \
@@ -75,5 +79,13 @@ function uninstall_driver() {
     ${BIN}/helm uninstall "aws-ebs-csi-driver" --namespace kube-system --kubeconfig "${KUBECONFIG}"
   elif [[ ${DEPLOY_METHOD} == "kustomize" ]]; then
     kubectl --kubeconfig "${KUBECONFIG}" delete -k "${BASE_DIR}/../../deploy/kubernetes/overlays/stable"
+  fi
+
+  if [ -n "${REGISTRY_SERVER:-}" ]; then
+    loudecho "Removing imagePullSecret ${IMAGE_PULL_SECRET_NAME}"
+    kubectl delete secret "${IMAGE_PULL_SECRET_NAME}" \
+      --namespace kube-system \
+      --kubeconfig "${KUBECONFIG}" \
+      --ignore-not-found
   fi
 }

--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -23,9 +23,20 @@ function loudecho() {
 }
 
 function install_driver() {
+  if [ -n "${REGISTRY_SERVER:-}" ] && [ -n "${REGISTRY_USERNAME:-}" ] && [ -n "${REGISTRY_PASSWORD:-}" ]; then
+    loudecho "Creating image pull secret ${IMAGE_PULL_SECRET_NAME} in kube-system"
+    kubectl create secret docker-registry "${IMAGE_PULL_SECRET_NAME}" \
+      --docker-server="${REGISTRY_SERVER}" \
+      --docker-username="${REGISTRY_USERNAME}" \
+      --docker-password="${REGISTRY_PASSWORD}" \
+      --namespace kube-system \
+      --kubeconfig "${KUBECONFIG}" \
+      --dry-run=client -o yaml | kubectl apply --kubeconfig "${KUBECONFIG}" -f -
+  fi
+
   if [[ ${DEPLOY_METHOD} == "helm" ]]; then
     HELM_ARGS=(upgrade --install aws-ebs-csi-driver
-      "${BASE_DIR}/../../charts/aws-ebs-csi-driver"
+      "${HELM_CHART_REPOSITORY}"
       --namespace kube-system
       --set node.enableWindows="${WINDOWS}"
       --set node.windowsHostProcess="${WINDOWS_HOSTPROCESS}"
@@ -34,6 +45,9 @@ function install_driver() {
       --timeout 10m0s
       --wait
       --kubeconfig "${KUBECONFIG}")
+    if [ -n "${HELM_CHART_TAG:-}" ]; then
+      HELM_ARGS+=(--version "${HELM_CHART_TAG}")
+    fi
     if [ -n "${HELM_VALUES_FILE:-}" ]; then
       HELM_ARGS+=(-f "${HELM_VALUES_FILE}")
     fi


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?
The current E2E test suite is hardcoded to use the chart local to the repository. As part of testing an alternatively packaged, remote Helm chart the suite has been updated to allow specifying an arbitrary chart location and registry credentials. The default behavior remains unchanged.

#### How was this change tested?
The change was tested by running the E2E test suite on kops both with and without the new chart and registry credential variables.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
