### PR TITLE
Fix pod restart CI checker

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -242,9 +242,10 @@ fi
 
 if [[ "${HELM_CT_TEST}" != true ]]; then
   # If there are more than 3 restarts in any single container fail the test and print table with restarts.
-  if [[ $(kubectl get pods -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver" -o json |
+  POD_RESTARTS=$(kubectl get pods -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver" -o json --kubeconfig "${KUBECONFIG}" |
     jq -r '.items[].status.containerStatuses[]?.restartCount // 0' |
-    sort -nr | head -n 1) -gt 3 ]]; then
+    sort -nr | head -n 1)
+  if [[ ${POD_RESTARTS} -gt 3 ]]; then
     loudecho "ERROR: Container restart count exceeds threshold"
     kubectl get pods -n kube-system -l "app.kubernetes.io/name=aws-ebs-csi-driver" -o custom-columns="POD:.metadata.name,CONTAINER:.spec.containers[*].name,RESTARTS:.status.containerStatuses[*].restartCount" --kubeconfig "${KUBECONFIG}"
     TEST_PASSED=1


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Our CI randomly runs into an error like this before the uninstall:
```
error: EOF
jq: parse error: Invalid numeric literal at line 1, column 7
release "aws-ebs-csi-driver" uninstalled
```

Two issues:
1. The `kubectl` this check relies on doesn't pass `--kubeconfig` and thus it's been broken since merged
2. Because a ton of the work is done inside the `if`, the failure is completely ignored and the resulting run marked as passing despite the fact we have `set -euo pipefail`

To fix this, we start passing `--kubeconfig` and move the command to setting a variable so if it fails it isn't silently ignored in CI.

#### How was this change tested?

CI

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
