### PR TITLE
Support offline E2E tests

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -147,7 +147,7 @@ else
     # Regex matching volume expansion tests susceptible to transient failures on Windows due to defragsvc contention.
     WINDOWS_VOLUME_EXPAND_REGEX="volume-expand|expansion of pvcs created for ephemeral"
 
-    TEST_PACKAGE_VERSION=$(curl -L https://dl.k8s.io/release/stable-${packageVersion}.txt)
+    TEST_PACKAGE_VERSION=${TEST_PACKAGE_VERSION:-$(curl -L https://dl.k8s.io/release/stable-${packageVersion}.txt)}
 
     run_kubetest2() {
       local run_id="$1"
@@ -162,6 +162,7 @@ else
         --skip-regex="${skip}" \
         --focus-regex="${focus}" \
         --test-package-version="${TEST_PACKAGE_VERSION}" \
+        ${KUBETEST2_USE_BUILT_BINARIES:+--use-built-binaries} \
         --parallel=${GINKGO_PARALLEL} \
         ${extra_ginkgo_args:+--ginkgo-args="${extra_ginkgo_args}"} \
         --test-args="-storage.testdriver=${PWD}/manifests.yaml -kubeconfig=${KUBECONFIG} -node-os-distro=${NODE_OS_DISTRO}"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What is this PR about? / Why do we need it?

Makes two changes to support running the E2E tests offline:
- Allow supplying `TEST_PACKAGE_VERSION` as an environment variable which will skip the `curl` call to the internet
- Allow telling `kubetest2` to use pre-built binaries (so it can be used against a pre-downloaded set of binaries)

#### How was this change tested?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
