### PR TITLE
Bumping sidecar deps ahead of Helm Chart Release

### DIFF
--- a/charts/aws-ebs-csi-driver/values.yaml
+++ b/charts/aws-ebs-csi-driver/values.yaml
@@ -21,7 +21,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-provisioner
-      tag: "v6.3.0-eksbuild.5"
+      tag: "v6.3.0-eksbuild.6"
     logLevel: 2
     # Additional parameters provided by csi-provisioner.
     additionalArgs: []
@@ -48,7 +48,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-attacher
-      tag: "v4.12.0-eksbuild.6"
+      tag: "v4.12.0-eksbuild.7"
     # Tune leader lease election for csi-attacher.
     # Leader election is on by default.
     leaderElection:
@@ -77,7 +77,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-snapshotter
-      tag: "v8.6.0-eksbuild.6"
+      tag: "v8.6.0-eksbuild.7"
     logLevel: 2
     # Additional parameters provided by csi-snapshotter.
     additionalArgs: []
@@ -105,7 +105,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/livenessprobe
-      tag: "v2.19.0-eksbuild.6"
+      tag: "v2.19.0-eksbuild.7"
     # Additional parameters provided by livenessprobe.
     additionalArgs: []
     resources: {}
@@ -117,7 +117,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-resizer
-      tag: "v2.2.1-eksbuild.4"
+      tag: "v2.2.1-eksbuild.5"
     # Tune leader lease election for csi-resizer.
     # Leader election is on by default.
     leaderElection:
@@ -144,7 +144,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/csi-components/csi-node-driver-registrar
-      tag: "v2.17.0-eksbuild.6"
+      tag: "v2.17.0-eksbuild.7"
     logLevel: 2
     # The port the health probe is bound to.
     healthPort: 9809
@@ -166,7 +166,7 @@ sidecars:
     image:
       pullPolicy: IfNotPresent
       repository: public.ecr.aws/ebs-csi-driver/volume-modifier-for-k8s
-      tag: "v0.9.5-eksbuild.6"
+      tag: "v0.9.6-eksbuild.1"
     leaderElection:
       enabled: true
       # Optional values to tune lease behavior.

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -140,7 +140,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-provisioner
-          image: "public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.5"
+          image: "public.ecr.aws/csi-components/csi-provisioner:v6.3.0-eksbuild.6"
           imagePullPolicy: "IfNotPresent"
           args:
             - --timeout=60s
@@ -175,7 +175,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-attacher
-          image: "public.ecr.aws/csi-components/csi-attacher:v4.12.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/csi-attacher:v4.12.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --timeout=6m
@@ -206,7 +206,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-snapshotter
-          image: "public.ecr.aws/csi-components/csi-snapshotter:v8.6.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/csi-snapshotter:v8.6.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=$(ADDRESS)
@@ -236,7 +236,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: csi-resizer
-          image: "public.ecr.aws/csi-components/csi-resizer:v2.2.1-eksbuild.4"
+          image: "public.ecr.aws/csi-components/csi-resizer:v2.2.1-eksbuild.5"
           imagePullPolicy: "IfNotPresent"
           args:
             - --timeout=60s
@@ -270,7 +270,7 @@ spec:
               type: RuntimeDefault
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: "public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=/csi/csi.sock

--- a/deploy/kubernetes/base/node-windows.yaml
+++ b/deploy/kubernetes/base/node-windows.yaml
@@ -102,7 +102,7 @@ spec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
           terminationMessagePolicy: FallbackToLogsOnError
         - name: node-driver-registrar
-          image: "public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=$(ADDRESS)
@@ -139,7 +139,7 @@ spec:
               memory: 150Mi
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: "public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=unix:/csi/csi.sock

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -105,7 +105,7 @@ spec:
                 command: ["/bin/aws-ebs-csi-driver", "pre-stop-hook"]
           terminationMessagePolicy: FallbackToLogsOnError
         - name: node-driver-registrar
-          image: "public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/csi-node-driver-registrar:v2.17.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=$(ADDRESS)
@@ -145,7 +145,7 @@ spec:
             readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
         - name: liveness-probe
-          image: "public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.6"
+          image: "public.ecr.aws/csi-components/livenessprobe:v2.19.0-eksbuild.7"
           imagePullPolicy: "IfNotPresent"
           args:
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
#### What is this PR about? / Why do we need it?

Bumping sidecar dependencies ahead of new Helm Chart release. Ran `make update-sidecar-dependencies `

#### How was this change tested?

`make update && make verify && make test`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
