### PR TITLE
Add mutex to MetricRecorder

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -56,6 +56,7 @@ var (
 
 type MetricRecorder struct {
 	registry        *prometheus.Registry
+	mu              sync.RWMutex
 	metrics         map[string]any
 	asyncEC2Metrics *AsyncEC2Collector
 }
@@ -128,7 +129,9 @@ func (m *MetricRecorder) IncreaseCount(name string, helpText string, labels map[
 		return // recorder is not initialized
 	}
 
+	m.mu.RLock()
 	metric, ok := m.metrics[name]
+	m.mu.RUnlock()
 
 	if !ok {
 		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels)
@@ -150,7 +153,10 @@ func (m *MetricRecorder) ObserveHistogram(name string, helpText string, value fl
 	if m == nil {
 		return // recorder is not initialized
 	}
+
+	m.mu.RLock()
 	metric, ok := m.metrics[name]
+	m.mu.RUnlock()
 
 	if !ok {
 		klog.V(4).InfoS("Metric not found, registering", "name", name, "labels", labels, "buckets", buckets)
@@ -214,6 +220,8 @@ func (m *MetricRecorder) InitializeMetricsHandler(address, path, certFile, keyFi
 }
 
 func (m *MetricRecorder) registerHistogramVec(name, help string, labels []string, buckets []float64) *prometheus.HistogramVec {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if metric, exists := m.metrics[name]; exists {
 		if histogramVec, ok := metric.(*prometheus.HistogramVec); ok {
 			return histogramVec
@@ -235,6 +243,8 @@ func (m *MetricRecorder) registerHistogramVec(name, help string, labels []string
 }
 
 func (m *MetricRecorder) registerCounterVec(name, help string, labels []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if _, exists := m.metrics[name]; exists {
 		return
 	}
@@ -258,11 +268,18 @@ func getLabelNames(labels map[string]string) []string {
 }
 
 func (m *MetricRecorder) initializeMetricWithOperations(name, help string, labelNames []string) {
-	if _, exists := m.metrics[name]; !exists {
-		metric := m.registerHistogramVec(name, help, labelNames, nil)
-		for _, op := range operations {
-			metric.WithLabelValues(op)
-		}
+	m.mu.RLock()
+	_, exists := m.metrics[name]
+	m.mu.RUnlock()
+	if exists {
+		return
+	}
+	metric := m.registerHistogramVec(name, help, labelNames, nil)
+	if metric == nil {
+		return
+	}
+	for _, op := range operations {
+		metric.WithLabelValues(op)
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -15,9 +15,12 @@
 package metrics
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/component-base/metrics/testutil"
 )
 
@@ -89,6 +92,27 @@ test_re_register_total{key="value2"} 1
 			}
 		})
 	}
+}
+
+func TestMetricRecorderConcurrentAccess(t *testing.T) {
+	m := &MetricRecorder{
+		registry: prometheus.NewRegistry(),
+		metrics:  make(map[string]any),
+	}
+
+	const goroutines = 2
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			labels := map[string]string{"k": fmt.Sprintf("v%d", id)}
+			m.IncreaseCount("concurrent_counter", "help", labels)
+			m.ObserveHistogram("concurrent_hist", "help", float64(id), labels, []float64{1, 5, 10})
+			m.initializeMetricWithOperations("concurrent_op", "help", []string{"request"})
+		}(i)
+	}
+	wg.Wait()
 }
 
 func getMetricNameFromExpected(expected string) string {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/king bug
#### What is this PR about? / Why do we need it?
Added a mutex to the metrics recorder to prevent concurrent writing to metrics map
#### How was this change tested?
Added temp concurrency test 

```
 package metrics

  import (
        "fmt"
        "sync"
        "testing"

        "github.com/prometheus/client_golang/prometheus"
  )

  func TestRaceRepro(t *testing.T) {
        m := &MetricRecorder{
                registry: prometheus.NewRegistry(),
                metrics:  make(map[string]any),
        }

        const goroutines = 16
        const iterations = 100
        var wg sync.WaitGroup
        wg.Add(goroutines)
        for i := range goroutines {
                go func(id int) {
                        defer wg.Done()
                        for j := range iterations {
                                name := fmt.Sprintf("repro_counter_%d", j%4)
                                m.IncreaseCount(name, "help", map[string]string{"k": fmt.Sprintf("v%d", id)})
                                hist := fmt.Sprintf("repro_hist_%d", j%4)
                                m.ObserveHistogram(hist, "help", float64(j), map[string]string{"k": fmt.Sprintf("v%d", id)}, []float64{1, 5, 10})
                        }
                }(i)
        }
        wg.Wait()
  }
  
```

Confirmed this fails on master and passes with my fix.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add mutex to MetricRecorder to prevent crashes caused by concurrent access
```
