### PR TITLE
Add additional volumeMounts config to volumemodifier controller sidecar

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/controller.yaml
@@ -481,6 +481,9 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          {{- with .Values.sidecars.volumemodifier.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.controller.enableMetrics }}
           ports:
             - name: metrics-volmod

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -1221,6 +1221,11 @@
                 }
               }
             },
+            "volumeMounts": {
+              "type": "array",
+              "description": "Add additional volume mounts on the volumemodifier container",
+              "default": []
+            },
             "securityContext": {
               "type": "object"
             }

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -180,6 +180,11 @@ sidecars:
     # Additional parameters provided by volume-modifier-for-k8s.
     additionalArgs: []
     resources: {}
+    # Add additional volume mounts on the volumemodifier container with sidecars.volumemodifier.volumeMounts
+    volumeMounts: []
+    # And add mount paths for those additional volumes:
+    # - name: custom-dir
+    #   mountPath: /mount/path
     securityContext:
       seccompProfile:
         type: RuntimeDefault

--- a/tests/helm-template/infra_test.go
+++ b/tests/helm-template/infra_test.go
@@ -543,6 +543,7 @@ func TestDebug(t *testing.T) {
 
 func TestMiscellaneous(t *testing.T) {
 	resources := renderChart(t, "miscellaneous")
+	want := loadValuesMap(t, "miscellaneous")
 	controller := mustFind(t, resources, "Deployment", "ebs-csi-controller")
 	cPS := podSpec(t, controller)
 
@@ -567,6 +568,25 @@ func TestMiscellaneous(t *testing.T) {
 		c := findContainer(t, cPS, "volumemodifier")
 		if !hasArg(c, "--leader-election=false") {
 			t.Error("volumemodifier should have --leader-election=false")
+		}
+	})
+
+	t.Run("volumemodifierVolumeMounts", func(t *testing.T) {
+		wantMounts, _ := want["sidecars"].(obj)["volumemodifier"].(obj)["volumeMounts"].([]interface{})
+		c := findContainer(t, cPS, "volumemodifier")
+		mounts := nestedSlice(t, c, "volumeMounts")
+		for _, wm := range wantMounts {
+			wmObj := wm.(obj)
+			var found bool
+			for _, m := range mounts {
+				mm := m.(obj)
+				if mm["name"] == wmObj["name"] && mm["mountPath"] == wmObj["mountPath"] {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("volumemodifier should have mount %v at %v", wmObj["name"], wmObj["mountPath"])
+			}
 		}
 	})
 

--- a/tests/helm-template/testdata/miscellaneous.yaml
+++ b/tests/helm-template/testdata/miscellaneous.yaml
@@ -15,6 +15,10 @@
 controller:
   volumeModificationFeature:
     enabled: true
+  volumes:
+    - name: extra-volume
+      configMap:
+        name: kube-root-ca.crt
 node:
   volumeAttachLimit: 25
   metadataSources: metadata-labeler
@@ -29,6 +33,9 @@ sidecars:
     logLevel: 5
     leaderElection:
       enabled: false
+    volumeMounts:
+      - name: extra-volume
+        mountPath: /extra
   metadataLabeler:
     enabled: true
     logLevel: 5


### PR DESCRIPTION
#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?
In my deployment environment I have a custom AWS CA bundle that all my workloads require in order to avoid x509 CA errors when hitting AWS endpoints.

I am already able to do this for the controller container via `.Values.controller.volumeMounts` which allows my EBS volumes to be created successfully. However when I include `ebs.csi.aws.com/*` annotations, the EBS volume is unable to be modified.

#### How was this change tested?
I mounted my AWS CA bundle to the volumemodifier container and could confirm my EBS volumes were successfully modified according to my PVC's annotations.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Adds support for `.Values.sidecars.volumemodifier.volumeMounts` to enable user-specified volume mounts for the volumemodifier container.
```
