### PR TITLE
Remove Single/Multi AZ Targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,15 +148,6 @@ e2e/functional: bin/helm bin/ginkgo
 	HELM_EXTRA_FLAGS="--set=controller.volumeModificationFeature.enabled=true,sidecars.provisioner.additionalArgs[0]='--feature-gates=VolumeAttributesClass=true',sidecars.resizer.additionalArgs[0]='--feature-gates=VolumeAttributesClass=true',node.enableMetrics=true" \
 	./hack/e2e/run.sh
 
-# Temporary aliases kept until test-infra migrates to e2e/functional, then
-# removed. single-az runs the merged suite; multi-az is a no-op (now included).
-.PHONY: e2e/single-az
-e2e/single-az: e2e/functional
-
-.PHONY: e2e/multi-az
-e2e/multi-az:
-	@echo "e2e/multi-az is a no-op: its tests are now part of e2e/functional."
-
 .PHONY: e2e/disruptive
 e2e/disruptive: bin/helm bin/ginkgo
 	TEST_PATH=./tests/e2e/... \

--- a/hack/prow-e2e.sh
+++ b/hack/prow-e2e.sh
@@ -22,14 +22,8 @@
 make bin/aws
 
 case ${1} in
-test-e2e-functional | test-e2e-single-az)
-  # test-e2e-single-az is a temporary alias that runs the merged [functional]
-  # suite until the test-infra jobs migrate to test-e2e-functional.
+test-e2e-functional)
   TEST="functional"
-  ;;
-test-e2e-multi-az)
-  echo "test-e2e-multi-az is a no-op: its tests are now part of test-e2e-functional."
-  exit 0
   ;;
 test-e2e-disruptive)
   TEST="disruptive"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What is this PR about? / Why do we need it?

This PR removes all remaining targets/references to single/multi-AZ test suites now that they have been unified into 1 single suite `functional`. 

The [necessary changes](https://github.com/kubernetes/test-infra/pull/37488) have also been merged in the test-infra repo and [ran a few times](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-aws-ebs-csi-driver-e2e-functional)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
