### PR TITLE
Fixing warn-on-invalid-tag validation bug

### DIFF
--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -61,6 +61,7 @@ func validateExtraTags(tags map[string]string, warnOnly bool) error {
 		if err != nil {
 			if warnOnly {
 				klog.InfoS("Skipping tag: the following key-value pair is not valid", "key", k, "value", v, "err", err)
+				delete(tags, k)
 			} else {
 				return err
 			}

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -108,6 +108,48 @@ func TestValidateExtraTags(t *testing.T) {
 	}
 }
 
+func TestValidateExtraTagsWarnOnly(t *testing.T) {
+	testCases := []struct {
+		name         string
+		tags         map[string]string
+		expectedTags map[string]string
+	}{
+		{
+			name: "valid tags are preserved",
+			tags: map[string]string{
+				"extra-tag-key": "extra-tag-value",
+			},
+			expectedTags: map[string]string{
+				"extra-tag-key": "extra-tag-value",
+			},
+		},
+		{
+			name: "reserved keys are removed",
+			tags: map[string]string{
+				cloud.VolumeNameTagKey:   "attacker-vol-name",
+				cloud.SnapshotNameTagKey: "attacker-snap-name",
+				ClusterNameTagKey:        "attacker-cluster",
+				"valid-key":              "valid-value",
+			},
+			expectedTags: map[string]string{
+				"valid-key": "valid-value",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExtraTags(tc.tags, true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(tc.tags, tc.expectedTags) {
+				t.Fatalf("tags not equal\ngot:\n%v\nexpected:\n%v", tc.tags, tc.expectedTags)
+			}
+		})
+	}
+}
+
 func TestValidateMode(t *testing.T) {
 	testCases := []struct {
 		name   string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What is this PR about? / Why do we need it?

The `validateExtraTags` function in `pkg/driver/validation.go` logs the tag violations and returns nil when `warnOnly=true`, but does not remove the invalid keys from the tag map. This allows for overriding values for driver-managed tags. This PR fixes this.

#### How was this change tested?

Added unit test to cover specific case.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
Disallow overriding driver-reserved tags when `--warn-on-invalid-tag` is `true`.
```
