### PR TITLE
Push Helm chart artifact to staging OCI registry on release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ vendor/
 # Files used by Makefile when upgrading sidecars
 hack/release-scripts/image-digests.yaml
 
+# Packaged Helm chart output (make helm-chart-push)
+artifacts/
+
 # E2E artifacts
 _rundir/
 _artifacts/

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,14 @@ create-manifest: all-image-registry
 push-manifest: create-manifest
 	docker manifest push --purge $(IMAGE):$(TAG)
 
+## Helm chart
+# Package the Helm chart and push it to the staging OCI registry.
+# Invoked by hack/cloudbuild.sh on helm-chart tags.
+
+.PHONY: helm-chart-push
+helm-chart-push: bin/helm
+	./hack/helm-chart-package.sh
+
 ## Tools
 # Tools necessary to perform other targets
 

--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -44,3 +44,10 @@ export IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
 export TAG=${GIT_TAG:10}
 export VERSION=$PULL_BASE_REF
 IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push
+
+# Push the Helm chart to the staging OCI registry when triggered by the
+# helm-chart tag that chart-releaser creates (e.g. helm-chart-aws-ebs-csi-driver-2.62.0).
+if [[ "${PULL_BASE_REF}" =~ ^helm-chart- ]]; then
+  loudecho "Push helm chart to staging GCR (${PULL_BASE_REF})"
+  make helm-chart-push
+fi

--- a/hack/helm-chart-package.sh
+++ b/hack/helm-chart-package.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Packages the Helm chart and pushes it to the staging OCI registry. Invoked by
+# the `helm-chart-push` Makefile target, which runs from hack/cloudbuild.sh when
+# triggered by a helm-chart tag (e.g. helm-chart-aws-ebs-csi-driver-2.62.0).
+
+set -euo pipefail
+
+BIN="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../bin"
+
+HELM=${HELM:-"${BIN}/helm"}
+CHART_DIR=${CHART_DIR:-charts/aws-ebs-csi-driver}
+DEST_CHART_DIR=${DEST_CHART_DIR:-artifacts}
+HELM_CHART_REPO=${HELM_CHART_REPO:-gcr.io/k8s-staging-provider-aws/charts}
+
+# The chart version is extracted from the helm-chart tag that triggered this
+# build (e.g. helm-chart-aws-ebs-csi-driver-2.62.0 -> 2.62.0). The tag is
+# created by chart-releaser-action.
+chart_version="${PULL_BASE_REF##helm-chart-aws-ebs-csi-driver-}"
+
+${HELM} package --version "${chart_version}" "${CHART_DIR}" -d "${DEST_CHART_DIR}"
+${HELM} push "${DEST_CHART_DIR}/aws-ebs-csi-driver-${chart_version}.tgz" "oci://${HELM_CHART_REPO}"

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -96,7 +96,11 @@ function install_tar_binary() {
     TAR_EXTRA_FLAGS=""
   fi
 
-  curl --location "${DOWNLOAD_URL}" | tar "$TAR_EXTRA_FLAGS" --extract --touch --transform "s/.*/${BINARY_NAME}/" -C "${INSTALL_PATH}" "${BINARY_PATH}"
+  # Extract the single binary to stdout and redirect it to the destination,
+  # rather than using GNU tar's --transform to rename in place. The release
+  # build image (gcb-docker-gcloud) ships BusyBox tar, which supports neither
+  # --transform nor --touch; -O (extract to stdout) is portable across both.
+  curl --location "${DOWNLOAD_URL}" | tar "$TAR_EXTRA_FLAGS" --extract -O "${BINARY_PATH}" >"${INSTALL_PATH}/${BINARY_NAME}"
   chmod +x "${INSTALL_PATH}/${BINARY_NAME}"
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/2828

The driver image is published to both `registry.k8s.io` and `public.ecr.aws`, but the Helm chart still
ships only through github, which ties it to github availability and means users can't front the chart with ECR pull-through cache. This PR gets the chart into staging so that we can promote it to both GAR and ECR.

#### How was this change tested?

Triggered `aws-ebs-csi-driver-push-images` on a scratch `release-*` branch (https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/release-helm-oci-smoke2):

```
Successfully packaged chart and saved it to: artifacts/aws-ebs-csi-driver-2.62.0.tgz
Pushed: gcr.io/k8s-staging-provider-aws/charts/aws-ebs-csi-driver:2.62.0
Digest: sha256:1b6c5de27d465b6b5ca11b33585ae7b21af81e892651c94bf7345254a9b27a31
```

See build logs: https://storage.googleapis.com/kubernetes-ci-logs/logs/aws-ebs-csi-driver-push-images/2069444720483897344/artifacts/build.log

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```

#### Note for reviewers

This is the first step in the release job to install a tarball based tool inside the build image, and that image (`gcb-docker-gcloud`) is alpine. BusyBox doesn't support GNU tar's `--transform`, hence the diff in install.sh - I've switched it to extract via stdout which is portable across both and produces a byte identical binary on GNU tar.