### PR TITLE
Fix detach pending metric name in documentation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,7 +23,7 @@ The following metrics are currently supported:
 |aws_ebs_csi_api_request_duration_seconds|Histogram|Duration by request type in seconds| request=\<AWS SDK API Request Type\> <br/> le=\<Time In Seconds\>                                                                                                          | 
 |aws_ebs_csi_api_request_errors_total|Counter|Total number of errors by error code and request type| request=\<AWS SDK API Request Type\> <br/> error=\<Error Code\>                                                                                                            | 
 |aws_ebs_csi_api_request_throttles_total|Counter|Total number of throttled requests per request type| request=\<AWS SDK API Request Type\>                                                                                                                                       |
-|aws_ebs_csi_ec2_detach_pending_seconds|Counter|Number of seconds csi driver has been waiting for volume to be detached from instance| attachment_state=<Last observed attachment state\><br/>volume_id=<EBS Volume ID of associated volume\><br/>instance_id=<EC2 Instance ID associated with detaching volume\> |
+|aws_ebs_csi_ec2_detach_pending_seconds_total|Counter|Number of seconds csi driver has been waiting for volume to be detached from instance| attachment_state=<Last observed attachment state\><br/>volume_id=<EBS Volume ID of associated volume\><br/>instance_id=<EC2 Instance ID associated with detaching volume\> |
 
 ## CSI Sidecar Metrics (`ebs-csi-controller`)
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind documentation

#### What is this PR about? / Why do we need it?

Document the correct metric name for the total detach pending time. In the code the metric name is defined as https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/85bd59cbdc901d27016c7b15b4c91bb37b16f2c8/pkg/metrics/async.go#L26

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
