### PR TITLE
Switch Windows tests to m7a family instances

### DIFF
--- a/hack/e2e/eksctl/cluster.yaml
+++ b/hack/e2e/eksctl/cluster.yaml
@@ -58,7 +58,7 @@ managedNodeGroups:
     amiFamily: WindowsServer2025CoreContainer
     desiredCapacity: 3
     disablePodIMDS: true
-    instanceTypes: [m5.2xlarge]
+    instanceTypes: [m7a.2xlarge]
     ssh:
       allow: false
       enableSsm: true
@@ -87,7 +87,7 @@ nodeGroups:
     ami: {{ .Env.WINDOWS_AMI }}
     desiredCapacity: 3
     disablePodIMDS: true
-    instanceType: m5.2xlarge
+    instanceType: m7a.2xlarge
     ssh:
       allow: false
       enableSsm: true


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

We're seeing an excessive number of Windows E2E flakes that look like:
```
MountVolume.MountDevice failed for volume "pvc-796c8723-d264-4ec8-a8f8-376194a4b00d" : rpc error: code = NotFound desc = Failed to find device path /dev/xvdaa. disk number for device path "/dev/xvdaa" volume id "vol-0b21011e877c74079" not found
```

To the best of our knowledge, this is a Microsoft and/or AWS-side issue that cannot be fixed or worked around in the driver. The relevant teams have been informed/engaged on this issue, but in the meantime we can work around it in our tests by using a different instance type. Testing indicates `m7a` either is not susceptible to this issue, or at the very least it is much rarer.

This will slightly increase the cost of the Windows E2E job but should in theory result in a net cost savings by reducing the number of times the job has to be rerun in entirety.

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
