### PR TITLE
Adding E2E CI Job Targeting Oldest Supported EKS Version

### DIFF
--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -49,6 +49,24 @@ test-e2e-external-eks)
   TEST="external"
   export CLUSTER_TYPE="eksctl"
   ;;
+test-e2e-external-eks-oldest)
+  TEST="external"
+  export CLUSTER_TYPE="eksctl"
+  OLDEST_EKS_VERSION=$(aws eks describe-cluster-versions \
+    --region "${AWS_REGION:-us-west-2}" \
+    --cluster-type eks \
+    --output json |
+    jq -r '[.clusterVersions[]
+            | select(.versionStatus == "STANDARD_SUPPORT" or .versionStatus == "EXTENDED_SUPPORT")
+            | .clusterVersion]
+           | sort_by(split(".") | map(tonumber))
+           | .[0] // empty')
+  if [[ -z "${OLDEST_EKS_VERSION}" ]]; then
+    echo "Failed to resolve the oldest supported EKS Kubernetes version from the EKS API" >&2
+    exit 1
+  fi
+  export K8S_VERSION_EKSCTL="${OLDEST_EKS_VERSION}"
+  ;;
 test-e2e-external-eks-bottlerocket)
   TEST="external-eks-bottlerocket"
   export CLUSTER_TYPE="eksctl"


### PR DESCRIPTION
#### What type of PR is this?

Adding CI Test

#### What is this PR about? / Why do we need it?

This PR adds a CI job that pins to the oldest currently supported EKS Kubernetes version. It will be followed by a PR in the test-infra repo. 

#### How was this change tested?

Created EKS 1.30 Cluster and then ran: 
```
make e2e/external
```

To test full test (create cluster...etc) run: 
```
make test-e2e-external-eks-oldest
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
