### PR TITLE
Set user-agent-extra to 'dev' when installed via Makefile

### DIFF
--- a/hack/e2e/util.sh
+++ b/hack/e2e/util.sh
@@ -31,6 +31,7 @@ function install_driver() {
       --set node.windowsHostProcess="${WINDOWS_HOSTPROCESS}"
       --set controller.k8sTagClusterId="${CLUSTER_NAME}"
       --set image.pullPolicy="Always"
+      --set controller.userAgentExtra="dev"
       --timeout 10m0s
       --wait
       --kubeconfig "${KUBECONFIG}")


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Set user-agent-extra to `"dev"` when installed via the Makefile

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
