### PR TITLE
helm: add optional NetworkPolicy for controller and node

### DIFF
--- a/charts/aws-ebs-csi-driver/templates/_networkpolicy_node.tpl
+++ b/charts/aws-ebs-csi-driver/templates/_networkpolicy_node.tpl
@@ -1,0 +1,75 @@
+{{- define "networkpolicy-node" }}
+{{- if .Values.node.networkPolicy.enabled }}
+{{- if .Values.node.hostNetwork }}
+{{- fail (printf "node.networkPolicy.enabled=true has no effect on %s because node.hostNetwork=true: NetworkPolicy does not apply to pods using the host network namespace. Set node.hostNetwork=false to use NetworkPolicy enforcement on the node DaemonSet." .NodeName) }}
+{{- end }}
+{{- if .Values.node.enableWindows }}
+{{- fail (printf "node.networkPolicy.enabled=true has no effect on the %s Windows DaemonSet because Windows node pods always run with hostNetwork=true (NetworkPolicy is not enforced against hostNetwork pods). Set node.enableWindows=false, or do not enable node.networkPolicy, until Windows NetworkPolicy support is added." .NodeName) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .NodeName }}
+  namespace: {{ .Values.node.namespaceOverride | default .Release.Namespace }}
+  labels:
+    {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .NodeName }}
+      {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Always allow kubelet health checks (ebs-plugin liveness-probe + node-driver-registrar),
+    # regardless of any additional rules below.
+    - ports:
+        - protocol: TCP
+          port: 9808
+        - protocol: TCP
+          port: {{ .Values.sidecars.nodeDriverRegistrar.healthPort }}
+    {{- if .Values.node.enableMetrics }}
+    # Always allow metrics scraping when enabled, regardless of any additional rules below.
+    - ports:
+        - protocol: TCP
+          port: 3302
+    {{- end }}
+    {{- with .Values.node.networkPolicy.ingress }}
+    # Additional user-supplied ingress rules, appended to the defaults above.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # Always allow DNS resolution, HTTPS (kube-apiserver, etc.), and IMDS,
+    # regardless of any additional rules below.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32   # IMDS, for metadata source
+        - ipBlock:
+            cidr: fd00:ec2::254/128    # IMDS, IPv6
+      ports:
+        - protocol: TCP
+          port: 80
+    - to:
+        - ipBlock:
+            cidr: 169.254.170.23/32    # EKS Pod Identity Agent
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- with .Values.node.networkPolicy.egress }}
+    # Additional user-supplied egress rules, appended to the defaults above.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/networkpolicy-controller.yaml
+++ b/charts/aws-ebs-csi-driver/templates/networkpolicy-controller.yaml
@@ -1,0 +1,80 @@
+{{- if and (not .Values.nodeComponentOnly) .Values.controller.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ebs-csi-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "aws-ebs-csi-driver.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: ebs-csi-controller
+      {{- include "aws-ebs-csi-driver.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Always allow kubelet health checks against the ebs-plugin container,
+    # regardless of any additional rules supplied below.
+    - ports:
+        - protocol: TCP
+          port: 9808
+    {{- if .Values.controller.enableMetrics }}
+    # Always allow metrics scraping on the controller + sidecar metrics ports
+    # when metrics are enabled, regardless of any additional rules below.
+    - ports:
+        - protocol: TCP
+          port: 3301
+        - protocol: TCP
+          port: 3302
+        - protocol: TCP
+          port: 3303
+        - protocol: TCP
+          port: 3304
+        - protocol: TCP
+          port: 3305
+        - protocol: TCP
+          port: 3306
+        - protocol: TCP
+          port: 3307
+    {{- end }}
+    {{- with .Values.controller.networkPolicy.ingress }}
+    # Additional user-supplied ingress rules, appended to the defaults above.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # Always allow DNS resolution and HTTPS (EC2/EBS/KMS/STS API calls,
+    # kube-apiserver, etc.), regardless of any additional rules below.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    # Always allow IMDS access (IPv4 + IPv6), required when the controller is
+    # not using IRSA/Pod Identity and falls back to the node's IAM instance role.
+    - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        - ipBlock:
+            cidr: fd00:ec2::254/128
+      ports:
+        - protocol: TCP
+          port: 80
+    # Always allow EKS Pod Identity Agent access, required when using Pod Identity for controller credentials.
+    - to:
+        - ipBlock:
+            cidr: 169.254.170.23/32
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- with .Values.controller.networkPolicy.egress }}
+    # Additional user-supplied egress rules, appended to the defaults above.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/templates/networkpolicy-node.yaml
+++ b/charts/aws-ebs-csi-driver/templates/networkpolicy-node.yaml
@@ -1,0 +1,13 @@
+{{$defaultArgs := dict
+  "NodeName" "ebs-csi-node"
+}}
+{{- include "networkpolicy-node" (deepCopy $ | mustMerge $defaultArgs) -}}
+{{- range $name, $values := .Values.additionalDaemonSets }}
+{{$args := dict
+  "NodeName" (printf "ebs-csi-node-%s" $name)
+  "Values" (dict
+    "node" (deepCopy $.Values.node | mustMerge $values)
+  )
+}}
+{{- include "networkpolicy-node" (deepCopy $ | mustMerge $args) -}}
+{{- end }}

--- a/charts/aws-ebs-csi-driver/values.schema.json
+++ b/charts/aws-ebs-csi-driver/values.schema.json
@@ -311,6 +311,27 @@
             }
           }
         },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enables a Kubernetes NetworkPolicy restricting traffic to/from the controller Deployment. Off by default.",
+              "default": false
+            },
+            "ingress": {
+              "type": "array",
+              "description": "Additional ingress rules for the controller NetworkPolicy.",
+              "default": []
+            },
+            "egress": {
+              "type": "array",
+              "description": "Additional egress rules for the controller NetworkPolicy.",
+              "default": []
+            }
+          }
+        },
         "priorityClassName": {
           "description": "Priority class for the controller Deployment",
           "type": "string",
@@ -778,6 +799,27 @@
           "type": ["object", "null"],
           "description": "DNS configuration for the node pods",
           "default": null
+        },
+        "networkPolicy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enables a Kubernetes NetworkPolicy restricting traffic to/from the node DaemonSet. Off by default.",
+              "default": false
+            },
+            "ingress": {
+              "type": "array",
+              "description": "Additional ingress rules for the node NetworkPolicy.",
+              "default": []
+            },
+            "egress": {
+              "type": "array",
+              "description": "Additional egress rules for the node NetworkPolicy.",
+              "default": []
+            }
+          }
         }
       }
     },

--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -370,6 +370,13 @@ controller:
 
   # dnsConfig for the controller pods
   dnsConfig: {}
+
+  networkPolicy:
+    # Enable a k8s-native NetworkPolicy for the controller Deployment.
+    # Off by default so it has no effect on existing installs.
+    enabled: false
+    ingress: []
+    egress: []
 node:
   # Enable SELinux-only optimizations on the EBS CSI Driver node pods
   # Must only be set true if all linux nodes in the DaemonSet have SELinux enabled
@@ -494,6 +501,11 @@ node:
 
   # dnsConfig for the node pods
   dnsConfig: {}
+
+  networkPolicy:
+    enabled: false
+    ingress: []
+    egress: []
 additionalDaemonSets:
 # Additional node DaemonSets, using the node config structure
 # See docs/additional-daemonsets.md for more information

--- a/tests/helm-template/networkpolicy_test.go
+++ b/tests/helm-template/networkpolicy_test.go
@@ -1,0 +1,306 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helmtemplate
+
+import (
+	"testing"
+)
+
+// assertNetworkPolicyIngressHasPort checks that a NetworkPolicy allows ingress on the given port.
+func assertNetworkPolicyIngressHasPort(t *testing.T, np obj, port int) {
+	t.Helper()
+	rules := nestedSlice(t, np, "spec", "ingress")
+	for _, r := range rules {
+		rm, ok := r.(obj)
+		if !ok {
+			continue
+		}
+		ports, ok := rm["ports"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, p := range ports {
+			pm, ok := p.(obj)
+			if !ok {
+				continue
+			}
+			if pNum, ok := pm["port"].(float64); ok && int(pNum) == port {
+				return
+			}
+		}
+	}
+	name, _ := nestedString(np, "metadata", "name")
+	t.Errorf("NetworkPolicy %s should allow ingress on port %d", name, port)
+}
+
+// assertNetworkPolicyEgressHasIMDS checks that a NetworkPolicy allows egress to the
+// EC2 instance metadata service, required when not using IRSA/Pod Identity.
+func assertNetworkPolicyEgressHasIMDS(t *testing.T, np obj) {
+	t.Helper()
+	rules := nestedSlice(t, np, "spec", "egress")
+	for _, r := range rules {
+		rm, ok := r.(obj)
+		if !ok {
+			continue
+		}
+		to, ok := rm["to"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, dest := range to {
+			dm, ok := dest.(obj)
+			if !ok {
+				continue
+			}
+			ipBlock, ok := dm["ipBlock"].(obj)
+			if !ok {
+				continue
+			}
+			if cidr, ok := ipBlock["cidr"].(string); ok && cidr == "169.254.169.254/32" {
+				return
+			}
+		}
+	}
+	name, _ := nestedString(np, "metadata", "name")
+	t.Errorf("NetworkPolicy %s should allow egress to IMDS (169.254.169.254/32)", name)
+}
+
+// assertNetworkPolicyIngressLacksPort checks that a NetworkPolicy does NOT allow
+// ingress on the given port. Inverse of assertNetworkPolicyIngressHasPort.
+func assertNetworkPolicyIngressLacksPort(t *testing.T, np obj, port int) {
+	t.Helper()
+	rules := nestedSlice(t, np, "spec", "ingress")
+	for _, r := range rules {
+		rm, ok := r.(obj)
+		if !ok {
+			continue
+		}
+		ports, ok := rm["ports"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, p := range ports {
+			pm, ok := p.(obj)
+			if !ok {
+				continue
+			}
+			if pNum, ok := pm["port"].(float64); ok && int(pNum) == port {
+				name, _ := nestedString(np, "metadata", "name")
+				t.Errorf("NetworkPolicy %s should NOT allow ingress on port %d when metrics are disabled", name, port)
+				return
+			}
+		}
+	}
+}
+
+// Regression check: metrics ports must not appear in the rendered NetworkPolicy
+// when enableMetrics is false (the chart default), even with networkPolicy.enabled=true.
+func TestNetworkPolicyMetricsPortsAbsentWhenDisabled(t *testing.T) {
+	resources := renderChartWithSet(t,
+		"controller.networkPolicy.enabled=true",
+		"node.networkPolicy.enabled=true",
+		"controller.enableMetrics=false",
+		"node.enableMetrics=false",
+		"node.enableWindows=false",
+	)
+
+	controllerNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-controller")
+	for _, port := range []int{3301, 3302, 3303, 3304, 3305, 3306, 3307} {
+		assertNetworkPolicyIngressLacksPort(t, controllerNP, port)
+	}
+	// healthz must still be present even with metrics off.
+	assertNetworkPolicyIngressHasPort(t, controllerNP, 9808)
+
+	nodeNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-node")
+	assertNetworkPolicyIngressLacksPort(t, nodeNP, 3302)
+	assertNetworkPolicyIngressHasPort(t, nodeNP, 9808)
+}
+
+// testdata/networkpolicy.yaml enables metrics and supplies a custom ingress rule on
+// both controller and node, so this single render proves the required baseline rules
+// (health checks, metrics, IMDS egress) are always applied additively alongside any
+// user-supplied rules, rather than being replaced by them.
+func TestNetworkPolicy(t *testing.T) {
+	resources := renderChart(t, "networkpolicy")
+
+	controllerNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-controller")
+	sel := nested(t, controllerNP, "spec", "podSelector", "matchLabels")
+	if sel["app"] != "ebs-csi-controller" {
+		t.Errorf("controller NetworkPolicy podSelector app: got %v, want ebs-csi-controller", sel["app"])
+	}
+
+	hasIngress, hasEgress := false, false
+	for _, pt := range nestedSlice(t, controllerNP, "spec", "policyTypes") {
+		switch pt {
+		case "Ingress":
+			hasIngress = true
+		case "Egress":
+			hasEgress = true
+		}
+	}
+	if !hasIngress || !hasEgress {
+		t.Errorf("controller NetworkPolicy policyTypes: got Ingress=%v Egress=%v, want both true", hasIngress, hasEgress)
+	}
+	// Regression check: kubelet must be able to reach /healthz regardless of enableMetrics
+	// or any user-supplied ingress rules.
+	assertNetworkPolicyIngressHasPort(t, controllerNP, 9808)
+	// Metrics ports must still be present even though a custom ingress rule was also supplied.
+	assertNetworkPolicyIngressHasPort(t, controllerNP, 3301)
+	// The custom ingress rule must be appended, not dropped.
+	assertNetworkPolicyIngressHasPort(t, controllerNP, 9999)
+	// Regression check: controller must be able to reach IMDS for node-role credentials
+	// when IRSA/Pod Identity is not configured (the default).
+	assertNetworkPolicyEgressHasIMDS(t, controllerNP)
+	assertNetworkPolicyEgressHasPort(t, controllerNP, 443)
+
+	nodeNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-node")
+	nodeSel := nested(t, nodeNP, "spec", "podSelector", "matchLabels")
+	if nodeSel["app"] != "ebs-csi-node" {
+		t.Errorf("node NetworkPolicy podSelector app: got %v, want ebs-csi-node", nodeSel["app"])
+	}
+	assertNetworkPolicyIngressHasPort(t, nodeNP, 9808)
+	assertNetworkPolicyIngressHasPort(t, nodeNP, 9809)
+	assertNetworkPolicyIngressHasPort(t, nodeNP, 3302)
+	assertNetworkPolicyIngressHasPort(t, nodeNP, 9999)
+	assertNetworkPolicyEgressHasIMDS(t, nodeNP)
+	assertNetworkPolicyEgressHasPort(t, nodeNP, 443)
+}
+
+func TestNetworkPolicyDisabledByDefault(t *testing.T) {
+	// No testdata/default.yaml exists in this harness; renderChartWithSet with
+	// zero --set flags renders the chart's pure built-in defaults.
+	resources := renderChartWithSet(t)
+
+	if _, ok := find(resources, "NetworkPolicy", "ebs-csi-controller"); ok {
+		t.Error("NetworkPolicy must not render when controller.networkPolicy.enabled is unset (default false)")
+	}
+	if _, ok := find(resources, "NetworkPolicy", "ebs-csi-node"); ok {
+		t.Error("NetworkPolicy must not render when node.networkPolicy.enabled is unset (default false)")
+	}
+}
+
+func TestNetworkPolicyAdditionalDaemonSet(t *testing.T) {
+	resources := renderChart(t, "networkpolicy-additional-daemonset")
+
+	extraNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-node-extra")
+	sel := nested(t, extraNP, "spec", "podSelector", "matchLabels")
+	if sel["app"] != "ebs-csi-node-extra" {
+		t.Errorf("additional daemonset NetworkPolicy podSelector app: got %v, want ebs-csi-node-extra", sel["app"])
+	}
+}
+
+// assertNetworkPolicyEgressHasPort checks that a NetworkPolicy allows egress on the given port.
+func assertNetworkPolicyEgressHasPort(t *testing.T, np obj, port int) {
+	t.Helper()
+	rules := nestedSlice(t, np, "spec", "egress")
+	for _, r := range rules {
+		rm, ok := r.(obj)
+		if !ok {
+			continue
+		}
+		ports, ok := rm["ports"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, p := range ports {
+			pm, ok := p.(obj)
+			if !ok {
+				continue
+			}
+			if pNum, ok := pm["port"].(float64); ok && int(pNum) == port {
+				return
+			}
+		}
+	}
+	name, _ := nestedString(np, "metadata", "name")
+	t.Errorf("NetworkPolicy %s should allow egress on port %d", name, port)
+}
+
+// Regression check: enabling node.networkPolicy on a hostNetwork daemonset must
+// fail the render loudly rather than silently produce an inert NetworkPolicy,
+// since Kubernetes NetworkPolicy is not enforced against hostNetwork pods.
+func TestNetworkPolicyFailsWithHostNetwork(t *testing.T) {
+	renderChartWithSetExpectError(t,
+		"does not apply to pods using the host network namespace",
+		"node.networkPolicy.enabled=true",
+		"node.hostNetwork=true",
+		"node.enableWindows=false",
+	)
+}
+
+// Regression check: node.networkPolicy.enabled=true must fail the render when
+// node.enableWindows=true (the chart default), since Windows node pods always
+// run with hostNetwork=true and are therefore unprotected by the policy.
+func TestNetworkPolicyFailsWithWindowsEnabled(t *testing.T) {
+	renderChartWithSetExpectError(t,
+		"Windows node pods always run with hostNetwork=true",
+		"node.networkPolicy.enabled=true",
+		"node.enableWindows=true",
+	)
+}
+
+// assertNetworkPolicyEgressHasCIDR checks that a NetworkPolicy allows egress to
+// the given ipBlock CIDR. Generic version of assertNetworkPolicyEgressHasIMDS.
+func assertNetworkPolicyEgressHasCIDR(t *testing.T, np obj, cidr string) {
+	t.Helper()
+	rules := nestedSlice(t, np, "spec", "egress")
+	for _, r := range rules {
+		rm, ok := r.(obj)
+		if !ok {
+			continue
+		}
+		to, ok := rm["to"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, dest := range to {
+			dm, ok := dest.(obj)
+			if !ok {
+				continue
+			}
+			ipBlock, ok := dm["ipBlock"].(obj)
+			if !ok {
+				continue
+			}
+			if c, ok := ipBlock["cidr"].(string); ok && c == cidr {
+				return
+			}
+		}
+	}
+	name, _ := nestedString(np, "metadata", "name")
+	t.Errorf("NetworkPolicy %s should allow egress to %s", name, cidr)
+}
+
+// Regression check: IMDS IPv6 and EKS Pod Identity egress must be present by
+// default, alongside the existing IMDS IPv4 rule.
+func TestNetworkPolicyIMDSIPv6AndPodIdentity(t *testing.T) {
+	resources := renderChartWithSet(t,
+		"controller.networkPolicy.enabled=true",
+		"node.networkPolicy.enabled=true",
+		"node.enableWindows=false",
+	)
+
+	controllerNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-controller")
+	assertNetworkPolicyEgressHasCIDR(t, controllerNP, "169.254.169.254/32")
+	assertNetworkPolicyEgressHasCIDR(t, controllerNP, "fd00:ec2::254/128")
+	assertNetworkPolicyEgressHasCIDR(t, controllerNP, "169.254.170.23/32")
+
+	nodeNP := mustFind(t, resources, "NetworkPolicy", "ebs-csi-node")
+	assertNetworkPolicyEgressHasCIDR(t, nodeNP, "169.254.169.254/32")
+	assertNetworkPolicyEgressHasCIDR(t, nodeNP, "fd00:ec2::254/128")
+	assertNetworkPolicyEgressHasCIDR(t, nodeNP, "169.254.170.23/32")
+}

--- a/tests/helm-template/parameter_test.go
+++ b/tests/helm-template/parameter_test.go
@@ -110,6 +110,27 @@ func renderChartWithSet(t *testing.T, sets ...string) []obj {
 	return parseYAMLDocs(t, stdout.Bytes())
 }
 
+// renderChartWithSetExpectError runs helm template with inline --set flags and
+// asserts the render fails, returning the combined stderr for inspection. Use
+// this for testing fail()-guarded misconfigurations rather than renderChartWithSet,
+// which calls t.Fatal on any non-zero exit.
+func renderChartWithSetExpectError(t *testing.T, sets ...string) error {
+	t.Helper()
+	args := []string{"template", releaseName, chartPath()}
+	for _, s := range sets {
+		args = append(args, "--set", s)
+	}
+	cmd := exec.Command(helmBin(), args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("expected helm template to fail, but it succeeded\nstdout: %s", stdout.String())
+	}
+	return fmt.Errorf("%w: %s", err, stderr.String())
+}
+
 // parseYAMLDocs splits multi-doc YAML and converts each to a JSON-like map via sigs.k8s.io/yaml.
 func parseYAMLDocs(t *testing.T, data []byte) []obj {
 	t.Helper()

--- a/tests/helm-template/testdata/networkpolicy-additional-daemonset.yaml
+++ b/tests/helm-template/testdata/networkpolicy-additional-daemonset.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+controller:
+  networkPolicy:
+    enabled: true
+
+node:
+  enableWindows: false
+  networkPolicy:
+    enabled: true
+
+additionalDaemonSets:
+  extra:
+    nodeSelector:
+      example: "true"

--- a/tests/helm-template/testdata/networkpolicy.yaml
+++ b/tests/helm-template/testdata/networkpolicy.yaml
@@ -1,0 +1,40 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+controller:
+  enableMetrics: true
+  networkPolicy:
+    enabled: true
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                name: monitoring
+        ports:
+          - protocol: TCP
+            port: 9999
+
+node:
+  enableMetrics: true
+  enableWindows: false
+  networkPolicy:
+    enabled: true
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                name: monitoring
+        ports:
+          - protocol: TCP
+            port: 9999


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What is this PR about? / Why do we need it?
Adds optional, off-by-default NetworkPolicy resources for the controller and node components, gated by `controller.networkPolicy.enabled` / `node.networkPolicy.enabled`.

Users enforcing default-deny NetworkPolicy currently have no way to allow this driver's traffic without a wrapper chart. Default rules cover health checks, metrics, and IMDS/kube-apiserver/AWS API egress. Ingress/egress are extensible via `controller.networkPolicy.ingress`/`egress` and `node.networkPolicy.ingress`/`egress`, appended to the defaults.

Fixes #2963

#### How was this change tested?
- `helm lint` / `helm template` with both flags enabled
- `tests/helm-template` covers: default ports present, custom rules appended,
  metrics ports absent when `enableMetrics=false`, disabled by default, `additionalDaemonSets` support
- Not yet tested against live enforcement

#### Does this PR introduce a user-facing change?
```release-note
Added optional NetworkPolicy resources for controller and node, disabled by default.
Enable via `controller.networkPolicy.enabled` / `node.networkPolicy.enabled`.
```
