### PR TITLE
Call DescribeInstanceTypes at runtime to get multi-card info

### DIFF
--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -6,6 +6,7 @@
       "Action": [
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",

--- a/hack/e2e/kops/patch-cluster.yaml
+++ b/hack/e2e/kops/patch-cluster.yaml
@@ -32,6 +32,7 @@ spec:
           "Action": [
             "ec2:DescribeAvailabilityZones",
             "ec2:DescribeInstances",
+            "ec2:DescribeInstanceTypes",
             "ec2:DescribeSnapshots",
             "ec2:DescribeTags",
             "ec2:DescribeVolumes",

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/batcher"
 	dm "github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/devicemanager"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/limits"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/expiringcache"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/metrics"
 	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/plugin"
@@ -409,6 +410,7 @@ type cloud struct {
 	latestClientTokens    expiringcache.ExpiringCache[string, int]
 	volumeInitializations expiringcache.ExpiringCache[string, volumeInitialization]
 	latestIOPSLimits      expiringcache.ExpiringCache[string, iopsLimits]
+	cardCountCache        expiringcache.ExpiringCache[string, int]
 	accountID             string
 	accountIDOnce         sync.Once
 	attemptDryRun         atomic.Bool
@@ -503,6 +505,7 @@ func NewCloud(region string, awsSdkDebugLog bool, userAgentExtra string, batchin
 		latestClientTokens:    expiringcache.New[string, int](cacheForgetDelay),
 		volumeInitializations: expiringcache.New[string, volumeInitialization](volInitCacheForgetDelay),
 		latestIOPSLimits:      expiringcache.New[string, iopsLimits](iopsLimitCacheForgetDelay),
+		cardCountCache:        expiringcache.New[string, int](cacheForgetDelay),
 	}
 
 	// Ensure an EC2 Dry-run API call is made on startup and every dryRunInterval
@@ -1233,6 +1236,37 @@ func (c *cloud) batchDescribeInstances(request *ec2.DescribeInstancesInput) (*ty
 	return r.Result, nil
 }
 
+// getCardCount returns the number of EBS cards for a given instance type,
+// using a cache to avoid repeated API calls. Falls back to the static table
+// if the API call fails.
+func (c *cloud) getCardCount(ctx context.Context, instanceType string) int {
+	if val, ok := c.cardCountCache.Get(instanceType); ok {
+		return *val
+	}
+
+	resp, err := c.ec2.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []types.InstanceType{types.InstanceType(instanceType)},
+	})
+	if err != nil {
+		cards := limits.GetCardCount(instanceType)
+		klog.ErrorS(err, "Failed to describe instance type, falling back to static table", "instanceType", instanceType, "fallbackCards", cards)
+		c.cardCountCache.Set(instanceType, &cards)
+		return cards
+	}
+
+	cards := 1
+	if len(resp.InstanceTypes) > 0 {
+		info := resp.InstanceTypes[0]
+		if info.EbsInfo != nil && info.EbsInfo.MaximumEbsCards != nil && *info.EbsInfo.MaximumEbsCards > 1 {
+			cards = int(*info.EbsInfo.MaximumEbsCards)
+			klog.V(4).InfoS("Resolved EBS card count from API", "instanceType", instanceType, "cards", cards)
+		}
+	}
+
+	c.cardCountCache.Set(instanceType, &cards)
+	return cards
+}
+
 func (c *cloud) AttachDisk(ctx context.Context, volumeID, nodeID string) (string, error) {
 	if util.IsHyperPodNode(nodeID) {
 		return c.attachDiskHyperPod(ctx, volumeID, nodeID)
@@ -1249,7 +1283,8 @@ func (c *cloud) AttachDisk(ctx context.Context, volumeID, nodeID string) (string
 		c.likelyBadDeviceNames.Set(nodeID, likelyBadDeviceNames)
 	}
 
-	device, err := c.dm.NewDevice(instance, volumeID, likelyBadDeviceNames)
+	numCards := c.getCardCount(ctx, string(instance.InstanceType))
+	device, err := c.dm.NewDevice(instance, volumeID, likelyBadDeviceNames, numCards)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -2154,13 +2154,14 @@ func TestAttachDisk(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name     string
-		volumeID string
-		nodeID   string
-		nodeID2  string
-		path     string
-		expErr   error
-		mockFunc func(*MockEC2API, context.Context, string, string, string, string, dm.DeviceManager)
+		name       string
+		volumeID   string
+		nodeID     string
+		nodeID2    string
+		path       string
+		expErr     error
+		cardCounts map[string]int // pre-populated card count cache entries
+		mockFunc   func(*MockEC2API, context.Context, string, string, string, string, dm.DeviceManager)
 	}{
 		{
 			name:     "success: AttachVolume normal",
@@ -2226,7 +2227,7 @@ func TestAttachDisk(t *testing.T) {
 				instanceRequest := createInstanceRequest(nodeID)
 
 				fakeInstance := newFakeInstance(nodeID, volumeID, path)
-				_, err := dm.NewDevice(&fakeInstance, volumeID, new(sync.Map))
+				_, err := dm.NewDevice(&fakeInstance, volumeID, new(sync.Map), 1)
 				require.NoError(t, err)
 
 				gomock.InOrder(
@@ -2347,11 +2348,12 @@ func TestAttachDisk(t *testing.T) {
 			},
 		},
 		{
-			name:     "success: AttachVolume with card index",
-			volumeID: defaultVolumeID,
-			nodeID:   defaultNodeID,
-			path:     defaultPath,
-			expErr:   nil,
+			name:       "success: AttachVolume with card index",
+			volumeID:   defaultVolumeID,
+			nodeID:     defaultNodeID,
+			path:       defaultPath,
+			expErr:     nil,
+			cardCounts: map[string]int{"r8gb.48xlarge": 2},
 			mockFunc: func(mockEC2 *MockEC2API, ctx context.Context, volumeID, nodeID, nodeID2, path string, dm dm.DeviceManager) {
 				instanceRequest := createInstanceRequest(nodeID)
 
@@ -2412,10 +2414,22 @@ func TestAttachDisk(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockEC2 := NewMockEC2API(mockCtrl)
+
+			// Non-HyperPod AttachDisk calls cloud.getCardCount → DescribeInstanceTypes.
+			// Default mock returns 1 card (no multi-card behavior).
+			mockEC2.EXPECT().DescribeInstanceTypes(testutil.AnyContext(), testutil.EC2Input(&ec2.DescribeInstanceTypesInput{})).Return(&ec2.DescribeInstanceTypesOutput{
+				InstanceTypes: []types.InstanceTypeInfo{{EbsInfo: &types.EbsInfo{}}},
+			}, nil).AnyTimes()
+
 			c := newCloud(mockEC2)
 			cloudInstance, ok := c.(*cloud)
 			if !ok {
 				t.Fatalf("could not assert c as type cloud, %v", c)
+			}
+
+			// Pre-populate card count cache for tests that need specific values
+			for instanceType, count := range tc.cardCounts {
+				cloudInstance.cardCountCache.Set(instanceType, &count)
 			}
 
 			ctx := t.Context()
@@ -5170,6 +5184,7 @@ func newCloud(mockEC2 util.EC2API) Cloud {
 		latestClientTokens:    expiringcache.New[string, int](cacheForgetDelay),
 		volumeInitializations: expiringcache.New[string, volumeInitialization](cacheForgetDelay),
 		latestIOPSLimits:      expiringcache.New[string, iopsLimits](iopsLimitCacheForgetDelay),
+		cardCountCache:        expiringcache.New[string, int](cacheForgetDelay),
 	}
 	return c
 }

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/cloud/limits"
 	"k8s.io/klog/v2"
 )
 
@@ -57,7 +56,8 @@ type DeviceManager interface {
 	// NewDevice retrieves the device if the device is already assigned.
 	// Otherwise it creates a new device with next available device name
 	// and mark it as unassigned device.
-	NewDevice(instance *types.Instance, volumeID string, likelyBadNames *sync.Map) (device *Device, err error)
+	// numCards is the number of EBS cards on the instance (1 for single-card instances).
+	NewDevice(instance *types.Instance, volumeID string, likelyBadNames *sync.Map, numCards int) (device *Device, err error)
 
 	// GetDevice returns the device already assigned to the volume.
 	GetDevice(instance *types.Instance, volumeID string) (device *Device, err error)
@@ -123,7 +123,7 @@ func NewDeviceManager() DeviceManager {
 	}
 }
 
-func (d *deviceManager) NewDevice(instance *types.Instance, volumeID string, likelyBadNames *sync.Map) (*Device, error) {
+func (d *deviceManager) NewDevice(instance *types.Instance, volumeID string, likelyBadNames *sync.Map, numCards int) (*Device, error) {
 	d.mux.Lock()
 	defer d.mux.Unlock()
 
@@ -151,9 +151,8 @@ func (d *deviceManager) NewDevice(instance *types.Instance, volumeID string, lik
 	}
 
 	// Calculate card index for new volume
-	instanceType := string(instance.InstanceType)
 	cardCounts := d.getCardCounts(instance)
-	cardIndex := getNextCardIndex(instanceType, cardCounts)
+	cardIndex := getNextCardIndex(numCards, cardCounts)
 
 	// Add the chosen device and volume to the "attachments in progress" map
 	d.inFlight.Add(nodeID, volumeID, name, cardIndex)
@@ -196,9 +195,7 @@ func (d *deviceManager) getCardCounts(instance *types.Instance) map[int32]int {
 // It implements a "least occupied" load balancing strategy.
 // Returns nil when the instance has only 1 card. For instances with multiple cards,
 // returns the card with the fewest volumes. When counts are equal, prefers lower card index.
-func getNextCardIndex(instanceType string, cardCounts map[int32]int) *int32 {
-	numCards := limits.GetCardCount(instanceType)
-
+func getNextCardIndex(numCards int, cardCounts map[int32]int) *int32 {
 	// If instance has only 1 card, return nil (no index needed)
 	if numCards <= 1 {
 		return nil

--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -60,7 +60,7 @@ func TestNewDevice(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Should fail if instance is nil
-			dev1, err := dm.NewDevice(nil, tc.volumeID, new(sync.Map))
+			dev1, err := dm.NewDevice(nil, tc.volumeID, new(sync.Map), 1)
 			if err == nil {
 				t.Fatalf("Expected error when nil instance is passed in, got nothing")
 			}
@@ -71,11 +71,11 @@ func TestNewDevice(t *testing.T) {
 			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
 
 			// Should create valid Device with valid path
-			dev1, err = dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map))
+			dev1, err = dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map), 1)
 			assertDevice(t, dev1, false, err)
 
 			// Devices with same instance and volume should have same paths
-			dev2, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map))
+			dev2, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map), 1)
 			assertDevice(t, dev2, true /*IsAlreadyAssigned*/, err)
 			if dev1.Path != dev2.Path {
 				t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev2.Path)
@@ -83,7 +83,7 @@ func TestNewDevice(t *testing.T) {
 
 			// Should create new Device with the same path after releasing
 			dev2.Release(false)
-			dev3, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map))
+			dev3, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map), 1)
 			assertDevice(t, dev3, false, err)
 			if dev3.Path != dev1.Path {
 				t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev3.Path)
@@ -137,7 +137,7 @@ func TestNewDeviceWithExistingDevice(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeInstance := newFakeInstance("fake-instance", tc.existingID, tc.existingPath)
 
-			dev, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map))
+			dev, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map), 1)
 			assertDevice(t, dev, tc.existingID == tc.volumeID, err)
 
 			if dev.Path != tc.expectedPath {
@@ -170,7 +170,7 @@ func TestGetDevice(t *testing.T) {
 			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
 
 			// Should create valid Device with valid path
-			dev1, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map))
+			dev1, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map), 1)
 			assertDevice(t, dev1, false /*IsAlreadyAssigned*/, err)
 
 			// Devices with same instance and volume should have same paths
@@ -206,7 +206,7 @@ func TestReleaseDevice(t *testing.T) {
 			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
 
 			// Should get assigned Device after releasing tainted device
-			dev, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map))
+			dev, err := dm.NewDevice(fakeInstance, tc.volumeID, new(sync.Map), 1)
 			assertDevice(t, dev, false /*IsAlreadyAssigned*/, err)
 			dev.Taint()
 			dev.Release(false)
@@ -254,6 +254,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 		name              string
 		instance          *types.Instance
 		volumeID          string
+		numCards          int
 		expectedCardIndex *int32
 		isAlreadyAssigned bool
 	}{
@@ -272,6 +273,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 				},
 			},
 			volumeID:          "vol-2",
+			numCards:          1,
 			expectedCardIndex: nil,
 			isAlreadyAssigned: false,
 		},
@@ -292,6 +294,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 				},
 			},
 			volumeID:          "vol-2",
+			numCards:          2,
 			expectedCardIndex: aws.Int32(1), // Should pick card 1 (has fewer volumes)
 			isAlreadyAssigned: false,
 		},
@@ -312,6 +315,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 				},
 			},
 			volumeID:          "vol-1",
+			numCards:          2,
 			expectedCardIndex: aws.Int32(1),
 			isAlreadyAssigned: true,
 		},
@@ -346,6 +350,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 				},
 			},
 			volumeID:          "vol-4",
+			numCards:          2,
 			expectedCardIndex: aws.Int32(1), // Should pick card 1 (has fewer volumes)
 			isAlreadyAssigned: false,
 		},
@@ -370,6 +375,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 				},
 			},
 			volumeID:          "vol-3",
+			numCards:          2,
 			expectedCardIndex: aws.Int32(0), // Should pick card 0 (both have 0 volumes, picks lowest index)
 			isAlreadyAssigned: false,
 		},
@@ -378,7 +384,7 @@ func TestNewDeviceWithCardIndex(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dm := NewDeviceManager()
-			device, err := dm.NewDevice(tc.instance, tc.volumeID, new(sync.Map))
+			device, err := dm.NewDevice(tc.instance, tc.volumeID, new(sync.Map), tc.numCards)
 			if err != nil {
 				t.Fatalf("Expected no error, got %v", err)
 			}
@@ -497,25 +503,25 @@ func TestGetDeviceWithCardIndex(t *testing.T) {
 func TestGetNextCardIndex(t *testing.T) {
 	testCases := []struct {
 		name              string
-		instanceType      string
+		numCards          int
 		cardCounts        map[int32]int
 		expectedCardIndex *int32
 	}{
 		{
 			name:              "single card instance returns nil",
-			instanceType:      "m5.large",
+			numCards:          1,
 			cardCounts:        map[int32]int{},
 			expectedCardIndex: nil,
 		},
 		{
 			name:              "multi-card instance with empty counts picks card 0",
-			instanceType:      "r8gb.48xlarge",
+			numCards:          2,
 			cardCounts:        map[int32]int{},
 			expectedCardIndex: aws.Int32(0),
 		},
 		{
-			name:         "multi-card instance picks card with fewer volumes",
-			instanceType: "r8gb.48xlarge",
+			name:     "multi-card instance picks card with fewer volumes",
+			numCards: 2,
 			cardCounts: map[int32]int{
 				0: 3,
 				1: 1,
@@ -523,8 +529,8 @@ func TestGetNextCardIndex(t *testing.T) {
 			expectedCardIndex: aws.Int32(1),
 		},
 		{
-			name:         "multi-card instance with equal counts picks lowest index",
-			instanceType: "r8gb.48xlarge",
+			name:     "multi-card instance with equal counts picks lowest index",
+			numCards: 2,
 			cardCounts: map[int32]int{
 				0: 2,
 				1: 2,
@@ -532,8 +538,8 @@ func TestGetNextCardIndex(t *testing.T) {
 			expectedCardIndex: aws.Int32(0),
 		},
 		{
-			name:         "multi-card instance with only one card populated",
-			instanceType: "r8gb.48xlarge",
+			name:     "multi-card instance with only one card populated",
+			numCards: 2,
 			cardCounts: map[int32]int{
 				0: 5,
 			},
@@ -543,7 +549,7 @@ func TestGetNextCardIndex(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := getNextCardIndex(tc.instanceType, tc.cardCounts)
+			result := getNextCardIndex(tc.numCards, tc.cardCounts)
 
 			if tc.expectedCardIndex == nil {
 				if result != nil {
@@ -665,7 +671,8 @@ func TestGetCardCounts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dm := &deviceManager{
 				nameAllocator: &nameAllocator{},
-				inFlight:      make(inFlightAttaching),
+
+				inFlight: make(inFlightAttaching),
 			}
 
 			if tc.inflightSetup != nil {
@@ -691,6 +698,7 @@ func TestNewDeviceWithInflightCardIndex(t *testing.T) {
 	testCases := []struct {
 		name              string
 		instance          *types.Instance
+		numCards          int
 		volumeIDs         []string
 		expectedCardIndex []*int32
 	}{
@@ -701,6 +709,7 @@ func TestNewDeviceWithInflightCardIndex(t *testing.T) {
 				InstanceType:        "r8gb.48xlarge", // 2 cards
 				BlockDeviceMappings: []types.InstanceBlockDeviceMapping{},
 			},
+			numCards:  2,
 			volumeIDs: []string{"vol-1", "vol-2", "vol-3", "vol-4"},
 			// First goes to card 0, second to card 1, third to card 0, fourth to card 1
 			expectedCardIndex: []*int32{aws.Int32(0), aws.Int32(1), aws.Int32(0), aws.Int32(1)},
@@ -720,6 +729,7 @@ func TestNewDeviceWithInflightCardIndex(t *testing.T) {
 					},
 				},
 			},
+			numCards:  2,
 			volumeIDs: []string{"vol-1", "vol-2"},
 			// Card 0 has 1 volume, so first new volume goes to card 1, then card 0
 			expectedCardIndex: []*int32{aws.Int32(1), aws.Int32(0)},
@@ -731,7 +741,7 @@ func TestNewDeviceWithInflightCardIndex(t *testing.T) {
 			dm := NewDeviceManager()
 
 			for i, volumeID := range tc.volumeIDs {
-				device, err := dm.NewDevice(tc.instance, volumeID, new(sync.Map))
+				device, err := dm.NewDevice(tc.instance, volumeID, new(sync.Map), tc.numCards)
 				if err != nil {
 					t.Fatalf("Expected no error for volume %s, got %v", volumeID, err)
 				}

--- a/pkg/cloud/mock_ec2.go
+++ b/pkg/cloud/mock_ec2.go
@@ -215,6 +215,26 @@ func (mr *MockEC2APIMockRecorder) DescribeAvailabilityZones(ctx, params interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*MockEC2API)(nil).DescribeAvailabilityZones), varargs...)
 }
 
+// DescribeInstanceTypes mocks base method.
+func (m *MockEC2API) DescribeInstanceTypes(ctx context.Context, params *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, params}
+	for _, a := range optFns {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeInstanceTypes", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeInstanceTypesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeInstanceTypes indicates an expected call of DescribeInstanceTypes.
+func (mr *MockEC2APIMockRecorder) DescribeInstanceTypes(ctx, params interface{}, optFns ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, params}, optFns...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceTypes", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceTypes), varargs...)
+}
+
 // DescribeInstances mocks base method.
 func (m *MockEC2API) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/ec2_interface.go
+++ b/pkg/util/ec2_interface.go
@@ -43,4 +43,5 @@ type EC2API interface {
 	DeleteTags(ctx context.Context, params *ec2.DeleteTagsInput, optFns ...func(*ec2.Options)) (*ec2.DeleteTagsOutput, error)
 	EnableFastSnapshotRestores(ctx context.Context, params *ec2.EnableFastSnapshotRestoresInput, optFns ...func(*ec2.Options)) (*ec2.EnableFastSnapshotRestoresOutput, error)
 	LockSnapshot(ctx context.Context, params *ec2.LockSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.LockSnapshotOutput, error)
+	DescribeInstanceTypes(ctx context.Context, params *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error)
 }

--- a/tests/e2e/multi_card.go
+++ b/tests/e2e/multi_card.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+// Validates that the driver has ec2:DescribeInstanceTypes permission and that
+// the API returns valid EBS card information for the cluster's instance types.
+// This permission is required at runtime to resolve multi-card instance types.
+var _ = Describe("[ebs-csi-e2e] [single-az] Multi-Card", func() {
+	f := framework.NewDefaultFramework("ebs")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	var cs clientset.Interface
+
+	BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		Fail(fmt.Sprintf("failed to load AWS config: %v", err))
+	}
+	ec2Client := ec2.NewFromConfig(cfg)
+
+	It("should successfully call DescribeInstanceTypes for cluster node instance types", func() {
+		ctx := context.Background()
+
+		nodes, err := cs.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		framework.ExpectNoError(err, "listing nodes")
+		Expect(nodes.Items).NotTo(BeEmpty(), "cluster should have at least one node")
+
+		seen := map[string]bool{}
+		for _, node := range nodes.Items {
+			instanceType := node.Labels["node.kubernetes.io/instance-type"]
+			if instanceType == "" || seen[instanceType] {
+				continue
+			}
+			seen[instanceType] = true
+
+			By(fmt.Sprintf("Calling DescribeInstanceTypes for %s", instanceType))
+			resp, err := ec2Client.DescribeInstanceTypes(ctx, &ec2.DescribeInstanceTypesInput{
+				InstanceTypes: []ec2types.InstanceType{ec2types.InstanceType(instanceType)},
+			})
+			framework.ExpectNoError(err, "DescribeInstanceTypes for %s", instanceType)
+			Expect(resp.InstanceTypes).To(HaveLen(1), "expected exactly 1 result for %s", instanceType)
+
+			info := resp.InstanceTypes[0]
+			Expect(info.EbsInfo).NotTo(BeNil(), "EbsInfo should not be nil for %s", instanceType)
+
+			cards := int32(1)
+			if info.EbsInfo.MaximumEbsCards != nil {
+				cards = *info.EbsInfo.MaximumEbsCards
+			}
+			Expect(cards).To(BeNumerically(">=", 1), "card count should be >= 1 for %s", instanceType)
+			framework.Logf("Instance type %s has %d EBS card(s)", instanceType, cards)
+		}
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

Call DIT at runtime to get the latest EBS multi-card info for an instance rather than using a built in hardcoded table.

#### How was this change tested?

Unit tests + E2E tests (modified to mock new API calls)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Call DescribeInstanceTypes at runtime for EBS multi-card instances
```
