### PR TITLE
Migrate to runtime FIPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,24 +22,28 @@ COPY . .
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION
-ARG GOEXPERIMENT
-RUN --mount=type=cache,target=/gomodcache --mount=type=cache,target=/gocache OS=$TARGETOS ARCH=$TARGETARCH make
+ARG GOFIPS140=certified
+RUN --mount=type=cache,target=/gomodcache --mount=type=cache,target=/gocache OS=$TARGETOS ARCH=$TARGETARCH GOFIPS140=$GOFIPS140 make
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-csi-ebs:latest-al23@sha256:e33392c257e8aa3b08275372bf7ab88c3faee88f12bc5e25c35e2e34b1ba895c AS linux-al2023
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /bin/aws-ebs-csi-driver
+ENV GODEBUG=fips140=off
 ENTRYPOINT ["/bin/aws-ebs-csi-driver"]
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:1809@sha256:78a645ac8b05b75f161c58bce251f5208a2a30c41f2b7b49f9f47a585070a47b AS windows-ltsc2019
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENV PATH="C:\\Windows\\System32\\WindowsPowerShell\\v1.0;${PATH}"
+ENV GODEBUG=fips140=off
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:ltsc2022@sha256:b7eeed7c903d0eedb52aeaa1057eac1dc46cc543eab698d41507f753c2aa7548 AS windows-ltsc2022
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENV PATH="C:\\Windows\\System32\\WindowsPowerShell\\v1.0;${PATH}"
+ENV GODEBUG=fips140=off
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]
 
 FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-windows-base:ltsc2025@sha256:d352efedbc8ac1346e3747f9df14bae87d04c431b521656fcbd57859122640fc AS windows-ltsc2025
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver.exe /aws-ebs-csi-driver.exe
 ENV PATH="C:\\Windows\\System32\\WindowsPowerShell\\v1.0;${PATH}"
+ENV GODEBUG=fips140=off
 ENTRYPOINT ["/aws-ebs-csi-driver.exe"]

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,6 @@ else
 	BINARY=aws-ebs-csi-driver
 	OSVERSION?=al2023
 endif
-FIPS?=false
-ifeq ($(FIPS),true)
-	FIPS_DOCKER_ARGS=--build-arg=GOEXPERIMENT=boringcrypto
-endif
 
 GO_SOURCES=go.mod go.sum $(shell find pkg cmd -type f -name "*.go")
 
@@ -249,12 +245,8 @@ security: bin/govulncheck
 .PHONY: sub-push
 sub-push: all-image-registry push-manifest
 
-.PHONY: sub-push-fips
-sub-push-fips:
-	$(MAKE) FIPS=true TAG=$(TAG)-fips sub-push
-
 .PHONY: all-push
-all-push: sub-push sub-push-fips
+all-push: sub-push
 
 test-e2e-%:
 	./hack/prow-e2e.sh test-e2e-$*
@@ -272,7 +264,7 @@ bin:
 	@mkdir -p $@
 
 bin/$(BINARY): $(GO_SOURCES) | bin
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -mod=readonly -ldflags ${LDFLAGS} -o $@ ./cmd/
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) GOFIPS140=$(GOFIPS140) go build -mod=readonly -ldflags ${LDFLAGS} -o $@ ./cmd/
 
 .PHONY: all-image-registry
 all-image-registry: $(addprefix sub-image-,$(ALL_OS_ARCH_OSVERSION))
@@ -290,7 +282,7 @@ image:
 		-t=$(IMAGE):$(TAG)-$(OS)-$(ARCH)-$(OSVERSION) \
 		--build-arg=GOPROXY=$(GOPROXY) \
 		--build-arg=VERSION=$(VERSION) \
-		$(FIPS_DOCKER_ARGS) \
+		--build-arg=GOFIPS140=$(GOFIPS140) \
 		$(DOCKER_EXTRA_ARGS) \
 		.
 

--- a/charts/aws-ebs-csi-driver/templates/_helpers.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Determine image
 */}}
 {{- define "aws-ebs-csi-driver.fullImagePath" -}}
-{{ printf "%s%s:%s%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) (.Values.fips | ternary "-fips" "") }}
+{{ printf "%s%s:%s" (default "" .Values.image.containerRegistry) .Values.image.repository (default (printf "v%s" .Chart.AppVersion) (.Values.image.tag | toString)) }}
 {{- end -}}
 
 {{/*

--- a/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node-windows.tpl
@@ -122,6 +122,8 @@ spec:
             {{- if .Values.fips }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
+            - name: GODEBUG
+              value: "fips140=on"
             {{- end }}
             {{- if .Values.node.serviceAccount.disableMutation }}
             - name: DISABLE_TAINT_WATCHER

--- a/charts/aws-ebs-csi-driver/templates/_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_node.tpl
@@ -122,6 +122,8 @@ spec:
             {{- if .Values.fips }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
+            - name: GODEBUG
+              value: "fips140=on"
             {{- end }}
             {{- if .Values.node.serviceAccount.disableMutation }}
             - name: DISABLE_TAINT_WATCHER

--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -166,6 +166,8 @@ spec:
             {{- if .Values.fips }}
             - name: AWS_USE_FIPS_ENDPOINT
               value: "true"
+            - name: GODEBUG
+              value: "fips140=on"
             {{- end }}
           {{- with .Values.controller.envFrom }}
           envFrom:

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -118,7 +118,7 @@
     },
     "fips": {
       "type": "boolean",
-      "description": "Instruct the AWS SDK to use AWS FIPS endpoints, and deploy container built with BoringCrypto (a FIPS-validated cryptographic library) instead of the Go default. The EBS CSI Driver FIPS images have not undergone FIPS certification, and no official guarantee is made about the compliance of these images under the FIPS standard. Users relying on these images for FIPS compliance should perform their own independent evaluation",
+      "description": "Enable FIPS 140-3 mode: activates the Go Cryptographic Module (CMVP #5247) at runtime via GODEBUG=fips140=on, and instructs the AWS SDK to use FIPS endpoints via AWS_USE_FIPS_ENDPOINT. See docs/fips.md for details.",
       "default": "false"
     },
     "debugLogs": {

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -11,10 +11,9 @@ image:
 customLabels: {}
 # k8s-app: aws-ebs-csi-driver
 
-# Instruct the AWS SDK to use AWS FIPS endpoints, and deploy container built with Boring Crypto (a FIPS-validated cryptographic library) instead of the Go default
-#
-# The EBS CSI Driver FIPS images have not undergone FIPS certification, and no official guarantee is made about the compliance of these images under the FIPS standard
-# Users relying on these images for FIPS compliance should perform their own independent evaluation
+# Enable FIPS 140-3 mode: activates the Go Cryptographic Module (CMVP #5247) at runtime and
+# instructs the AWS SDK to use FIPS endpoints via AWS_USE_FIPS_ENDPOINT.
+# See docs/fips.md for details.
 fips: false
 sidecars:
   provisioner:

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -1,15 +1,41 @@
-# EBS CSI Driver FIPS Support
+# EBS CSI Driver FIPS 140-3 Support
 
-## Support
+## Overview
 
-The EBS CSI Driver Helm chart can be configured to enable two modifications to better support environments that require FIPS certification. Both of these modifications are activated by changing the Helm parameter `fips` from `false` to `true`.
+The EBS CSI Driver is built with Go's native FIPS 140-3 cryptographic module ([CMVP Certificate #5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247)). FIPS mode is disabled by default and can be activated at runtime without requiring a separate image.
 
-### FIPS Endpoints
+## Enabling FIPS Mode
 
-The AWS SDK will be instructed to use FIPS endpoints [via the `AWS_USE_FIPS_ENDPOINT` environment variable](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoints.html). FIPS endpoints are only supported in some regions, and thus the option will only work in regions that have both an STS and EC2 FIPS endpoint available. For a full list of current regions with FIPS endpoints available, see [the FIPS section of the AWS documentation](https://aws.amazon.com/compliance/fips/).
+### Helm
 
-### FIPS Image
+Set `fips: true` in your Helm values. This activates two things:
 
-The EBS CSI Driver image will be swapped with an image built using BoringCrypto as Go's cryptographic library. BoringCrypto has [an active FIPS 140-3 certification](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4735).
+1. **FIPS cryptography** via `GODEBUG=fips140=on`, which enables the Go Cryptographic Module's FIPS 140-3 mode (integrity checks, approved-only algorithms in `crypto/tls`, DRBG-backed `crypto/rand`).
+2. **FIPS endpoints** via `AWS_USE_FIPS_ENDPOINT=true`, which instructs the AWS SDK to use FIPS-validated API endpoints.
 
-The EBS CSI Driver FIPS images have not undergone FIPS certification, and no official guarantee is made about the compliance of these images under the FIPS standard. Users relying on these images for FIPS compliance should perform their own independent evaluation.
+FIPS endpoints are only available in some regions. See [AWS FIPS documentation](https://aws.amazon.com/compliance/fips/) for regional availability.
+
+### Kustomize
+
+Add the following environment variables to the controller and node DaemonSet containers:
+
+```yaml
+env:
+  - name: GODEBUG
+    value: "fips140=on"
+  - name: AWS_USE_FIPS_ENDPOINT
+    value: "true"
+```
+
+## How It Works
+
+The driver binary is compiled with `GOFIPS140=certified`, which embeds Go's certified FIPS 140-3 cryptographic module. The Dockerfile sets `GODEBUG=fips140=off` by default, so FIPS mode remains inactive unless explicitly enabled via the pod environment.
+
+When FIPS mode is active:
+- The cryptographic module performs integrity self-checks and known-answer tests at startup
+- `crypto/tls` restricts connections to FIPS-approved cipher suites and protocol versions
+- `crypto/rand` uses a NIST SP 800-90A Rev 1 DRBG
+
+## Disclaimer
+
+The EBS CSI Driver itself has not undergone FIPS certification. No official guarantee is made about the compliance of this software under the FIPS standard. Users relying on this for FIPS compliance should perform their own independent evaluation.

--- a/hack/e2e/build-image.sh
+++ b/hack/e2e/build-image.sh
@@ -68,13 +68,7 @@ function build_and_push() {
     export ALL_ARCH_linux="${IMAGE_ARCH}"
   fi
 
-  PUSH_TYPE="sub-push"
-
-  if [[ "${FIPS_TEST}" == "true" ]]; then
-    PUSH_TYPE="sub-push-fips"
-  fi
-
-  make -j $(nproc) ${PUSH_TYPE}
+  make -j $(nproc) sub-push
 
   loudecho "Image pushed to ${IMAGE_NAME}:${IMAGE_TAG}"
 }

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -38,8 +38,6 @@ AMI_FAMILY=${AMI_FAMILY:-"AmazonLinux2023"}
 WINDOWS_HOSTPROCESS=${WINDOWS_HOSTPROCESS:-"false"}
 OUTPOST_ARN=${OUTPOST_ARN:-}
 OUTPOST_INSTANCE_TYPE=${OUTPOST_INSTANCE_TYPE:-${INSTANCE_TYPE}}
-FIPS_TEST=${FIPS_TEST:-"false"}
-
 # kops: must include patch version (e.g. 1.19.1)
 # eksctl: mustn't include patch version (e.g. 1.19)
 K8S_VERSION_KOPS=${K8S_VERSION_KOPS:-1.36.1}

--- a/hack/e2e/test-images.sh
+++ b/hack/e2e/test-images.sh
@@ -65,7 +65,7 @@ build_and_push "${AWS_REGION}" \
   "${IMAGE_TAG}" \
   "${IMAGE_ARCH}"
 
-imageSuffixes=("fips-windows-amd64-ltsc2022 fips-windows-amd64-ltsc2019 fips-windows-amd64-ltsc2025 windows-amd64-ltsc2019 windows-amd64-ltsc2022 windows-amd64-ltsc2025 fips-linux-amd64-al2023 fips-linux-arm64-al2023 linux-amd64-al2023 linux-arm64-al2023")
+imageSuffixes=("windows-amd64-ltsc2019 windows-amd64-ltsc2022 windows-amd64-ltsc2025 linux-amd64-al2023 linux-arm64-al2023")
 
 loudecho "Ensuring all images are present"
 
@@ -79,10 +79,6 @@ done
 loudecho "Ensuring image indexes have all images"
 if [ ! "$(docker manifest inspect ${IMAGE}:${TAG} | jq ".manifests[3].platform")" ]; then
   loudecho "Error index image is missing images"
-  exit 1
-fi
-if [ ! "$(docker manifest inspect ${IMAGE}:${TAG}-fips | jq ".manifests[3].platform")" ]; then
-  loudecho "Error fips index image is missing images"
   exit 1
 fi
 

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -37,7 +37,6 @@ test-e2e-external)
   ;;
 test-e2e-external-fips)
   TEST="external-fips"
-  export FIPS_TEST="true"
   ;;
 test-e2e-external-arm64)
   TEST="external"
@@ -79,7 +78,6 @@ test-e2e-external-eks-windows)
   ;;
 test-e2e-external-eks-windows-fips)
   TEST="external-windows-fips"
-  export FIPS_TEST="true"
   export CLUSTER_TYPE="eksctl"
   export WINDOWS="true"
   ;;

--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -551,17 +551,13 @@ func TestGetNextCardIndex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := getNextCardIndex(tc.numCards, tc.cardCounts)
 
-			if tc.expectedCardIndex == nil {
-				if result != nil {
-					t.Fatalf("Expected nil card index, got %v", *result)
-				}
-			} else {
-				if result == nil {
-					t.Fatalf("Expected card index %v, got nil", *tc.expectedCardIndex)
-				}
-				if *result != *tc.expectedCardIndex {
-					t.Fatalf("Expected card index %v, got %v", *tc.expectedCardIndex, *result)
-				}
+			switch {
+			case tc.expectedCardIndex == nil && result != nil:
+				t.Fatalf("Expected nil card index, got %v", *result)
+			case tc.expectedCardIndex != nil && result == nil:
+				t.Fatalf("Expected card index %v, got nil", *tc.expectedCardIndex)
+			case tc.expectedCardIndex != nil && result != nil && *result != *tc.expectedCardIndex:
+				t.Fatalf("Expected card index %v, got %v", *tc.expectedCardIndex, *result)
 			}
 		})
 	}

--- a/tests/e2e/parameter_tests.go
+++ b/tests/e2e/parameter_tests.go
@@ -294,19 +294,32 @@ echo "PASS: reflink is disabled on /mnt/test-1"
 		Expect(ds.Status.DesiredNumberScheduled).To(BeNumerically(">", 0))
 	})
 
-	It("[param:fips] should use FIPS-compliant image", func() {
+	It("[param:fips] should enable FIPS mode via container environment", func() {
+		// FIPS is a runtime toggle: the driver ships a single image built with
+		// GOFIPS140=certified, and fips=true activates the Go FIPS 140-3 module
+		// via GODEBUG=fips140=on plus AWS FIPS endpoints. There is no separate
+		// -fips image to assert on.
 		pods, err := cs.CoreV1().Pods(ebsNamespace).List(context.Background(), metav1.ListOptions{
 			LabelSelector: controllerLabel,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pods.Items).NotTo(BeEmpty())
+		var foundPlugin bool
 		for _, pod := range pods.Items {
 			for _, c := range pod.Spec.Containers {
-				if c.Name == ebsPluginContainer {
-					Expect(c.Image).To(ContainSubstring("fips"), "Controller should use FIPS image")
+				if c.Name != ebsPluginContainer {
+					continue
 				}
+				foundPlugin = true
+				env := map[string]string{}
+				for _, e := range c.Env {
+					env[e.Name] = e.Value
+				}
+				Expect(env).To(HaveKeyWithValue("GODEBUG", "fips140=on"), "ebs-plugin should run with GODEBUG=fips140=on to activate the FIPS 140-3 module")
+				Expect(env).To(HaveKeyWithValue("AWS_USE_FIPS_ENDPOINT", "true"), "ebs-plugin should use AWS FIPS endpoints")
 			}
 		}
+		Expect(foundPlugin).To(BeTrue(), "controller pod should have an ebs-plugin container")
 	})
 
 	It("[param:metadataLabeler] should label nodes with EBS volume and ENI counts", func() {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Migrate to runtime-based FIPS, see https://go.dev/doc/security/fips140

In order to do this, we do the following:
- Build with `GOFIPS140=certified`. This ensures we get the latest FIPS library that is certified, regardless of Go version.
- The above auto-enables FIPS in the built images. To avoid this, we turn it back off by default with `GODEBUG=fips140=off` in the `Dockerfile`.
- Change the `fips` Helm parameter to enable the FIPS library via `GODEBUG=fips140=on` (instead of swapping out the image like we did previously).
- Updated the docs to document the above (also added a short section on how to make the relevant changes in Kustomize).

#### How was this change tested?

`make e2e/external-fips` and similar

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
WIP
```
