### PR TITLE
Validate reserved tag keys on tag deletion path during volume modification

### DIFF
--- a/pkg/driver/controller_modify_volume.go
+++ b/pkg/driver/controller_modify_volume.go
@@ -229,6 +229,9 @@ func parseModifyVolumeParameters(params map[string]string) (*modifyVolumeRequest
 			case strings.HasPrefix(key, ModificationAddTag):
 				rawTagsToAdd = append(rawTagsToAdd, value)
 			case strings.HasPrefix(key, ModificationDeleteTag):
+				if err := validateExtraTags(map[string]string{value: ""}, false); err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "Cannot delete reserved tag: %v", err)
+				}
 				options.modifyTagsOptions.TagsToDelete = append(options.modifyTagsOptions.TagsToDelete, value)
 			default:
 				return nil, status.Errorf(codes.InvalidArgument, "Invalid mutable parameter key: %s", key)

--- a/pkg/driver/controller_modify_volume_test.go
+++ b/pkg/driver/controller_modify_volume_test.go
@@ -251,6 +251,39 @@ func TestParseModifyVolumeParameters(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "delete reserved tag CSIVolumeName",
+			params: map[string]string{
+				ModificationDeleteTag + "_1": "CSIVolumeName",
+			},
+			expectError: true,
+		},
+		{
+			name: "delete reserved tag ebs.csi.aws.com/cluster",
+			params: map[string]string{
+				ModificationDeleteTag + "_1": cloud.AwsEbsDriverTagKey,
+			},
+			expectError: true,
+		},
+		{
+			name: "delete reserved tag with kubernetes.io prefix",
+			params: map[string]string{
+				ModificationDeleteTag + "_1": "kubernetes.io/created-for/pvc/name",
+			},
+			expectError: true,
+		},
+		{
+			name: "delete non-reserved tag succeeds",
+			params: map[string]string{
+				ModificationDeleteTag + "_1": "my-custom-tag",
+			},
+			expectedOptions: &modifyVolumeRequest{
+				modifyTagsOptions: cloud.ModifyTagsOptions{
+					TagsToAdd:    map[string]string{},
+					TagsToDelete: []string{"my-custom-tag"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
/kind bug

#### What is this PR about? / Why do we need it?

Reserved tag keys are validated when adding tags but not when deleting them during volume modification. This adds the same validation to the deletion path.

#### How was this change tested?

Unit tests and e2e validation on a kOps cluster.

```release-note
Prevent deletion of reserved tag keys during volume modification.
```