### PR TITLE
Pass volume limit from DescribeInstanceTypes via metadata-labeler

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -6,6 +6,7 @@
       "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -32,6 +32,7 @@ spec:
           "Action": [
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeInstances",
+            "ec2:DescribeInstanceTypes",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",
             "ec2:DescribeVolumes",

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -2309,6 +2309,51 @@ func (c *cloud) getInstancesPatchingBatch(ctx context.Context, nodeIDs []string)
 	return instances, nil
 }
 
+// GetInstanceTypesInfo returns volume attachment info for the given instance types via DescribeInstanceTypes.
+func (c *cloud) GetInstanceTypesInfo(ctx context.Context, instanceTypes []string) (map[string]InstanceTypeInfo, error) {
+	result := make(map[string]InstanceTypeInfo, len(instanceTypes))
+
+	typeNames := make([]types.InstanceType, len(instanceTypes))
+	for i, t := range instanceTypes {
+		typeNames[i] = types.InstanceType(t)
+	}
+
+	// DescribeInstanceTypes supports up to 100 instance types per call
+	const batchSize = 100
+	for i := 0; i < len(typeNames); i += batchSize {
+		end := min(i+batchSize, len(typeNames))
+		batch := typeNames[i:end]
+
+		var nextToken *string
+		for {
+			resp, err := c.ec2.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{
+				InstanceTypes: batch,
+				NextToken:     nextToken,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error calling DescribeInstanceTypes: %w", err)
+			}
+
+			for _, it := range resp.InstanceTypes {
+				if it.EbsInfo == nil || it.EbsInfo.MaximumEbsAttachments == nil {
+					continue
+				}
+				result[string(it.InstanceType)] = InstanceTypeInfo{
+					MaxAttachments: int(*it.EbsInfo.MaximumEbsAttachments),
+					AttachmentType: string(it.EbsInfo.AttachmentLimitType),
+				}
+			}
+
+			if resp.NextToken == nil {
+				break
+			}
+			nextToken = resp.NextToken
+		}
+	}
+
+	return result, nil
+}
+
 func describeSnapshots(ctx context.Context, svc util.EC2API, request *ec2.DescribeSnapshotsInput) ([]types.Snapshot, error) {
 	var snapshots []types.Snapshot
 	var nextToken *string

--- a/pkg/cloud/interface.go
+++ b/pkg/cloud/interface.go
@@ -42,5 +42,12 @@ type Cloud interface {
 	AvailabilityZones(ctx context.Context) (map[string]struct{}, error)
 	DryRun(ctx context.Context) error
 	GetInstancesPatching(ctx context.Context, nodeIDs []string) ([]*types.Instance, error)
+	GetInstanceTypesInfo(ctx context.Context, instanceTypes []string) (map[string]InstanceTypeInfo, error)
 	LockSnapshot(ctx context.Context, lockOptions *SnapshotLockOptions) (err error)
+}
+
+// InstanceTypeInfo contains volume attachment information for an instance type.
+type InstanceTypeInfo struct {
+	MaxAttachments int
+	AttachmentType string
 }

--- a/pkg/cloud/limits/volume_limits.go
+++ b/pkg/cloud/limits/volume_limits.go
@@ -45,6 +45,13 @@ var dedicatedInstances = map[string]struct{}{
 	"m8gn.metal-24xl": {},
 }
 
+// IsDedicatedOverride returns true if the instance type is known to have an incorrect
+// attachment type from the API and should be treated as dedicated.
+func IsDedicatedOverride(instanceType string) bool {
+	_, ok := dedicatedInstances[instanceType]
+	return ok
+}
+
 // GetVolumeLimits returns the volume limit and attachment type for a given instance type.
 // Returns (limit, attachmentType) where limit is the maximum number of volumes
 // and attachmentType is either "shared" or "dedicated".

--- a/pkg/cloud/metadata/interface.go
+++ b/pkg/cloud/metadata/interface.go
@@ -30,6 +30,8 @@ type MetadataService interface {
 	GetNumAttachedENIs() int
 	GetNumBlockDeviceMappings() int
 	GetOutpostArn() arn.ARN
+	GetVolumeAttachmentLimit() int
+	GetVolumeAttachmentType() string
 	UpdateMetadata() error
 }
 

--- a/pkg/cloud/metadata/k8s.go
+++ b/pkg/cloud/metadata/k8s.go
@@ -119,6 +119,8 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface, metadataLabeler b
 	numAttachedENIs := 1        // Default: All nodes have at least 1 attached ENI
 	numBlockDeviceMappings := 0 // Default: 0
 	sageMakerLabels := false
+	metadataLabelerVolumeAttachmentLimit := 0
+	metadataLabelerVolumeAttachmentType := ""
 
 	if val, ok := node.GetLabels()[LabelSageMakerENICount]; ok {
 		if num, err := strconv.Atoi(val); err == nil {
@@ -157,23 +159,27 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface, metadataLabeler b
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
+		var labels metadataLabels
+
 		backoffErr := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
-			if numAttachedENIs, numBlockDeviceMappings, err = getEC2ENIsVolumes(node); err != nil {
-				klog.ErrorS(err, "get ENI and volume labels failed, retrying...")
-				node, err = clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-				//nolint: nilerr // Want to catch retry all errs until context times out
-				if err != nil {
-					return false, nil
-				}
+			var labelErr error
+			if labels, labelErr = getMetadataLabels(node); labelErr != nil {
+				klog.ErrorS(labelErr, "get metadata labels failed, retrying...")
+				node, _ = clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 				return false, nil
 			}
 			return true, nil
 		})
 
 		if backoffErr != nil {
-			klog.ErrorS(backoffErr, "get ENI and volume labels failed after multiple retries")
+			klog.ErrorS(backoffErr, "get metadata labels failed after multiple retries")
 			return nil, backoffErr
 		}
+
+		numAttachedENIs = labels.ENIs
+		numBlockDeviceMappings = labels.Volumes
+		metadataLabelerVolumeAttachmentLimit = labels.VolumeAttachmentLimit
+		metadataLabelerVolumeAttachmentType = labels.VolumeAttachmentType
 	}
 
 	instanceID, err := parseProviderID(node)
@@ -214,6 +220,8 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface, metadataLabeler b
 		AvailabilityZone:       availabilityZone,
 		NumAttachedENIs:        numAttachedENIs,
 		NumBlockDeviceMappings: numBlockDeviceMappings,
+		VolumeAttachmentLimit:  metadataLabelerVolumeAttachmentLimit,
+		VolumeAttachmentType:   metadataLabelerVolumeAttachmentType,
 	}
 
 	// Only let metadata.UpdateMetadata work for metadataLabeler data source
@@ -224,16 +232,36 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface, metadataLabeler b
 	return &instanceInfo, nil
 }
 
-func getEC2ENIsVolumes(node *corev1.Node) (int, int, error) {
+type metadataLabels struct {
+	ENIs                  int
+	Volumes               int
+	VolumeAttachmentLimit int
+	VolumeAttachmentType  string
+}
+
+func getMetadataLabels(node *corev1.Node) (metadataLabels, error) {
 	eni, err := getLabelAsInt(node, ENIsLabel, 1)
 	if err != nil {
-		return 0, 0, err
+		return metadataLabels{}, err
 	}
 	vol, err := getLabelAsInt(node, VolumesLabel, 0)
 	if err != nil {
-		return 0, 0, err
+		return metadataLabels{}, err
 	}
-	return eni, vol, nil
+	limit, err := getLabelAsInt(node, VolumeAttachmentLimitLabel, 0)
+	if err != nil {
+		return metadataLabels{}, err
+	}
+	attachType, ok := node.GetLabels()[VolumeAttachmentTypeLabel]
+	if !ok {
+		return metadataLabels{}, fmt.Errorf("%s label not found on node", VolumeAttachmentTypeLabel)
+	}
+	return metadataLabels{
+		ENIs:                  eni,
+		Volumes:               vol,
+		VolumeAttachmentLimit: limit,
+		VolumeAttachmentType:  attachType,
+	}, nil
 }
 
 func getLabelAsInt(node *corev1.Node, label string, defaultValue int) (int, error) {

--- a/pkg/cloud/metadata/labels.go
+++ b/pkg/cloud/metadata/labels.go
@@ -26,6 +26,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/limits"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,11 +59,19 @@ var (
 
 	// ENIsLabel is the label name for the number of ENIs on a node.
 	ENIsLabel string
+
+	// VolumeAttachmentLimitLabel is the label name for the volume attachment limit on a node.
+	VolumeAttachmentLimitLabel string
+
+	// VolumeAttachmentTypeLabel is the label name for the volume attachment type on a node.
+	VolumeAttachmentTypeLabel string
 )
 
 type enisVolumes struct {
-	ENIs    int
-	Volumes int
+	ENIs                  int
+	Volumes               int
+	VolumeAttachmentLimit int
+	VolumeAttachmentType  string
 }
 
 // initVariables initializes variables that depend on driver name.
@@ -71,6 +80,8 @@ func initVariables() {
 	once.Do(func() {
 		VolumesLabel = util.GetDriverName() + "/non-csi-ebs-volumes-count"
 		ENIsLabel = util.GetDriverName() + "/enis-count"
+		VolumeAttachmentLimitLabel = util.GetDriverName() + "/volume-attachment-limit"
+		VolumeAttachmentTypeLabel = util.GetDriverName() + "/volume-attachment-type"
 	})
 }
 
@@ -221,8 +232,8 @@ func getNodes(ctx context.Context, kubeclient kubernetes.Interface) (*v1.NodeLis
 	return nodes, nil
 }
 
-func updateMetadataEC2(ctx context.Context, kubeclient kubernetes.Interface, cloud cloud.Cloud, nodes *v1.NodeList, pvInformer cache.SharedIndexInformer) error {
-	enisVolumeMap, err := getMetadata(ctx, cloud, nodes, pvInformer)
+func updateMetadataEC2(ctx context.Context, kubeclient kubernetes.Interface, c cloud.Cloud, nodes *v1.NodeList, pvInformer cache.SharedIndexInformer) error {
+	enisVolumeMap, err := getMetadata(ctx, c, nodes, pvInformer)
 	if err != nil {
 		klog.ErrorS(err, "Unable to get ENI/Volume count")
 		return err
@@ -236,7 +247,7 @@ func updateMetadataEC2(ctx context.Context, kubeclient kubernetes.Interface, clo
 }
 
 // getMetadata calls the EC2 API to get the number of ENIs and non-CSI managed volumes attached to each node.
-func getMetadata(ctx context.Context, cloud cloud.Cloud, nodes *v1.NodeList, pvInformer cache.SharedIndexInformer) (map[string]enisVolumes, error) {
+func getMetadata(ctx context.Context, c cloud.Cloud, nodes *v1.NodeList, pvInformer cache.SharedIndexInformer) (map[string]enisVolumes, error) {
 	nodeIds := make([]string, 0, len(nodes.Items))
 	for _, node := range nodes.Items {
 		id, err := parseProviderID(&node)
@@ -247,11 +258,29 @@ func getMetadata(ctx context.Context, cloud cloud.Cloud, nodes *v1.NodeList, pvI
 			nodeIds = append(nodeIds, id)
 		}
 	}
-	respList, err := cloud.GetInstancesPatching(ctx, nodeIds)
+	respList, err := c.GetInstancesPatching(ctx, nodeIds)
 
 	if err != nil {
 		klog.ErrorS(err, "Failed to describe instances")
 		return nil, err
+	}
+
+	// Collect unique instance types from DescribeInstances response and get their attachment info
+	uniqueTypes := make(map[string]struct{})
+	for _, instance := range respList {
+		uniqueTypes[string(instance.InstanceType)] = struct{}{}
+	}
+	typeList := make([]string, 0, len(uniqueTypes))
+	for t := range uniqueTypes {
+		typeList = append(typeList, t)
+	}
+
+	var instanceTypesInfo map[string]cloud.InstanceTypeInfo
+	if len(typeList) > 0 {
+		instanceTypesInfo, err = c.GetInstanceTypesInfo(ctx, typeList)
+		if err != nil {
+			klog.ErrorS(err, "Failed to describe instance types, falling back to static table")
+		}
 	}
 
 	enisVolumesMap := make(map[string]enisVolumes, len(respList))
@@ -265,10 +294,33 @@ func getMetadata(ctx context.Context, cloud cloud.Cloud, nodes *v1.NodeList, pvI
 			// -1 for root volume because we eventually add this back in when calculating allocatable count in getVolumesLimit()
 			numBlockDeviceMappings = getNonCSIManagedVolumes(pvInformer, instance.BlockDeviceMappings) - 1
 		}
-		enisVolumesMap[*instance.InstanceId] = enisVolumes{ENIs: numAttachedENIs, Volumes: numBlockDeviceMappings}
+
+		instanceType := string(instance.InstanceType)
+		attachLimit, attachType := getVolumeAttachmentInfo(instanceType, instanceTypesInfo)
+
+		enisVolumesMap[*instance.InstanceId] = enisVolumes{
+			ENIs:                  numAttachedENIs,
+			Volumes:               numBlockDeviceMappings,
+			VolumeAttachmentLimit: attachLimit,
+			VolumeAttachmentType:  attachType,
+		}
 	}
 
 	return enisVolumesMap, nil
+}
+
+// getVolumeAttachmentInfo returns the volume attachment limit and type for an instance type.
+// It prefers DescribeInstanceTypes data, falling back to the static table.
+// The dedicatedInstances override is always applied.
+func getVolumeAttachmentInfo(instanceType string, instanceTypesInfo map[string]cloud.InstanceTypeInfo) (int, string) {
+	if info, ok := instanceTypesInfo[instanceType]; ok && info.MaxAttachments > 0 && info.AttachmentType != "" {
+		attachType := info.AttachmentType
+		if limits.IsDedicatedOverride(instanceType) {
+			attachType = util.AttachmentDedicated
+		}
+		return info.MaxAttachments, attachType
+	}
+	return limits.GetVolumeLimits(instanceType)
 }
 
 // patchNodes patches the labels of each node to have the number of ENIs and non-CSI managed volumes attached to each node.
@@ -319,6 +371,8 @@ func patchSingleNode(ctx context.Context, node v1.Node, enisVolumeMap map[string
 	numBlockDeviceMappings := enisVolumeMap[instanceID].Volumes
 	newNode.Labels[VolumesLabel] = strconv.Itoa(numBlockDeviceMappings)
 	newNode.Labels[ENIsLabel] = strconv.Itoa(numAttachedENIs)
+	newNode.Labels[VolumeAttachmentLimitLabel] = strconv.Itoa(enisVolumeMap[instanceID].VolumeAttachmentLimit)
+	newNode.Labels[VolumeAttachmentTypeLabel] = enisVolumeMap[instanceID].VolumeAttachmentType
 
 	oldData, err := json.Marshal(node)
 	if err != nil {

--- a/pkg/cloud/metadata/labels_test.go
+++ b/pkg/cloud/metadata/labels_test.go
@@ -62,7 +62,7 @@ func TestGetMetadata(t *testing.T) {
 				makeInstance("i-001", 2, []string{"vol-001", "vol-002"}),
 			},
 			want: map[string]enisVolumes{
-				"i-001": {ENIs: 2, Volumes: 1},
+				"i-001": {ENIs: 2, Volumes: 1, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
 			},
 		},
 		{
@@ -76,8 +76,8 @@ func TestGetMetadata(t *testing.T) {
 				makeInstance("i-002", 3, []string{"vol-002", "vol-003", "vol-004"}),
 			},
 			want: map[string]enisVolumes{
-				"i-001": {ENIs: 1, Volumes: 0},
-				"i-002": {ENIs: 3, Volumes: 2},
+				"i-001": {ENIs: 1, Volumes: 0, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
+				"i-002": {ENIs: 3, Volumes: 2, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
 			},
 		},
 		{
@@ -92,7 +92,7 @@ func TestGetMetadata(t *testing.T) {
 				makeInstance("i-001", 1, []string{"vol-001", "vol-002"}),
 			},
 			want: map[string]enisVolumes{
-				"i-001": {ENIs: 1, Volumes: 0},
+				"i-001": {ENIs: 1, Volumes: 0, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
 			},
 		},
 		{
@@ -107,7 +107,7 @@ func TestGetMetadata(t *testing.T) {
 				makeInstance("i-001", 1, []string{"vol-001", "vol-002"}),
 			},
 			want: map[string]enisVolumes{
-				"i-001": {ENIs: 1, Volumes: 0},
+				"i-001": {ENIs: 1, Volumes: 0, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
 			},
 		},
 		{
@@ -138,6 +138,12 @@ func TestGetMetadata(t *testing.T) {
 				mockCloud.EXPECT().GetInstancesPatching(ctx, expectedNodeIDs).
 					Return(tt.instances, tt.cloudErr).Times(1)
 			}
+			if !tt.wantErr {
+				mockCloud.EXPECT().GetInstanceTypesInfo(ctx, gomock.Eq([]string{"c5.large"})).
+					Return(map[string]cloud.InstanceTypeInfo{
+						"c5.large": {MaxAttachments: 27, AttachmentType: "shared"},
+					}, nil).Times(1)
+			}
 
 			pvInformer := setupPVInformer(t, tt.pvs)
 
@@ -161,22 +167,26 @@ func TestPatchSingleNode(t *testing.T) {
 		metadata    map[string]enisVolumes
 		wantENIs    string
 		wantVolumes string
+		wantLimit   string
+		wantType    string
 		wantErr     bool
 	}{
 		{
 			name: "patch node successfully",
 			node: makeNode("i-001", "aws:///us-west-2a/i-001"),
 			metadata: map[string]enisVolumes{
-				"i-001": {ENIs: 3, Volumes: 5},
+				"i-001": {ENIs: 3, Volumes: 5, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
 			},
 			wantENIs:    "3",
 			wantVolumes: "5",
+			wantLimit:   "27",
+			wantType:    "shared",
 		},
 		{
 			name: "invalid provider ID",
 			node: makeNode("i-001", "invalid"),
 			metadata: map[string]enisVolumes{
-				"i-001": {ENIs: 1, Volumes: 1},
+				"i-001": {ENIs: 1, Volumes: 1, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"},
 			},
 			wantErr: true,
 		},
@@ -201,6 +211,12 @@ func TestPatchSingleNode(t *testing.T) {
 				}
 				if got := node.Labels[VolumesLabel]; got != tt.wantVolumes {
 					t.Errorf("Volumes label = %v, want %v", got, tt.wantVolumes)
+				}
+				if got := node.Labels[VolumeAttachmentLimitLabel]; got != tt.wantLimit {
+					t.Errorf("VolumeAttachmentLimit label = %v, want %v", got, tt.wantLimit)
+				}
+				if got := node.Labels[VolumeAttachmentTypeLabel]; got != tt.wantType {
+					t.Errorf("VolumeAttachmentType label = %v, want %v", got, tt.wantType)
 				}
 			}
 		})
@@ -395,6 +411,10 @@ func TestUpdateMetadataEC2(t *testing.T) {
 			} else {
 				instances := []*types.Instance{makeInstance("i-001", tt.metadata["i-001"].ENIs, []string{"vol-001", "vol-002", "vol-003", "vol-004"})}
 				mockCloud.EXPECT().GetInstancesPatching(ctx, []string{"i-001"}).Return(instances, nil)
+				mockCloud.EXPECT().GetInstanceTypesInfo(ctx, gomock.Eq([]string{"c5.large"})).
+					Return(map[string]cloud.InstanceTypeInfo{
+						"c5.large": {MaxAttachments: 27, AttachmentType: "shared"},
+					}, nil)
 			}
 
 			err := updateMetadataEC2(ctx, clientset, mockCloud, nodeList, pvInformer)
@@ -448,6 +468,10 @@ func TestPatchNewNodes(t *testing.T) {
 
 			instances := []*types.Instance{makeInstance("i-001", tt.metadata["i-001"].ENIs, []string{"vol-001", "vol-002"})}
 			mockCloud.EXPECT().GetInstancesPatching(ctx, []string{"i-001"}).Return(instances, nil).MinTimes(1)
+			mockCloud.EXPECT().GetInstanceTypesInfo(ctx, gomock.Eq([]string{"c5.large"})).
+				Return(map[string]cloud.InstanceTypeInfo{
+					"c5.large": {MaxAttachments: 27, AttachmentType: "shared"},
+				}, nil).MinTimes(1)
 
 			patched := make(chan struct{})
 			clientset.PrependReactor("patch", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
@@ -491,8 +515,10 @@ func TestPatchNewNodes(t *testing.T) {
 func makeNode(name, providerID string) corev1.Node {
 	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: make(map[string]string),
+			Name: name,
+			Labels: map[string]string{
+				corev1.LabelInstanceTypeStable: "c5.large",
+			},
 		},
 		Spec: corev1.NodeSpec{
 			ProviderID: providerID,
@@ -513,6 +539,7 @@ func makeInstance(id string, numENIs int, volumeIDs []string) *types.Instance {
 
 	return &types.Instance{
 		InstanceId:          &id,
+		InstanceType:        types.InstanceTypeC5Large,
 		NetworkInterfaces:   make([]types.InstanceNetworkInterface, numENIs),
 		BlockDeviceMappings: blockDevices,
 	}
@@ -583,4 +610,97 @@ func setupPVInformer(t *testing.T, pvs []corev1.PersistentVolume) cache.SharedIn
 	factory.Start(stopCh)
 	cache.WaitForCacheSync(stopCh, pvInformer.HasSynced)
 	return pvInformer
+}
+
+func TestGetVolumeAttachmentInfo(t *testing.T) {
+	tests := []struct {
+		name              string
+		instanceType      string
+		instanceTypesInfo map[string]cloud.InstanceTypeInfo
+		wantLimit         int
+		wantType          string
+	}{
+		{
+			name:         "uses API data when available",
+			instanceType: "c5.large",
+			instanceTypesInfo: map[string]cloud.InstanceTypeInfo{
+				"c5.large": {MaxAttachments: 27, AttachmentType: "shared"},
+			},
+			wantLimit: 27,
+			wantType:  "shared",
+		},
+		{
+			name:         "applies dedicated override from API data",
+			instanceType: "i8ge.metal-24xl",
+			instanceTypesInfo: map[string]cloud.InstanceTypeInfo{
+				"i8ge.metal-24xl": {MaxAttachments: 128, AttachmentType: "shared"},
+			},
+			wantLimit: 128,
+			wantType:  "dedicated",
+		},
+		{
+			name:              "falls back to static table when API data missing",
+			instanceType:      "c5.large",
+			instanceTypesInfo: map[string]cloud.InstanceTypeInfo{},
+			wantLimit:         27,
+			wantType:          "shared",
+		},
+		{
+			name:              "falls back to static table when API data nil",
+			instanceType:      "c5.large",
+			instanceTypesInfo: nil,
+			wantLimit:         27,
+			wantType:          "shared",
+		},
+		{
+			name:         "falls back when API returns zero attachments",
+			instanceType: "c5.large",
+			instanceTypesInfo: map[string]cloud.InstanceTypeInfo{
+				"c5.large": {MaxAttachments: 0, AttachmentType: "shared"},
+			},
+			wantLimit: 27,
+			wantType:  "shared",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLimit, gotType := getVolumeAttachmentInfo(tt.instanceType, tt.instanceTypesInfo)
+			if gotLimit != tt.wantLimit {
+				t.Errorf("getVolumeAttachmentInfo() limit = %v, want %v", gotLimit, tt.wantLimit)
+			}
+			if gotType != tt.wantType {
+				t.Errorf("getVolumeAttachmentInfo() type = %v, want %v", gotType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestGetMetadataWithDITFallback(t *testing.T) {
+	initVariables()
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCloud := cloud.NewMockCloud(ctrl)
+	nodes := []corev1.Node{makeNode("i-001", "aws:///us-west-2a/i-001")}
+	nodeList := &corev1.NodeList{Items: nodes}
+
+	instances := []*types.Instance{makeInstance("i-001", 2, []string{"vol-001", "vol-002"})}
+	mockCloud.EXPECT().GetInstancesPatching(ctx, []string{"i-001"}).Return(instances, nil)
+	// Simulate DIT failure - should fall back to static table
+	mockCloud.EXPECT().GetInstanceTypesInfo(ctx, gomock.Eq([]string{"c5.large"})).Return(nil, errors.New("DIT API error"))
+
+	pvInformer := setupPVInformer(t, nil)
+	got, err := getMetadata(ctx, mockCloud, nodeList, pvInformer)
+
+	if err != nil {
+		t.Fatalf("getMetadata() unexpected error: %v", err)
+	}
+
+	want := enisVolumes{ENIs: 2, Volumes: 1, VolumeAttachmentLimit: 27, VolumeAttachmentType: "shared"}
+	if got["i-001"] != want {
+		t.Errorf("getMetadata() = %v, want %v", got["i-001"], want)
+	}
 }

--- a/pkg/cloud/metadata/metadata.go
+++ b/pkg/cloud/metadata/metadata.go
@@ -35,6 +35,8 @@ type Metadata struct {
 	NumAttachedENIs        int
 	NumBlockDeviceMappings int
 	OutpostArn             arn.ARN
+	VolumeAttachmentLimit  int
+	VolumeAttachmentType   string
 	IMDSClient             IMDS
 	K8sAPIClient           kubernetes.Interface
 }
@@ -122,6 +124,8 @@ func (m *Metadata) UpdateMetadata() error {
 		}
 		m.NumAttachedENIs = updatedMetadata.NumAttachedENIs
 		m.NumBlockDeviceMappings = updatedMetadata.NumBlockDeviceMappings
+		m.VolumeAttachmentLimit = updatedMetadata.VolumeAttachmentLimit
+		m.VolumeAttachmentType = updatedMetadata.VolumeAttachmentType
 	}
 
 	return nil
@@ -191,6 +195,16 @@ func (m *Metadata) GetNumBlockDeviceMappings() int {
 // GetOutpostArn returns outpost arn if instance is running on an outpost. empty otherwise.
 func (m *Metadata) GetOutpostArn() arn.ARN {
 	return m.OutpostArn
+}
+
+// GetVolumeAttachmentLimit returns the maximum number of EBS volume attachments for this instance type.
+func (m *Metadata) GetVolumeAttachmentLimit() int {
+	return m.VolumeAttachmentLimit
+}
+
+// GetVolumeAttachmentType returns the volume attachment type ("shared" or "dedicated") for this instance type.
+func (m *Metadata) GetVolumeAttachmentType() string {
+	return m.VolumeAttachmentType
 }
 
 // InvalidSourceErr returns an error message when a metadata source is invalid.

--- a/pkg/cloud/metadata/metadata_test.go
+++ b/pkg/cloud/metadata/metadata_test.go
@@ -150,6 +150,8 @@ func TestNewMetadataService(t *testing.T) {
 						corev1.LabelTopologyZone:       "us-west-2a",
 						ENIsLabel:                      "4",
 						VolumesLabel:                   "5",
+						VolumeAttachmentLimitLabel:     "27",
+						VolumeAttachmentTypeLabel:      "shared",
 					},
 				},
 				Spec: corev1.NodeSpec{
@@ -163,6 +165,8 @@ func TestNewMetadataService(t *testing.T) {
 				AvailabilityZone:       "us-west-2a",
 				NumAttachedENIs:        4,
 				NumBlockDeviceMappings: 5,
+				VolumeAttachmentLimit:  27,
+				VolumeAttachmentType:   "shared",
 			},
 		},
 		{
@@ -296,6 +300,8 @@ func TestNewMetadataService(t *testing.T) {
 				assert.Equal(t, tc.expectedMetadata.NumAttachedENIs, metadata.GetNumAttachedENIs())
 				assert.Equal(t, tc.expectedMetadata.NumBlockDeviceMappings, metadata.GetNumBlockDeviceMappings())
 				assert.Equal(t, tc.expectedMetadata.OutpostArn, metadata.GetOutpostArn())
+				assert.Equal(t, tc.expectedMetadata.VolumeAttachmentLimit, metadata.GetVolumeAttachmentLimit())
+				assert.Equal(t, tc.expectedMetadata.VolumeAttachmentType, metadata.GetVolumeAttachmentType())
 			}
 		})
 	}
@@ -528,6 +534,8 @@ func TestIMDSInstanceInfo(t *testing.T) {
 				assert.Equal(t, tc.expectedMetadata.NumAttachedENIs, metadata.GetNumAttachedENIs())
 				assert.Equal(t, tc.expectedMetadata.NumBlockDeviceMappings, metadata.GetNumBlockDeviceMappings())
 				assert.Equal(t, tc.expectedMetadata.OutpostArn, metadata.GetOutpostArn())
+				assert.Equal(t, tc.expectedMetadata.VolumeAttachmentLimit, metadata.GetVolumeAttachmentLimit())
+				assert.Equal(t, tc.expectedMetadata.VolumeAttachmentType, metadata.GetVolumeAttachmentType())
 			}
 		})
 	}
@@ -776,6 +784,8 @@ func TestMetadataLabelerInstanceInfo(t *testing.T) {
 						corev1.LabelTopologyZone:       "us-west-2a",
 						ENIsLabel:                      "5",
 						VolumesLabel:                   "4",
+						VolumeAttachmentLimitLabel:     "27",
+						VolumeAttachmentTypeLabel:      "shared",
 					},
 				},
 				Spec: corev1.NodeSpec{
@@ -789,6 +799,8 @@ func TestMetadataLabelerInstanceInfo(t *testing.T) {
 				AvailabilityZone:       "us-west-2a",
 				NumAttachedENIs:        5,
 				NumBlockDeviceMappings: 4,
+				VolumeAttachmentLimit:  27,
+				VolumeAttachmentType:   "shared",
 			},
 		},
 		{
@@ -828,6 +840,8 @@ func TestMetadataLabelerInstanceInfo(t *testing.T) {
 				require.Equal(t, tc.expectedMetadata.AvailabilityZone, metadata.AvailabilityZone)
 				require.Equal(t, tc.expectedMetadata.NumAttachedENIs, metadata.NumAttachedENIs)
 				require.Equal(t, tc.expectedMetadata.NumBlockDeviceMappings, metadata.NumBlockDeviceMappings)
+				require.Equal(t, tc.expectedMetadata.VolumeAttachmentLimit, metadata.VolumeAttachmentLimit)
+				require.Equal(t, tc.expectedMetadata.VolumeAttachmentType, metadata.VolumeAttachmentType)
 			}
 		})
 	}

--- a/pkg/cloud/metadata/mock_metadata.go
+++ b/pkg/cloud/metadata/mock_metadata.go
@@ -134,6 +134,34 @@ func (mr *MockMetadataServiceMockRecorder) GetRegion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockMetadataService)(nil).GetRegion))
 }
 
+// GetVolumeAttachmentLimit mocks base method.
+func (m *MockMetadataService) GetVolumeAttachmentLimit() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachmentLimit")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetVolumeAttachmentLimit indicates an expected call of GetVolumeAttachmentLimit.
+func (mr *MockMetadataServiceMockRecorder) GetVolumeAttachmentLimit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachmentLimit", reflect.TypeOf((*MockMetadataService)(nil).GetVolumeAttachmentLimit))
+}
+
+// GetVolumeAttachmentType mocks base method.
+func (m *MockMetadataService) GetVolumeAttachmentType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVolumeAttachmentType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetVolumeAttachmentType indicates an expected call of GetVolumeAttachmentType.
+func (mr *MockMetadataServiceMockRecorder) GetVolumeAttachmentType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVolumeAttachmentType", reflect.TypeOf((*MockMetadataService)(nil).GetVolumeAttachmentType))
+}
+
 // UpdateMetadata mocks base method.
 func (m *MockMetadataService) UpdateMetadata() error {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/mock_cloud.go
+++ b/pkg/cloud/mock_cloud.go
@@ -199,6 +199,21 @@ func (mr *MockCloudMockRecorder) GetDiskByName(ctx, name, capacityBytes interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskByName", reflect.TypeOf((*MockCloud)(nil).GetDiskByName), ctx, name, capacityBytes)
 }
 
+// GetInstanceTypesInfo mocks base method.
+func (m *MockCloud) GetInstanceTypesInfo(ctx context.Context, instanceTypes []string) (map[string]InstanceTypeInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceTypesInfo", ctx, instanceTypes)
+	ret0, _ := ret[0].(map[string]InstanceTypeInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstanceTypesInfo indicates an expected call of GetInstanceTypesInfo.
+func (mr *MockCloudMockRecorder) GetInstanceTypesInfo(ctx, instanceTypes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceTypesInfo", reflect.TypeOf((*MockCloud)(nil).GetInstanceTypesInfo), ctx, instanceTypes)
+}
+
 // GetInstancesPatching mocks base method.
 func (m *MockCloud) GetInstancesPatching(ctx context.Context, nodeIDs []string) ([]*types.Instance, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cloud/mock_ec2.go
+++ b/pkg/cloud/mock_ec2.go
@@ -215,6 +215,26 @@ func (mr *MockEC2APIMockRecorder) DescribeAvailabilityZones(ctx, params interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*MockEC2API)(nil).DescribeAvailabilityZones), varargs...)
 }
 
+// DescribeInstanceTypes mocks base method.
+func (m *MockEC2API) DescribeInstanceTypes(ctx context.Context, params *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeInstanceTypes", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeInstanceTypesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeInstanceTypes indicates an expected call of DescribeInstanceTypes.
+func (mr *MockEC2APIMockRecorder) DescribeInstanceTypes(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceTypes", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceTypes), varargs...)
+}
+
 // DescribeInstances mocks base method.
 func (m *MockEC2API) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -817,9 +817,15 @@ func (d *NodeService) getVolumesLimit() int64 {
 		return d.options.VolumeAttachLimit
 	}
 
-	instanceType := d.metadata.GetInstanceType()
-	availableAttachments, limitType := limits.GetVolumeLimits(instanceType)
-	klog.V(4).InfoS("getVolumesLimit: Retrieved inputs", "instanceType", instanceType, "attachmentLimit", availableAttachments, "limitType", limitType)
+	availableAttachments := d.metadata.GetVolumeAttachmentLimit()
+	limitType := d.metadata.GetVolumeAttachmentType()
+
+	// Fallback to static table if labels are not set (non-metadata-labeler sources)
+	if availableAttachments == 0 || limitType == "" {
+		instanceType := d.metadata.GetInstanceType()
+		availableAttachments, limitType = limits.GetVolumeLimits(instanceType)
+	}
+	klog.V(4).InfoS("getVolumesLimit: Retrieved inputs", "attachmentLimit", availableAttachments, "limitType", limitType)
 
 	// Calculate reserved volume attachments (additional EBS volumes)
 	reservedVolumeAttachments := d.options.ReservedVolumeAttachments

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1157,6 +1157,37 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 10,
 		},
 		{
+			name: "metadata_labeler_shared_limit",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 25,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(27)
+				m.EXPECT().GetVolumeAttachmentType().Return("shared")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				m.EXPECT().GetNumAttachedENIs().Return(2)
+				return m
+			},
+		},
+		{
+			name: "metadata_labeler_dedicated_limit",
+			options: &Options{
+				VolumeAttachLimit:         -1,
+				ReservedVolumeAttachments: -1,
+			},
+			expectedVal: 127,
+			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
+				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(128)
+				m.EXPECT().GetVolumeAttachmentType().Return("dedicated")
+				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
+				return m
+			},
+		},
+		{
 			name: "t2.medium_volume_attach_limit",
 			options: &Options{
 				VolumeAttachLimit:         -1,
@@ -1165,6 +1196,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 38,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetInstanceType().Return("t2.medium")
 				return m
@@ -1179,6 +1212,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 27,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetInstanceType().Return("m5.large")
 				m.EXPECT().GetNumAttachedENIs().Return(0)
@@ -1194,6 +1229,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 36,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("t2.medium")
 				return m
 			},
@@ -1207,6 +1244,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 23,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("m5d.large")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(3)
@@ -1222,6 +1261,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 2,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("d3en.12xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1237,6 +1278,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 2,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("d3.8xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1252,6 +1295,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 127,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("m7i.48xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				return m
@@ -1265,6 +1310,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 1,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("t3.xlarge")
 				m.EXPECT().GetNumAttachedENIs().Return(40)
 				return m
@@ -1279,6 +1326,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 15,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("mac1.metal")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1294,6 +1343,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 24,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("g4dn.xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1309,6 +1360,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 24,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("g4ad.xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1324,6 +1377,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 21,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("g4dn.12xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1340,6 +1395,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 8,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("g5.48xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1356,6 +1413,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 25,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("inf1.xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1372,6 +1431,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 25,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("inf1.2xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1388,6 +1449,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 22,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("inf1.6xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)
@@ -1404,6 +1467,8 @@ func TestGetVolumesLimit(t *testing.T) {
 			expectedVal: 10,
 			metadataMock: func(ctrl *gomock.Controller) *metadata.MockMetadataService {
 				m := metadata.NewMockMetadataService(ctrl)
+				m.EXPECT().GetVolumeAttachmentLimit().Return(0)
+				m.EXPECT().GetVolumeAttachmentType().Return("")
 				m.EXPECT().GetInstanceType().Return("inf1.24xlarge")
 				m.EXPECT().GetNumBlockDeviceMappings().Return(0)
 				m.EXPECT().GetNumAttachedENIs().Return(1)

--- a/pkg/util/ec2_interface.go
+++ b/pkg/util/ec2_interface.go
@@ -43,4 +43,5 @@ type EC2API interface {
 	DeleteTags(ctx context.Context, params *ec2.DeleteTagsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error)
 	EnableFastSnapshotRestores(ctx context.Context, params *ec2.EnableFastSnapshotRestoresInput, optFns ...func(*ec2.Options)) (*ec2.EnableFastSnapshotRestoresOutput, error)
 	LockSnapshot(ctx context.Context, params *ec2.LockSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.LockSnapshotOutput, error)
+	DescribeInstanceTypes(ctx context.Context, params *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 }

--- a/tests/e2e/metadata-labeler.go
+++ b/tests/e2e/metadata-labeler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/limits"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,12 +49,14 @@ const (
 )
 
 type instanceMetadata struct {
-	ENIs             int
-	Volumes          int
-	InstanceType     string
-	AllocatableCount int32
-	NodeID           string
-	AvailabilityZone string
+	ENIs                  int
+	Volumes               int
+	InstanceType          string
+	AllocatableCount      int32
+	NodeID                string
+	AvailabilityZone      string
+	VolumeAttachmentLimit int
+	VolumeAttachmentType  string
 }
 
 var _ = framework.Describe("[ebs-csi-e2e] [Disruptive] Metadata Labeler Sidecar", framework.WithDisruptive(), func() {
@@ -107,6 +110,7 @@ var _ = framework.Describe("[ebs-csi-e2e] [Disruptive] Metadata Labeler Sidecar"
 			})
 			Expect(err).NotTo(HaveOccurred(), "Failed to describe EC2 instances")
 			expectedMetadata = getVolENIs(resp)
+			populateVolumeAttachmentInfo(ec2Client, expectedMetadata)
 
 			By("Checking initial node labels")
 			checkVolENI(expectedMetadata, labeledMetadata, nodes)
@@ -202,16 +206,65 @@ func getVolENIs(resp *ec2.DescribeInstancesOutput) map[string]*instanceMetadata 
 	return expectedMetadata
 }
 
+// populateVolumeAttachmentInfo calls DescribeInstanceTypes to get volume attachment limits for each instance type.
+func populateVolumeAttachmentInfo(ec2Client *ec2.Client, metadata map[string]*instanceMetadata) {
+	uniqueTypes := make(map[string]struct{})
+	for _, m := range metadata {
+		uniqueTypes[m.InstanceType] = struct{}{}
+	}
+
+	typeNames := make([]types.InstanceType, 0, len(uniqueTypes))
+	for t := range uniqueTypes {
+		typeNames = append(typeNames, types.InstanceType(t))
+	}
+
+	resp, err := ec2Client.DescribeInstanceTypes(context.TODO(), &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: typeNames,
+	})
+	Expect(err).NotTo(HaveOccurred(), "Failed to describe instance types")
+
+	typeInfo := make(map[string]struct {
+		limit      int
+		attachType string
+	})
+	for _, it := range resp.InstanceTypes {
+		if it.EbsInfo != nil && it.EbsInfo.MaximumEbsAttachments != nil {
+			typeInfo[string(it.InstanceType)] = struct {
+				limit      int
+				attachType string
+			}{
+				limit:      int(*it.EbsInfo.MaximumEbsAttachments),
+				attachType: string(it.EbsInfo.AttachmentLimitType),
+			}
+		}
+	}
+
+	for _, m := range metadata {
+		if info, ok := typeInfo[m.InstanceType]; ok {
+			m.VolumeAttachmentLimit = info.limit
+			m.VolumeAttachmentType = info.attachType
+			// Apply the same dedicated override the labeler uses
+			if limits.IsDedicatedOverride(m.InstanceType) {
+				m.VolumeAttachmentType = util.AttachmentDedicated
+			}
+		}
+	}
+}
+
 // checkVolENI compares `expectedMetadata` and `labeledMetadata` to have the same number of volumes and ENIs attached to each node in `nodes`
 func checkVolENI(expectedMetadata, labeledMetadata map[string]*instanceMetadata, nodes *corev1.NodeList) {
 	for _, node := range nodes.Items {
 		vol, _ := strconv.Atoi(node.GetLabels()[util.GetDriverName()+"/non-csi-ebs-volumes-count"])
 		enis, _ := strconv.Atoi(node.GetLabels()[util.GetDriverName()+"/enis-count"])
+		attachLimit, _ := strconv.Atoi(node.GetLabels()[util.GetDriverName()+"/volume-attachment-limit"])
+		attachType := node.GetLabels()[util.GetDriverName()+"/volume-attachment-type"]
 		id := parseProviderID(node.Spec.ProviderID)
 		labeledMetadata[id] = &instanceMetadata{}
 		labeledMetadata[id].ENIs = enis
 		labeledMetadata[id].Volumes = vol
 		labeledMetadata[id].NodeID = node.Name
+		labeledMetadata[id].VolumeAttachmentLimit = attachLimit
+		labeledMetadata[id].VolumeAttachmentType = attachType
 
 		if expectedMetadata[id] != nil {
 			if labeledMetadata[id].Volumes != expectedMetadata[id].Volumes {
@@ -221,6 +274,14 @@ func checkVolENI(expectedMetadata, labeledMetadata map[string]*instanceMetadata,
 			if labeledMetadata[id].ENIs != expectedMetadata[id].ENIs {
 				Fail(fmt.Sprintf("ENI count mismatch for node %s: expected %d, got %d\n",
 					node.Name, expectedMetadata[id].ENIs, labeledMetadata[id].ENIs))
+			}
+			if labeledMetadata[id].VolumeAttachmentLimit != expectedMetadata[id].VolumeAttachmentLimit {
+				Fail(fmt.Sprintf("VolumeAttachmentLimit mismatch for node %s: expected %d, got %d\n",
+					node.Name, expectedMetadata[id].VolumeAttachmentLimit, labeledMetadata[id].VolumeAttachmentLimit))
+			}
+			if labeledMetadata[id].VolumeAttachmentType != expectedMetadata[id].VolumeAttachmentType {
+				Fail(fmt.Sprintf("VolumeAttachmentType mismatch for node %s: expected %s, got %s\n",
+					node.Name, expectedMetadata[id].VolumeAttachmentType, labeledMetadata[id].VolumeAttachmentType))
 			}
 		}
 	}
@@ -280,10 +341,17 @@ func checkLabelsUpdated(cs kubernetes.Interface, labeledMetadata, expectedMetada
 			id := parseProviderID(node.Spec.ProviderID)
 			vol, _ := strconv.Atoi(node.Labels[util.GetDriverName()+"/non-csi-ebs-volumes-count"])
 			eni, _ := strconv.Atoi(node.Labels[util.GetDriverName()+"/enis-count"])
+			attachLimit, _ := strconv.Atoi(node.Labels[util.GetDriverName()+"/volume-attachment-limit"])
+			attachType := node.Labels[util.GetDriverName()+"/volume-attachment-type"]
 			labeledMetadata[id].Volumes = vol
 			labeledMetadata[id].ENIs = eni
+			labeledMetadata[id].VolumeAttachmentLimit = attachLimit
+			labeledMetadata[id].VolumeAttachmentType = attachType
 
 			if vol != expectedMetadata[id].Volumes || eni != expectedMetadata[id].ENIs {
+				return false
+			}
+			if attachLimit != expectedMetadata[id].VolumeAttachmentLimit || attachType != expectedMetadata[id].VolumeAttachmentType {
 				return false
 			}
 		}

--- a/tests/sanity/fake_sanity_cloud.go
+++ b/tests/sanity/fake_sanity_cloud.go
@@ -142,6 +142,10 @@ func (d *fakeCloud) GetInstancesPatching(ctx context.Context, nodeIDs []string) 
 	return []*types.Instance{}, nil
 }
 
+func (d *fakeCloud) GetInstanceTypesInfo(ctx context.Context, instanceTypes []string) (map[string]cloud.InstanceTypeInfo, error) {
+	return map[string]cloud.InstanceTypeInfo{}, nil
+}
+
 func (d *fakeCloud) ListSnapshots(ctx context.Context, sourceVolumeID string, maxResults int32, nextToken string) (*cloud.ListSnapshotsResponse, error) {
 	var s []*cloud.Snapshot
 	startIndex := 0

--- a/tests/sanity/fake_sanity_metadata_service.go
+++ b/tests/sanity/fake_sanity_metadata_service.go
@@ -65,3 +65,11 @@ func (m *fakeMetadataService) GetNumBlockDeviceMappings() int {
 func (m *fakeMetadataService) GetOutpostArn() arn.ARN {
 	return m.outpostArn
 }
+
+func (m *fakeMetadataService) GetVolumeAttachmentLimit() int {
+	return 0
+}
+
+func (m *fakeMetadataService) GetVolumeAttachmentType() string {
+	return ""
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Instead of using our hardcoded table, in the `metadata-labeler` path we now call DIT at runtime and pass the result via node label. This enables users to immediately get updates from EC2 (e.g. new instance releases) without having to wait on a driver release.

#### How was this change tested?

Manually (Create a cluster with `metadata-labeler` enabled, observe labels are added) and with new unit tests and modification to the E2E test for metadata-labeler.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Pass volume limits from DescribeInstanceTypes when using metadata-labeler
```
