### PR TITLE
Fix VAC e2e tests on EKS versions below 1.34

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -132,6 +132,11 @@ else
     pushd "${BASE_DIR}/../../tests/e2e-kubernetes"
     packageVersion=$(echo $(cut -d '.' -f 1,2 <<<$K8S_VERSION))
 
+    # VolumeAttributesClass went GA in 1.34, older test packages can only decode v1beta1
+    if [[ $(cut -d '.' -f 2 <<<"${packageVersion}") -lt 34 ]]; then
+      sed -i 's|^apiVersion: storage.k8s.io/v1$|apiVersion: storage.k8s.io/v1beta1|' volumeattributesclass.yaml
+    fi
+
     # TODO: Always skip broken upstream test - remove after fix released
     GINKGO_SKIP="(should be protected by vac\\-protection finalizer)|should provision storage with pvc data source in parallel|${GINKGO_SKIP}"
     GINKGO_SKIP="${GINKGO_SKIP%|}" # Strip trailing | if needed - remove with above TODO


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes CI, `pull-aws-ebs-csi-driver-external-test-eks-oldest` is currently red. The job broke yesterday when EKS 1.30 went out of support and the job started testing against 1.31.

VolumeAttributesClass didn't go GA until Kubernetes 1.34, so test binaries older than that can only decode the manifest as v1beta1. Our `volumeattributesclass.yaml` uses the v1 API version, which the 1.31 binary can't decode so all six vac tests fail before they even start.

This PR rewrites the apiVersion in the manifest to v1beta1 at runtime whenever the test package is older than 1.34.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
