### PR TITLE
Unifying single/multi AZ tests into single suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,21 +140,22 @@ e2e/parameters: bin/helm bin/ginkgo
 e2e/parameters-all: bin/helm bin/ginkgo test/helm-template
 	./hack/e2e/param-sets.sh run-all
 
-.PHONY: e2e/single-az
-e2e/single-az: bin/helm bin/ginkgo
-	AWS_AVAILABILITY_ZONES=us-west-2a \
+.PHONY: e2e/functional
+e2e/functional: bin/helm bin/ginkgo
 	TEST_PATH=./tests/e2e/... \
-	GINKGO_FOCUS="\[ebs-csi-e2e\] \[single-az\]" \
+	GINKGO_FOCUS="\[ebs-csi-e2e\] \[functional\]" \
 	GINKGO_PARALLEL=5 \
 	HELM_EXTRA_FLAGS="--set=controller.volumeModificationFeature.enabled=true,sidecars.provisioner.additionalArgs[0]='--feature-gates=VolumeAttributesClass=true',sidecars.resizer.additionalArgs[0]='--feature-gates=VolumeAttributesClass=true',node.enableMetrics=true" \
 	./hack/e2e/run.sh
 
+# Temporary aliases kept until test-infra migrates to e2e/functional, then
+# removed. single-az runs the merged suite; multi-az is a no-op (now included).
+.PHONY: e2e/single-az
+e2e/single-az: e2e/functional
+
 .PHONY: e2e/multi-az
-e2e/multi-az: bin/helm bin/ginkgo
-	TEST_PATH=./tests/e2e/... \
-	GINKGO_FOCUS="\[ebs-csi-e2e\] \[multi-az\]" \
-	GINKGO_PARALLEL=5 \
-	./hack/e2e/run.sh
+e2e/multi-az:
+	@echo "e2e/multi-az is a no-op: its tests are now part of e2e/functional."
 
 .PHONY: e2e/disruptive
 e2e/disruptive: bin/helm bin/ginkgo

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -59,7 +59,8 @@ Creates a cluster for running E2E tests against. There are many parameters that 
 - `AMI_FAMILY`: Which ami family to create a linux node group with for the cluster (`eksctl` clusters only) - defaults to `AmazonLinux2023`
 - `WINDOWS`: Whether or not to create a Windows node group for the cluster (`eksctl` clusters only) - defaults to `false`
 - `AWS_REGION`: Which region to create the cluster in - defaults to `us-west-2`
-- `AWS_AVAILABILITY_ZONES`: Which AZs to create nodes for the cluster in - defaults to `us-west-2a,us-west-2b,us-west-2c`
+- `AWS_AVAILABILITY_ZONES`: Which AZs to create nodes for the cluster in - defaults to the first `NUM_AZS` non-opt-in AZs in the region
+- `NUM_AZS`: How many AZs to auto-detect when `AWS_AVAILABILITY_ZONES` is unset - defaults to `2`
 - `OUTPOST_ARN`: If set, create an additional nodegroup on an [outpost](https://aws.amazon.com/outposts/) (`eksctl clusters only)
 - `OUTPOST_INSTANCE_TYPE`: The instance type to use for the outpost nodegroup (only used when `OUTPOST_ARN` is non-empty) - defaults to `INSTANCE_TYPE`
 
@@ -201,13 +202,9 @@ Alternatively, you may run on an externally created cluster by passing `CLUSTER_
 
 Run the Kubernetes upstream [external storage E2E tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/README.md). This is the most comprehensive E2E test, recommended for local development.
 
-### `make e2e/single-az`
+### `make e2e/functional`
 
-Run the single-AZ EBS CSI E2E tests. Requires a cluster with only one Availability Zone.
-
-### `make e2e/multi-az`
-
-Run the multi-AZ EBS CSI E2E tests. Requires a cluster with at least two Availability Zones.
+Run the EBS CSI functional E2E tests (the `[functional]` labeled specs) against a single multi-AZ cluster. `AWS_AVAILABILITY_ZONES` is derived automatically from the cluster's worker nodes. The multi-attach specs pin their volume to an AZ with at least two schedulable worker nodes and place two pods on different nodes sharing it, so the cluster must have at least two nodes in one AZ (the default `make cluster/create` satisfies this).
 
 ### `make e2e/external-windows`
 

--- a/hack/e2e/config.sh
+++ b/hack/e2e/config.sh
@@ -28,8 +28,9 @@ KUBECONFIG=${KUBECONFIG:-"${TEST_DIR}/${CLUSTER_NAME}.${CLUSTER_TYPE}.kubeconfig
 # Use AWS_REGION as priority, fallback to region from awscli config, fallback to us-west-2
 REGION_FROM_CONFIG="$(${BIN}/aws configure get region || echo '')"
 export AWS_REGION=${AWS_REGION:-${REGION_FROM_CONFIG:-us-west-2}}
-# If zones are not provided, auto-detect the first 3 AZs that are not opt in
-ZONES=${AWS_AVAILABILITY_ZONES:-$(${BIN}/aws ec2 describe-availability-zones --region "${AWS_REGION}" | jq -r '[.AvailabilityZones[] | select(.OptInStatus == "opt-in-not-required") | .ZoneName][:3] | join(",")')}
+# If zones are not provided, auto-detect the first NUM_AZS AZs that are not opt in.
+NUM_AZS=${NUM_AZS:-2}
+ZONES=${AWS_AVAILABILITY_ZONES:-$(${BIN}/aws ec2 describe-availability-zones --region "${AWS_REGION}" | jq -r "[.AvailabilityZones[] | select(.OptInStatus == \"opt-in-not-required\") | .ZoneName][:${NUM_AZS}] | join(\",\")")}
 FIRST_ZONE=$(echo "${ZONES}" | cut -d, -f1)
 NODE_COUNT=${NODE_COUNT:-3}
 INSTANCE_TYPE=${INSTANCE_TYPE:-c5.large}

--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -41,20 +41,20 @@ else
   exit 1
 fi
 
-# Fail single-az tests early if we know cluster is multi-az.
-IGNORE_SINGLE_AZ_ERR=${IGNORE_SINGLE_AZ_ERR:="false"}
-if [[ $IGNORE_SINGLE_AZ_ERR != "true" && "$GINKGO_FOCUS" =~ "single-az" ]]; then
-  # Get unique AZs of non-control-plane nodes
-  azs=$(kubectl get nodes \
+# [env]-gated tests (pre-provisioned, topology-aware) read AWS_AVAILABILITY_ZONES
+# to target real AZs. When unset, derive it from the live worker nodes.
+if [[ -z "${AWS_AVAILABILITY_ZONES:-}" ]]; then
+  AWS_AVAILABILITY_ZONES=$(kubectl get nodes \
     --kubeconfig "${KUBECONFIG}" \
     --selector '!node-role.kubernetes.io/control-plane' \
-    -o jsonpath='{.items[*].metadata.labels.topology\.kubernetes\.io/zone}' | tr " " "\n" | sort -u)
-
-  # Check if there's exactly one AZ and it matches $AWS_AVAILABILITY_ZONES
-  if [[ $(echo "$azs" | wc -w) -gt 1 ]] || [[ "$azs" != "$AWS_AVAILABILITY_ZONES" ]]; then
-    loudecho "ERROR. single-az tests require all worker nodes to be in a single availability zone (AZ) that matches env var \$AWS_AVAILABILITY_ZONES (Currently set as \"$AWS_AVAILABILITY_ZONES\"). Please delete nodes in other AZs. If you want to bypass this error, set env var IGNORE_SINGLE_AZ_ERR='true'"
+    --field-selector 'spec.unschedulable=false' \
+    -o jsonpath='{.items[*].metadata.labels.topology\.kubernetes\.io/zone}' | tr " " "\n" | sort -u | paste -sd, -)
+  if [[ -z "${AWS_AVAILABILITY_ZONES}" ]]; then
+    loudecho "ERROR. Could not derive AWS_AVAILABILITY_ZONES from cluster worker nodes. Set it explicitly or ensure worker nodes are labeled with topology.kubernetes.io/zone."
     exit 1
   fi
+  export AWS_AVAILABILITY_ZONES
+  loudecho "Derived AWS_AVAILABILITY_ZONES from cluster worker nodes: ${AWS_AVAILABILITY_ZONES}"
 fi
 
 if [[ "$WINDOWS" == true ]]; then

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -22,12 +22,14 @@
 make bin/aws
 
 case ${1} in
-test-e2e-single-az)
-  TEST="single-az"
-  export AWS_AVAILABILITY_ZONES="us-west-2a"
+test-e2e-functional | test-e2e-single-az)
+  # test-e2e-single-az is a temporary alias that runs the merged [functional]
+  # suite until the test-infra jobs migrate to test-e2e-functional.
+  TEST="functional"
   ;;
 test-e2e-multi-az)
-  TEST="multi-az"
+  echo "test-e2e-multi-az is a no-op: its tests are now part of test-e2e-functional."
+  exit 0
   ;;
 test-e2e-disruptive)
   TEST="disruptive"

--- a/tests/e2e/driver/driver.go
+++ b/tests/e2e/driver/driver.go
@@ -41,7 +41,7 @@ type DynamicPVTestDriver interface {
 // PreProvisionedVolumeTestDriver represents an interface for a CSI driver that supports pre-provisioned volume.
 type PreProvisionedVolumeTestDriver interface {
 	// GetPersistentVolume returns a PersistentVolume with pre-provisioned volumeHandle
-	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode) *v1.PersistentVolume
+	GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode, availabilityZone string) *v1.PersistentVolume
 }
 
 type VolumeSnapshotTestDriver interface {

--- a/tests/e2e/driver/ebs_csi_driver.go
+++ b/tests/e2e/driver/ebs_csi_driver.go
@@ -68,7 +68,7 @@ func (d *ebsCSIDriver) GetVolumeSnapshotClass(namespace string, parameters map[s
 	return getVolumeSnapshotClass(generateName, provisioner, parameters)
 }
 
-func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode) *v1.PersistentVolume {
+func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size string, reclaimPolicy *v1.PersistentVolumeReclaimPolicy, namespace string, accessMode v1.PersistentVolumeAccessMode, volumeMode v1.PersistentVolumeMode, availabilityZone string) *v1.PersistentVolume {
 	provisioner := d.driverName
 	generateName := fmt.Sprintf("%s-%s-preprovsioned-pv-", namespace, provisioner)
 	// Default to Retain ReclaimPolicy for pre-provisioned volumes
@@ -104,6 +104,24 @@ func (d *ebsCSIDriver) GetPersistentVolume(volumeID string, fsType string, size 
 				},
 			},
 			VolumeMode: &volumeMode,
+			// Pin the PV to the AZ the pre-provisioned volume was created in so
+			// the consuming pod schedules there; otherwise on a multi-AZ cluster
+			// the pod may land in a different AZ than the volume and never attach.
+			NodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      ebscsidriver.WellKnownZoneTopologyKey,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{availabilityZone},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -15,6 +15,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -27,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -36,7 +38,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Dynamic Provisioning", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -267,7 +269,12 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 	})
 
 	It("should succeed multi-attach with dynamically provisioned IO2 block device", func() {
+		zone := multiAttachZone(cs)
+		if zone == "" {
+			Fail("no availability zone has two or more schedulable worker nodes; multi-attach requires a cluster with at least two nodes in one AZ")
+		}
 		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		allowedTopologyValues := []string{zone}
 		pods := []testsuites.PodDetails{
 			{
 				Volumes: []testsuites.VolumeDetails{
@@ -282,8 +289,9 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 							NameGenerate: "test-block-volume-",
 							DevicePath:   "/dev/xvda",
 						},
-						AccessMode:        v1.ReadWriteMany,
-						VolumeBindingMode: &volumeBindingMode,
+						AccessMode:            v1.ReadWriteMany,
+						VolumeBindingMode:     &volumeBindingMode,
+						AllowedTopologyValues: allowedTopologyValues,
 					},
 				},
 			},
@@ -318,7 +326,12 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 	})
 
 	It("should fail to multi-attach dynamically provisioned IO2 block device - not enabled", func() {
+		zone := multiAttachZone(cs)
+		if zone == "" {
+			Fail("no availability zone has two or more schedulable worker nodes; multi-attach requires a cluster with at least two nodes in one AZ")
+		}
 		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+		allowedTopologyValues := []string{zone}
 		pods := []testsuites.PodDetails{
 			{
 				Volumes: []testsuites.VolumeDetails{
@@ -333,8 +346,9 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 							NameGenerate: "test-block-volume-",
 							DevicePath:   "/dev/xvda",
 						},
-						AccessMode:        v1.ReadWriteOnce,
-						VolumeBindingMode: &volumeBindingMode,
+						AccessMode:            v1.ReadWriteOnce,
+						VolumeBindingMode:     &volumeBindingMode,
+						AllowedTopologyValues: allowedTopologyValues,
 					},
 				},
 			},
@@ -351,8 +365,9 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 							NameGenerate: "test-block-volume-",
 							DevicePath:   "/dev/xvda",
 						},
-						AccessMode:        v1.ReadWriteOnce,
-						VolumeBindingMode: &volumeBindingMode,
+						AccessMode:            v1.ReadWriteOnce,
+						VolumeBindingMode:     &volumeBindingMode,
+						AllowedTopologyValues: allowedTopologyValues,
 					},
 				},
 			},
@@ -686,7 +701,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Dynamic Provisioning", func() {
 	})
 })
 
-var _ = Describe("[ebs-csi-e2e] [single-az] Snapshot", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Snapshot", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -751,7 +766,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Snapshot", func() {
 	})
 })
 
-var _ = Describe("[ebs-csi-e2e] [multi-az] Dynamic Provisioning", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Topology Aware Dynamic Provisioning", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -829,6 +844,36 @@ var _ = Describe("[ebs-csi-e2e] [multi-az] Dynamic Provisioning", func() {
 		test.Run(cs, ns)
 	})
 })
+
+// multiAttachZone returns an availability zone with at least two schedulable
+// worker nodes, or "" if none exists.
+func multiAttachZone(cs clientset.Interface) string {
+	nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		Fail(fmt.Sprintf("could not list nodes to find a multi-node AZ: %v", err))
+	}
+	nodesPerZone := map[string]int{}
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
+			continue
+		}
+		if node.Spec.Unschedulable {
+			continue
+		}
+		zone := node.Labels[ebscsidriver.WellKnownZoneTopologyKey]
+		if zone == "" {
+			continue
+		}
+		nodesPerZone[zone]++
+	}
+	for zone, count := range nodesPerZone {
+		if count >= 2 {
+			return zone
+		}
+	}
+	return ""
+}
 
 func restClient(group string, version string) (restclientset.Interface, error) {
 	// setup rest client

--- a/tests/e2e/format_options.go
+++ b/tests/e2e/format_options.go
@@ -31,7 +31,7 @@ var (
 	testedFsTypes = []string{ebscsidriver.FSTypeExt4, ebscsidriver.FSTypeExt3, ebscsidriver.FSTypeXfs}
 )
 
-var _ = Describe("[ebs-csi-e2e] [single-az] [format-options] Formatting a volume", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] [format-options] Formatting a volume", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 

--- a/tests/e2e/modify_volume.go
+++ b/tests/e2e/modify_volume.go
@@ -124,7 +124,7 @@ var (
 	}
 )
 
-var _ = Describe("[ebs-csi-e2e] [single-az] [modify-volume] Modifying a PVC", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] [modify-volume] Modifying a PVC", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 

--- a/tests/e2e/multi_card.go
+++ b/tests/e2e/multi_card.go
@@ -32,7 +32,7 @@ import (
 // Validates that the driver has ec2:DescribeInstanceTypes permission and that
 // the API returns valid EBS card information for the cluster's instance types.
 // This permission is required at runtime to resolve multi-card instance types.
-var _ = Describe("[ebs-csi-e2e] [single-az] Multi-Card", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Multi-Card", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 

--- a/tests/e2e/nvme_metrics.go
+++ b/tests/e2e/nvme_metrics.go
@@ -36,7 +36,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = Describe("[ebs-csi-e2e] [single-az] NVMe Metrics", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] NVMe Metrics", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -49,20 +49,21 @@ var (
 )
 
 // Requires env AWS_AVAILABILITY_ZONES a comma separated list of AZs to be set.
-var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Pre-Provisioned", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
 	var (
-		cs           clientset.Interface
-		ns           *v1.Namespace
-		ebsDriver    driver.PreProvisionedVolumeTestDriver
-		pvTestDriver driver.PVTestDriver
-		snapshotrcs  k8srestclient.Interface
-		cloud        awscloud.Cloud
-		volumeID     string
-		snapshotID   string
-		diskSize     string
+		cs               clientset.Interface
+		ns               *v1.Namespace
+		ebsDriver        driver.PreProvisionedVolumeTestDriver
+		pvTestDriver     driver.PVTestDriver
+		snapshotrcs      k8srestclient.Interface
+		cloud            awscloud.Cloud
+		volumeID         string
+		snapshotID       string
+		diskSize         string
+		availabilityZone string
 		// Set to true if the volume should be deleted automatically after test
 		skipManuallyDeletingVolume bool
 	)
@@ -77,7 +78,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 			Skip(fmt.Sprintf("env %q not set", awsAvailabilityZonesEnv))
 		}
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
-		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
+		availabilityZone = availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
 
 		cloud = awscloud.NewCloud(region, false, "", true, false)
@@ -127,6 +128,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 						VolumeID:                   volumeID,
 						PreProvisionedVolumeFsType: ebscsidriver.FSTypeExt4,
 						ClaimSize:                  diskSize,
+						AvailabilityZone:           availabilityZone,
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
@@ -171,6 +173,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 						VolumeID:                   volumeID,
 						PreProvisionedVolumeFsType: ebscsidriver.FSTypeExt4,
 						ClaimSize:                  diskSize,
+						AvailabilityZone:           availabilityZone,
 						VolumeMount: testsuites.VolumeMountDetails{
 							NameGenerate:      "test-volume-",
 							MountPathGenerate: "/mnt/test-",
@@ -195,6 +198,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 				PreProvisionedVolumeFsType: ebscsidriver.FSTypeExt4,
 				ClaimSize:                  diskSize,
 				ReclaimPolicy:              &reclaimPolicy,
+				AvailabilityZone:           availabilityZone,
 			},
 		}
 		test := testsuites.PreProvisionedReclaimPolicyTest{
@@ -213,6 +217,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 				PreProvisionedVolumeFsType: ebscsidriver.FSTypeExt4,
 				ClaimSize:                  diskSize,
 				ReclaimPolicy:              &reclaimPolicy,
+				AvailabilityZone:           availabilityZone,
 			},
 		}
 		test := testsuites.PreProvisionedReclaimPolicyTest{
@@ -223,7 +228,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 	})
 })
 
-var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Pre-Provisioned with Multi-Attach", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 
@@ -233,6 +238,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 		ebsDriver                  driver.PreProvisionedVolumeTestDriver
 		cloud                      awscloud.Cloud
 		volumeID                   string
+		availabilityZone           string
 		skipManuallyDeletingVolume bool
 	)
 
@@ -241,11 +247,10 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 		ns = f.Namespace
 		ebsDriver = driver.InitEbsCSIDriver()
 
-		if os.Getenv(awsAvailabilityZonesEnv) == "" {
-			Skip(fmt.Sprintf("env %q not set", awsAvailabilityZonesEnv))
+		availabilityZone = multiAttachZone(cs)
+		if availabilityZone == "" {
+			Fail("no availability zone has two or more schedulable worker nodes; multi-attach requires a cluster with at least two nodes in one AZ")
 		}
-		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
-		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
 		region := availabilityZone[0 : len(availabilityZone)-1]
 
 		cloud = awscloud.NewCloud(region, false, "", true, false)
@@ -268,7 +273,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 	})
 
 	AfterEach(func() {
-		if !skipManuallyDeletingVolume {
+		if cloud != nil && !skipManuallyDeletingVolume {
 			deleteDiskWithRetry(cloud, volumeID)
 		}
 	})
@@ -285,9 +290,10 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 							NameGenerate: "test-block-volume-",
 							DevicePath:   "/dev/xvda",
 						},
-						AccessMode:    v1.ReadWriteMany,
-						VolumeID:      volumeID,
-						ReclaimPolicy: &reclaimPolicy,
+						AccessMode:       v1.ReadWriteMany,
+						VolumeID:         volumeID,
+						ReclaimPolicy:    &reclaimPolicy,
+						AvailabilityZone: availabilityZone,
 					},
 				},
 			},
@@ -300,9 +306,10 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned with Multi-Attach", 
 							NameGenerate: "test-block-volume-",
 							DevicePath:   "/dev/xvda",
 						},
-						AccessMode:    v1.ReadWriteMany,
-						VolumeID:      volumeID,
-						ReclaimPolicy: &reclaimPolicy,
+						AccessMode:       v1.ReadWriteMany,
+						VolumeID:         volumeID,
+						ReclaimPolicy:    &reclaimPolicy,
+						AvailabilityZone: availabilityZone,
 					},
 				},
 			},

--- a/tests/e2e/requires_aws_api.go
+++ b/tests/e2e/requires_aws_api.go
@@ -59,7 +59,7 @@ func validateEc2Snapshot(ctx context.Context, ec2Client *ec2.Client, input *ec2.
 	return describeResult
 }
 
-var _ = Describe("[ebs-csi-e2e] [single-az] [requires-aws-api] Dynamic Provisioning", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] [requires-aws-api] Dynamic Provisioning", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 

--- a/tests/e2e/testsuites/specs.go
+++ b/tests/e2e/testsuites/specs.go
@@ -45,6 +45,7 @@ type VolumeDetails struct {
 	CreateVolumeParameters     map[string]string // Optional, used when dynamically-provisioned volumes
 	VolumeID                   string            // Optional, used with pre-provisioned volumes
 	PreProvisionedVolumeFsType string            // Optional, used with pre-provisioned volumes
+	AvailabilityZone           string            // Optional, used with pre-provisioned volumes to set PV node affinity
 	DataSource                 *DataSource       // Optional, used with PVCs created from snapshots
 }
 
@@ -179,7 +180,7 @@ func (volume *VolumeDetails) SetupPreProvisionedPersistentVolumeClaim(client cli
 		volumeMode = v1.PersistentVolumeBlock
 	}
 	By("setting up the PV")
-	pv := csiDriver.GetPersistentVolume(volume.VolumeID, volume.PreProvisionedVolumeFsType, volume.ClaimSize, volume.ReclaimPolicy, namespace.Name, volume.AccessMode, volumeMode)
+	pv := csiDriver.GetPersistentVolume(volume.VolumeID, volume.PreProvisionedVolumeFsType, volume.ClaimSize, volume.ReclaimPolicy, namespace.Name, volume.AccessMode, volumeMode, volume.AvailabilityZone)
 	tpv := NewTestPreProvisionedPersistentVolume(client, pv)
 	tpv.Create()
 	By("setting up the PVC")

--- a/tests/e2e/testsuites/testsuites.go
+++ b/tests/e2e/testsuites/testsuites.go
@@ -400,27 +400,32 @@ func (t *TestPersistentVolumeClaim) ValidateProvisionedPersistentVolume() {
 				To(HaveLen(1))
 		}
 		if len(t.storageClass.AllowedTopologies) > 0 {
-			// Since we're chaging our topology key, assume we have the values below to compare:
-			// NodeSelectorTerms: [{[{topology.ebs.csi.aws.com/zone In [us-west-2a]} {topology.kubernetes.io/zone In [us-west-2a]}] []}]
-			// AllowedTopologies: [{[{topology.ebs.csi.aws.com/zone [us-west-2a us-west-2b us-west-2c]}]}]
-			// As you can see tests might fail depending on the ordering of the NodeSelectorTerms. That's why we're doing this "hack".
-			// This is a quick fix to unblock the PRs we have. We really need to improve this. TODO
+			// The provisioner records the volume's zone in the PV's node
+			// affinity. The key it uses (e.g. topology.kubernetes.io/zone) is
+			// the same key the StorageClass's allowedTopologies specifies, so
+			// validate against that key rather than assuming a fixed one.
+			// A PV may carry several node-selector terms; find the one that
+			// constrains the topology key and confirm its value(s) fall within
+			// the StorageClass's allowed set.
+			topologyKey := t.storageClass.AllowedTopologies[0].MatchLabelExpressions[0].Key
+			allowedValues := t.storageClass.AllowedTopologies[0].MatchLabelExpressions[0].Values
 
 			keyFound := false
-			for _, v := range t.persistentVolume.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions {
-				if v.Key == "topology"+util.GetDriverName()+"/zone" {
+			for _, term := range t.persistentVolume.Spec.NodeAffinity.Required.NodeSelectorTerms {
+				for _, expr := range term.MatchExpressions {
+					if expr.Key != topologyKey {
+						continue
+					}
 					keyFound = true
-					Expect(v.Key).To(Equal(t.storageClass.AllowedTopologies[0].MatchLabelExpressions[0].Key))
+					for _, v := range expr.Values {
+						Expect(allowedValues).To(ContainElement(v))
+					}
 				}
 			}
 
 			// additional sanity check so we can catch an unintended test case that'd hide failures
 			if !keyFound {
 				Fail("Volume is expected to have a node selector term.")
-			}
-
-			for _, v := range t.persistentVolume.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0].Values {
-				Expect(t.storageClass.AllowedTopologies[0].MatchLabelExpressions[0].Values).To(ContainElement(v))
 			}
 		}
 	}

--- a/tests/e2e/volume_properties.go
+++ b/tests/e2e/volume_properties.go
@@ -26,7 +26,7 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
-var _ = Describe("[ebs-csi-e2e] [single-az] Volume Properties Verification", func() {
+var _ = Describe("[ebs-csi-e2e] [functional] Volume Properties Verification", func() {
 	f := framework.NewDefaultFramework("ebs")
 	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR unifies what were previously single-az and multi-az test targets into one. 

This is PR # 1 out of three needed for this unification. In this PR we hijack 'single-az' target to actually run the functional target, keep 'multi-az' target as a no-op, and add in the new functional target. PR # 2 will be a 'test-infra' PR where we add in our configurations to run our new test and remove the single-az/multi-az targets. And lastly, PR # 3 will be a driver PR where we remove the 'single-az' and 'multi-az' targets and just leave the 'functional'.

#### How was this change tested?

- Created a kops cluster with 4 worker nodes (ensuring two of them are in the same AZ)
- Ran 'make e2e/functional' and 'make e2e/single-az' to test both the actual target and the hijack.
- Got test succeeded: 
```
Will run 90 of 100 specs
Running in parallel across 5 processes
SS••••••••••••••••••••••••••••••S••S••••••••••••••••••••••••••••••••••••••••••••••••••••SSSSSSSS••••
Ran 88 of 100 Specs in 797.618 seconds
SUCCESS! -- 88 Passed | 0 Failed | 0 Pending | 12 Skipped
```
- Results of CI run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_aws-ebs-csi-driver/2964/pull-aws-ebs-csi-driver-e2e-single-az/2077808960680759296

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
