### PR TITLE
Fix possible nil pointer deref on clones path

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -375,12 +375,12 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if volumeID != "" {
 		sourceVolume, err := d.cloud.GetDiskByID(ctx, volumeID)
 
-		if kmsKeyID != "" && sourceVolume.KmsKeyID != kmsKeyID {
-			return nil, status.Errorf(codes.InvalidArgument, "Cannot provision clone with different KMS key than source volume")
-		}
-
 		if err != nil {
 			return nil, status.Errorf(codes.NotFound, "Error source volume with volumeID %v not found: %v", volumeID, err)
+		}
+
+		if kmsKeyID != "" && sourceVolume.KmsKeyID != kmsKeyID {
+			return nil, status.Errorf(codes.InvalidArgument, "Cannot provision clone with different KMS key than source volume")
 		}
 
 		err = checkSourceTopology(req.GetAccessibilityRequirements(), sourceVolume.AvailabilityZone, sourceVolume.OutpostArn, sourceVolume.AvailabilityZoneID)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug 
#### What is this PR about? / Why do we need it?
This change ensures the source volume exists before checking its properties to avoid a nil pointer deference when the source volume does not exist.
#### How was this change tested?
CI
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Fix possible nil pointer deref on clones path
```
