### PR TITLE
Release v1.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+# v1.58.0
+
+## Changes by Kind
+
+### Feature
+
+- When --k8s-tag-cluster-id is set, tag volumes and snapshots with `ebs.csi.aws.com/cluster-name` to support cluster-scoped IAM policies. ([#2899](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2899), [@torredil](https://github.com/torredil))
+
+### Bug or Regression
+
+- Handle duplicate CreateVolume RPCs for in-use volumes ([#2908](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2908), [@ConnorJC3](https://github.com/ConnorJC3))
+
+### Other (Cleanup or Flake)
+
+- Append driver mode to user agent string for metadata labeler container. ([#2907](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2907), [@torredil](https://github.com/torredil))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp: [v1.30.0 → v1.31.0](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/compare/detectors/gcp/v1.30.0...detectors/gcp/v1.31.0)
+- github.com/aws/aws-sdk-go-v2/config: [v1.32.12 → v1.32.13](https://github.com/aws/aws-sdk-go-v2/compare/config/v1.32.12...config/v1.32.13)
+- github.com/aws/aws-sdk-go-v2/credentials: [v1.19.12 → v1.19.13](https://github.com/aws/aws-sdk-go-v2/compare/credentials/v1.19.12...credentials/v1.19.13)
+- github.com/aws/aws-sdk-go-v2/feature/ec2/imds: [v1.18.20 → v1.18.21](https://github.com/aws/aws-sdk-go-v2/compare/feature/ec2/imds/v1.18.20...feature/ec2/imds/v1.18.21)
+- github.com/aws/aws-sdk-go-v2/internal/configsources: [v1.4.20 → v1.4.21](https://github.com/aws/aws-sdk-go-v2/compare/internal/configsources/v1.4.20...internal/configsources/v1.4.21)
+- github.com/aws/aws-sdk-go-v2/internal/endpoints/v2: [v2.7.20 → v2.7.21](https://github.com/aws/aws-sdk-go-v2/compare/internal/endpoints/v2/v2.7.20...internal/endpoints/v2/v2.7.21)
+- github.com/aws/aws-sdk-go-v2/service/ec2: [v1.296.0 → v1.296.2](https://github.com/aws/aws-sdk-go-v2/compare/service/ec2/v1.296.0...service/ec2/v1.296.2)
+- github.com/aws/aws-sdk-go-v2/service/internal/presigned-url: [v1.13.20 → v1.13.21](https://github.com/aws/aws-sdk-go-v2/compare/service/internal/presigned-url/v1.13.20...service/internal/presigned-url/v1.13.21)
+- github.com/aws/aws-sdk-go-v2/service/sagemaker: [v1.236.1 → v1.238.0](https://github.com/aws/aws-sdk-go-v2/compare/service/sagemaker/v1.236.1...service/sagemaker/v1.238.0)
+- github.com/aws/aws-sdk-go-v2/service/signin: [v1.0.8 → v1.0.9](https://github.com/aws/aws-sdk-go-v2/compare/service/signin/v1.0.8...service/signin/v1.0.9)
+- github.com/aws/aws-sdk-go-v2/service/sso: [v1.30.13 → v1.30.14](https://github.com/aws/aws-sdk-go-v2/compare/service/sso/v1.30.13...service/sso/v1.30.14)
+- github.com/aws/aws-sdk-go-v2/service/ssooidc: [v1.35.17 → v1.35.18](https://github.com/aws/aws-sdk-go-v2/compare/service/ssooidc/v1.35.17...service/ssooidc/v1.35.18)
+- github.com/aws/aws-sdk-go-v2/service/sts: [v1.41.9 → v1.41.10](https://github.com/aws/aws-sdk-go-v2/compare/service/sts/v1.41.9...service/sts/v1.41.10)
+- github.com/aws/aws-sdk-go-v2: [v1.41.4 → v1.41.5](https://github.com/aws/aws-sdk-go-v2/compare/v1.41.4...v1.41.5)
+- github.com/fxamacker/cbor/v2: [v2.9.0 → v2.9.1](https://github.com/fxamacker/cbor/compare/v2.9.0...v2.9.1)
+- gonum.org/v1/gonum: v0.16.0 → v0.17.0
+- google.golang.org/genproto/googleapis/api: d00831a → 9d38bb4
+- google.golang.org/genproto/googleapis/rpc: d00831a → 9d38bb4
+- google.golang.org/grpc: v1.79.3 → v1.80.0
+- k8s.io/kube-openapi: 5883c5e → 16be699
+
+### Removed
+_Nothing has changed._
 
 # v1.57.1
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 
 ## Variables/Functions
 
-VERSION?=v1.57.1
+VERSION?=v1.58.0
 
 PKG=github.com/kubernetes-sigs/aws-ebs-csi-driver
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 
 | Driver Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Image | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver) Image |
 |----------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| v1.58.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.58.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.58.0                      |
 | v1.57.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.57.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.57.1                      |
-| v1.56.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.56.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.56.0                      |
 
 ## Releases
 

--- a/charts/aws-ebs-csi-driver/CHANGELOG.md
+++ b/charts/aws-ebs-csi-driver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Helm chart
 
+## 2.58.0
+
+Bumped driver to `v1.58.0`
+
 ## 2.57.0
 
 ### Security

--- a/charts/aws-ebs-csi-driver/Chart.yaml
+++ b/charts/aws-ebs-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.57.1
+appVersion: 1.58.0
 name: aws-ebs-csi-driver
 description: A Helm chart for AWS EBS CSI Driver
-version: 2.57.1
+version: 2.58.0
 kubeVersion: ">=1.17.0-0"
 home: https://github.com/kubernetes-sigs/aws-ebs-csi-driver
 sources:

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -64,7 +64,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.57.1
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.58.0
           imagePullPolicy: IfNotPresent
           args:
             - controller

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -42,7 +42,7 @@ spec:
         - operator: Exists
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.57.1
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.58.0
           imagePullPolicy: IfNotPresent
           args:
             - node

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -48,7 +48,7 @@ spec:
         runAsUser: 0
       containers:
         - name: ebs-plugin
-          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.57.1
+          image: public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.58.0
           imagePullPolicy: IfNotPresent
           args:
             - node

--- a/docs/install.md
+++ b/docs/install.md
@@ -142,7 +142,7 @@ You may deploy the EBS CSI driver via Kustomize, Helm, or as an [Amazon EKS mana
 
 #### Kustomize
 ```sh
-kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.57"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.58"
 ```
 
 *Note: Using the master branch to deploy the driver is not supported as the master branch may contain upcoming features incompatible with the currently released stable version of the driver.*


### PR DESCRIPTION
Releasing v1.58.0 of AWS EBS CSI Driver. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
