### PR TITLE
Add make verify to make pre-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,7 @@ pre-release:
 	$(MAKE) update-sidecar-dependencies
 	$(MAKE) update
 	$(MAKE) test
+	$(MAKE) verify
 	@echo "Pre-release updates succeeded! Review the diff and commit it as the release PR."
 
 # Generate the post-release PR file changes and draft changelog


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?
Adds `make verify` to `make pre-release`
#### How was this change tested?
`make pre-release`
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
