### PR TITLE
fix: serviceMonitor URL in Windows example

### DIFF
--- a/examples/kubernetes/windows/manifests/windows.yaml
+++ b/examples/kubernetes/windows/manifests/windows.yaml
@@ -40,7 +40,7 @@ spec:
           command:
             - powershell.exe
             - -command
-            - "Add-WindowsFeature Web-Server; Invoke-WebRequest -UseBasicParsing -Uri 'https://dotnetbinaries.blob.core.windows.net/servicemonitor/2.0.1.6/ServiceMonitor.exe' -OutFile 'C:\\ServiceMonitor.exe'; echo '<html><body><br/><br/><marquee><H1>Hello EKS!!!<H1><marquee></body><html>' > C:\\inetpub\\wwwroot\\default.html; C:\\ServiceMonitor.exe 'w3svc'; "
+            - "Add-WindowsFeature Web-Server; Invoke-WebRequest -UseBasicParsing -Uri 'https://github.com/microsoft/IIS.ServiceMonitor/releases/download/v2.0.1.10/ServiceMonitor.exe' -OutFile 'C:\\ServiceMonitor.exe'; echo '<html><body><br/><br/><marquee><H1>Hello EKS!!!<H1><marquee></body><html>' > C:\\inetpub\\wwwroot\\default.html; C:\\ServiceMonitor.exe 'w3svc'; "
           volumeMounts:
             - name: persistent-storage
               mountPath: C:\data


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What is this PR about? / Why do we need it?

Fixing servicemonitor URL from deprecated `dotnetbinaries` URL, see https://github.com/dotnet/announcements/issues/351. Just making this PR after making the same change/fix here https://github.com/aws/amazon-vpc-resource-controller-k8s/pull/704

Note that the version had to be bumped since microsoft only added the latest version `.10` to the new download location, rather than all historic versions, such as `.6`

#### How was this change tested?
Deployed the manifest and it runs as expected.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
