### PR TITLE
Add plugin method to override health check

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -2186,8 +2186,23 @@ func (c *cloud) EnableFastSnapshotRestores(ctx context.Context, availabilityZone
 }
 
 // DryRun will make a dry-run EC2 API call. Nil return value means we successfully received EC2 DryRunOperation error code.
+//
+// If a plugin is loaded, its HealthCheck result is incorporated: an unhealthy
+// plugin fails the check, and a plugin may opt to skip the driver's own
+// dry-run entirely (e.g. when its EC2 client uses credentials the dry-run
+// should not be issued against). See the EbsCsiPlugin interface for details.
 func (c *cloud) DryRun(ctx context.Context) error {
 	if c.attemptDryRun.Load() {
+		if p := plugin.GetPlugin(); p != nil {
+			skipDriverHealthCheck, pluginErr := p.HealthCheck()
+			if pluginErr != nil {
+				return fmt.Errorf("plugin unhealthy: %w", pluginErr)
+			} else if skipDriverHealthCheck {
+				c.attemptDryRun.Store(false)
+				return nil
+			}
+		}
+
 		// Rely on EC2 DAZ because it is required in ebs controller IAM role, but not in instance default role.
 		_, apiErr := c.ec2.DescribeAvailabilityZones(ctx,
 			&ec2.DescribeAvailabilityZonesInput{DryRun: aws.Bool(true)},

--- a/pkg/plugin/plugin_clients.go
+++ b/pkg/plugin/plugin_clients.go
@@ -28,6 +28,16 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	"github.com/kubernetes-sigs/aws-ebs-csi-driver/pkg/util"
+)
+
+// Compile-time assertions that the client bases fully implement the driver's
+// API interfaces. These ensure that if a new method is added to EC2API or
+// SageMakerAPI, the corresponding stub is added here too (so plugins embedding
+// these bases continue to compile).
+var (
+	_ util.EC2API       = &ec2ClientBase{}
+	_ util.SageMakerAPI = &sageMakerClientBase{}
 )
 
 // ec2ClientBase implements stub functionality for EC2API. It can be used
@@ -111,6 +121,12 @@ func (b *ec2ClientBase) DeleteTags(ctx context.Context, params *ec2.DeleteTagsIn
 }
 func (b *ec2ClientBase) EnableFastSnapshotRestores(ctx context.Context, params *ec2.EnableFastSnapshotRestoresInput, optFns ...func(*ec2.Options)) (*ec2.EnableFastSnapshotRestoresOutput, error) {
 	return b.client.EnableFastSnapshotRestores(ctx, params, optFns...)
+}
+func (b *ec2ClientBase) LockSnapshot(ctx context.Context, params *ec2.LockSnapshotInput, optFns ...func(*ec2.Options)) (*ec2.LockSnapshotOutput, error) {
+	return b.client.LockSnapshot(ctx, params, optFns...)
+}
+func (b *ec2ClientBase) DescribeInstanceTypes(ctx context.Context, params *ec2.DescribeInstanceTypesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
+	return b.client.DescribeInstanceTypes(ctx, params, optFns...)
 }
 
 // SagmeMakerAPI stub functions.

--- a/pkg/plugin/plugin_common.go
+++ b/pkg/plugin/plugin_common.go
@@ -69,6 +69,14 @@ type EbsCsiPlugin interface {
 	// GetSageMakerClient replaces the AWS SageMaker client the driver uses
 	GetSageMakerClient(cfg aws.Config, optFns ...func(*sagemaker.Options)) util.SageMakerAPI
 
+	// HealthCheck supplements or overrides the controller's periodic health check.
+	//
+	// When the driver is about to perform a health check, the plugin's HealthCheck is called first.
+	// If skipDriverHealthCheck is true, the driver's health check will be skipped (assumed healthy).
+	// If the plugin returns a non-nil value for err, the driver's health check will fail with the
+	// returned error. On node-mode drivers, this function currently has no effect.
+	HealthCheck() (skipDriverHealthCheck bool, err error)
+
 	// GetDriverName replaces the driver name in use (normally "ebs.csi.aws.com")
 	// This function can be called before Init and should not depend on it
 	GetDriverName() string
@@ -98,6 +106,10 @@ func (p *ebsCsiPluginBase) GetEC2Client(_ aws.Config, _ ...func(o *ec2.Options))
 
 func (p *ebsCsiPluginBase) GetSageMakerClient(_ aws.Config, _ ...func(o *sagemaker.Options)) util.SageMakerAPI {
 	return nil
+}
+
+func (p *ebsCsiPluginBase) HealthCheck() (bool, error) {
+	return false, nil
 }
 
 func (p *ebsCsiPluginBase) GetDriverName() string {


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Adds a new method to the plugin interface that allows plugins to:
- Provide their own health check data, allowing plugin health to be represented in the driver health; and
- Skip the driver health check (causing it to be assumed healthy) in cases where it shouldn't apply

Also adds some missing methods to `ec2ClientBase` that were not previously present, and adds a compile-time check to ensure the plugin client bases stay up to date with the interfaces going forward.

#### How was this change tested?

CI + Manually tested with a basic plugin

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Add plugin method to disable/override health check
```
