### PR TITLE
Updating Docs For Policy Changes

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/NOTES.txt
+++ b/charts/aws-ebs-csi-driver/templates/NOTES.txt
@@ -2,6 +2,4 @@ To verify that aws-ebs-csi-driver has started, run:
 
     kubectl get pod -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "aws-ebs-csi-driver.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
-The "a1CompatibilityDaemonSet" parameter has been removed. For more information see the EBS CSI Helm Chart changelog:
-https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/CHANGELOG.md#2550
-
+Two new AWS-managed IAM policies are available: AmazonEBSCSIDriverPolicyV2 scopes the EBS CSI driver to volumes and snapshots explicitly tagged for use by the driver. AmazonEBSCSIDriverEKSClusterScopedPolicy scopes the driver to volumes and snapshots belonging to a specific EKS cluster. If interested in migrating, see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2918.

--- a/docs/AmazonEBSCSIDriverEKSClusterScopedPolicy.json
+++ b/docs/AmazonEBSCSIDriverEKSClusterScopedPolicy.json
@@ -1,0 +1,188 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadOnlyDescribeOperations",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CreateAndCopyVolumesWithClusterTag",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "CopyClusterVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/vol-*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSnapshotsWithClusterTag",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSnapshotsFromClusterVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "ManageClusterVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "CreateVolumesFromAndEnableFSROnClusterSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:EnableFastSnapshotRestores"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "AttachDetachVolumesToClusterInstance",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:DetachVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/eks:cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "AttachDetachVolumesToManuallyTaggedInstance",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:DetachVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "DeleteAndLockClusterSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot",
+        "ec2:LockSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        }
+      }
+    },
+    {
+      "Sid": "TagResourcesOnCreation",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot",
+            "CopyVolumes"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "ModifyTagsOnClusterVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster-name": "${aws:PrincipalTag/eks-cluster-name}"
+        },
+        "Null": {
+          "aws:TagKeys": "false"
+        },
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": [
+            "ebs.csi.aws.com/cluster",
+            "ebs.csi.aws.com/cluster-name",
+            "kubernetes.io/created-for/pvc/name"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/AmazonEBSCSIDriverPolicyV2.json
+++ b/docs/AmazonEBSCSIDriverPolicyV2.json
@@ -1,0 +1,198 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadOnlyDescribeOperations",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CreateAndCopyVolumesWithManagedTag",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CopyManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/vol-*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CopyCSIMigratedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/vol-*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSnapshotsWithManagedTag",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSnapshotsFromManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "ManageManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "ManageCSIMigratedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
+        }
+      }
+    },
+    {
+      "Sid": "CreateVolumesFromAndEnableFSROnManagedSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:EnableFastSnapshotRestores"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "AttachDetachVolumesToAnyInstance",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:DetachVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:instance/*"
+    },
+    {
+      "Sid": "DeleteAndLockManagedSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot",
+        "ec2:LockSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Sid": "TagResourcesOnCreation",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot",
+            "CopyVolumes"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "ModifyTagsOnManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        },
+        "Null": {
+          "aws:TagKeys": "false"
+        },
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": [
+            "ebs.csi.aws.com/cluster",
+            "ebs.csi.aws.com/cluster-name",
+            "kubernetes.io/created-for/pvc/name"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/docs/example-iam-policy.json
+++ b/docs/example-iam-policy.json
@@ -168,7 +168,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:DeleteSnapshot"
+        "ec2:DeleteSnapshot",
+        "ec2:LockSnapshot"
       ],
       "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {
@@ -180,7 +181,8 @@
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:DeleteSnapshot"
+        "ec2:DeleteSnapshot",
+        "ec2:LockSnapshot"
       ],
       "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,9 +54,17 @@ To enable this metadata source:
 > [!NOTE]  
 > The example policy and documentation below use the [`aws` partition in ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html). When installing the EBS CSI Driver on other partitions, replace instances of `arn:aws:` with the local partition, such as `arn:aws-us-gov:` for AWS GovCloud.
 
-The driver requires IAM permissions to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./example-iam-policy.json) defines these permissions. AWS maintains a [managed policy version of the example policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEBSCSIDriverPolicy.html), available at ARN `arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy`.
+The driver requires IAM permissions to talk to Amazon EBS to manage the volume on user's behalf. [The example policy here](./AmazonEBSCSIDriverPolicyV2.json) defines these permissions. AWS maintains a [managed policy version of the example policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEBSCSIDriverPolicyV2.html), available at ARN `arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicyV2`.
 
-The baseline example policy excludes permissions for some rarer and potentially dangerous usecases. For these usecases, additional statements are necessary:
+The baseline example policy scopes permissions to volumes and snapshots crated by the EBS CSI Driver. Review the following if this affects your workflow:
+
+<details>
+<summary>Static provisioning (importing externally-created volumes or snapshots)</summary>
+<br>
+<code>AmazonEBSCSIDriverPolicyV2</code> scopes permissions to volumes and snapshots tagged with <code>ebs.csi.aws.com/cluster: true</code>. The driver automatically applies this tag to dynamically provisioned resources. If you use <a href="https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/examples/kubernetes/static-provisioning">static provisioning</a> (i.e. importing externally-created EBS volumes or snapshots), you must manually tag those resources with <code>ebs.csi.aws.com/cluster: true</code> for the driver to manage them. For more details, see <a href="https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2918">the announcement</a>.
+</details>
+
+The baseline example policy also excludes permissions for some rarer and potentially dangerous usecases. For these usecases, additional statements are necessary:
 
 <details>
 <summary>Encrypted EBS Volumes via KMS</summary>


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What is this PR about? / Why do we need it?

Updating documentations to point to `AmazonEBSCSIDriverPolicyV2` in place of `AmazonEBSCSIDriverPolicy`. 

#### Test

```
> make cluster/image && make cluster/install

[...cut for brevity] 
DESCRIPTION: Install complete
NOTES:
To verify that aws-ebs-csi-driver has started, run:

    kubectl get pod -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver,app.kubernetes.io/instance=aws-ebs-csi-driver"

Two new AWS-managed IAM policies are available: AmazonEBSCSIDriverPolicyV2 scopes the EBS CSI driver to volumes and snapshots explicitly tagged for use by the driver. AmazonEBSCSIDriverEKSClusterScopedPolicy scopes the driver to volumes and snapshots belonging to a specific EKS cluster. If interested in migrating, see https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2918.
+ set +x
###
## Sucessfully installed driver via helm
#
```

<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
