### PR TITLE
Add extra safeguards for volume limits table scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ update: update/gofix update/gofmt update/golangci-fix update/kustomize update/mo
 	@echo "All updates succeeded!"
 
 .PHONY: verify
-verify: verify/govet verify/golangci-lint verify/update
+verify: verify/govet verify/golangci-lint verify/update verify/volume-limits
 	@echo "All verifications passed!"
 
 .PHONY: cluster/create
@@ -369,3 +369,7 @@ verify/govet:
 .PHONY: verify/update
 verify/update: bin/helm bin/mockgen
 	./hack/verify-update.sh
+
+.PHONY: verify/volume-limits
+verify/volume-limits:
+	go run ./hack/detect-potentially-invalid-limits

--- a/hack/detect-potentially-invalid-limits/main.go
+++ b/hack/detect-potentially-invalid-limits/main.go
@@ -47,7 +47,7 @@ func main() {
 				// Log with red background and bold text to stand out in terminal
 				log.Printf("%s!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!%s", formatWarning, formatReset)
 				log.Printf("%s!!! WARNING - the following instance types have potentially invalid limits/types !!!%s", formatWarning, formatReset)
-				log.Printf("%s!!!          Check if they need to be hardcoded in pkg/volume_limits.go          !!!%s", formatWarning, formatReset)
+				log.Printf("%s!!!    Check if they need to be hardcoded in pkg/cloud/limits/volume_limits.go   !!!%s", formatWarning, formatReset)
 				log.Printf("%s!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!%s", formatWarning, formatReset)
 				loggedWarning = true
 			}

--- a/hack/generate-volume-limits-table/main.go
+++ b/hack/generate-volume-limits-table/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"sort"
@@ -92,6 +93,12 @@ func getAvailableRegions(ctx context.Context) ([]string, error) {
 	regions := make([]string, 0, len(result.Regions))
 	for _, region := range result.Regions {
 		regions = append(regions, *region.RegionName)
+	}
+
+	// As of the time of writing this code, AWS has 34 publicly available regions.
+	// This number should only ever go down if a region is closed. Do not decrease it otherwise.
+	if len(regions) < 34 {
+		return nil, fmt.Errorf("expected at least 34 regions but got %d (account is probably missing opt-in regions)", len(regions))
 	}
 
 	return regions, nil


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Add some additional safeguards to the volume limits table scripts:
- Bomb out of `generate-volume-limits-table` if we have less than the expected number of AWS regions. This has multiple times in the past resulted in accidentally dropping instance types that we should not drop.
- Add `detect-potentially-invalid-limits` to `make verify` so it's run in CI. This script is yet to misidentify a instance type, and if it does we can just add a hardcoded exception. The protection we get from running this automatically is much greater than once in a blue moon adding a manual exception.
- Fix file path in `generate-volume-limits-table` as we've since moved that file into its own sub-package.

#### How was this change tested?

Test account with all opt-in regions enabled:
```
$ go run ./hack/generate-volume-limits-table
2026/07/21 16:03:24 Discovered 34 regions
2026/07/21 16:03:24 Getting volume limits for ap-south-2...
...
```

Test account WITHOUT all opt-in regions enabled:
```
$ go run ./hack/generate-volume-limits-table
2026/07/21 16:03:38 Failed to discover regions: expected at least 34 regions but got 29 (account is probably missing opt-in regions)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
