### PR TITLE
Document OCI Helm chart publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ The [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) Container Storage 
 | v1.62.0        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.62.0                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.62.0                      |
 | v1.61.1        | registry.k8s.io/provider-aws/aws-ebs-csi-driver:v1.61.1                                           | public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.61.1                      |
 
+## Helm Charts
+
+The Helm chart is published through the GitHub Pages Helm repository and as an OCI artifact in both public registries.
+
+| Chart Version | [registry.k8s.io](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) Chart | [ECR Public](https://gallery.ecr.aws/ebs-csi-driver/charts/aws-ebs-csi-driver) Chart |
+|---------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| 2.62.0        | registry.k8s.io/provider-aws/charts/aws-ebs-csi-driver:2.62.0                                     | public.ecr.aws/ebs-csi-driver/charts/aws-ebs-csi-driver:2.62.0                       |
+
 ## Releases
 
 The EBS CSI Driver publishes monthly releases. Unscheduled releases may be published for patches to security vulnerabilities and other fixes deemed urgent.

--- a/docs/install.md
+++ b/docs/install.md
@@ -156,17 +156,30 @@ kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernete
 *Note: Using the master branch to deploy the driver is not supported as the master branch may contain upcoming features incompatible with the currently released stable version of the driver.*
 
 #### Helm
-- Add the `aws-ebs-csi-driver` Helm repository.
+Install from the GitHub Pages Helm repository:
 ```sh
 helm repo add aws-ebs-csi-driver https://kubernetes-sigs.github.io/aws-ebs-csi-driver
 helm repo update
-```
 
-- Install the latest release of the driver.
-```sh
 helm upgrade --install aws-ebs-csi-driver \
     --namespace kube-system \
     aws-ebs-csi-driver/aws-ebs-csi-driver
+```
+
+Install from registry.k8s.io:
+```sh
+helm upgrade --install aws-ebs-csi-driver \
+    --namespace kube-system \
+    oci://registry.k8s.io/provider-aws/charts/aws-ebs-csi-driver \
+    --version 2.62.0
+```
+
+Install from ECR Public:
+```sh
+helm upgrade --install aws-ebs-csi-driver \
+    --namespace kube-system \
+    oci://public.ecr.aws/ebs-csi-driver/charts/aws-ebs-csi-driver \
+    --version 2.62.0
 ```
 
 Review the [configuration values](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.yaml) for the Helm chart.

--- a/hack/release-scripts/generate-release-pr
+++ b/hack/release-scripts/generate-release-pr
@@ -88,7 +88,10 @@ parse_args() {
 
 update_readme() {
   log "Updating README.md"
+  chart_version=$(yq '.version' "$CHART_PATH")
   $SED "/^## Container Images$/,+5 s/$PREV_DRIVER_VERSION/$NEW_DRIVER_VERSION/g" -i "$README_PATH"
+  $SED "/^## Helm Charts$/,/^## Releases$/ s#aws-ebs-csi-driver:[0-9][0-9.]*#aws-ebs-csi-driver:$chart_version#g" -i "$README_PATH"
+  $SED "/^## Helm Charts$/,/^## Releases$/ s/^| [0-9][0-9.]*[[:space:]]*|/| $chart_version        |/" -i "$README_PATH"
 
   # If the major/minor version has changed, we also need to replace the old prev version with the new previous version
   # (If not, that means this is a patch release, and we shouldn't change the other version)
@@ -107,7 +110,9 @@ update_installmd() {
   log "Updating docs/install.md"
   prev_major_minor_version=$(echo "$PREV_DRIVER_VERSION" | sed 's/v\([0-9]*\.[0-9]*\).*/\1/')
   new_major_minor_version=$(echo "$NEW_DRIVER_VERSION" | sed 's/v\([0-9]*\.[0-9]*\).*/\1/')
+  chart_version=$(yq '.version' "$CHART_PATH")
   $SED "s/?ref=release-$prev_major_minor_version/?ref=release-$new_major_minor_version/g" -i "$INSTALL_MD_PATH"
+  $SED "/^#### Helm$/,/^Review the/ s/--version [0-9][0-9.]*/--version $chart_version/g" -i "$INSTALL_MD_PATH"
 }
 
 update_chart_and_overlays() {
@@ -131,10 +136,10 @@ update_chart_and_overlays() {
 }
 
 update_upstream_repo() {
-  update_readme
   update_makefile
-  update_installmd
   update_chart_and_overlays
+  update_readme
+  update_installmd
 }
 
 print_rest_of_release_steps() {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

This PR documents the new OCI Helm chart publishing paths in the README and install guide. The release script has also been updated to keep the chart versions current during future releases.

  Closes #2828.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
