### PR TITLE
Allow overriding TEST_PATH to support offline test runs

### DIFF
--- a/hack/e2e/run.sh
+++ b/hack/e2e/run.sh
@@ -210,7 +210,7 @@ else
       --focus="${GINKGO_FOCUS}" \
       --skip="${GINKGO_SKIP}" \
       --junit-report="${JUNIT_REPORT:-${REPORT_DIR}/junit.xml}" \
-      "${TEST_PATH}" \
+      "${TEST_PATH_OVERRIDE:-${TEST_PATH}}" \
       -- \
       -kubeconfig="${KUBECONFIG}" \
       -gce-zone="${FIRST_ZONE}"


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind cleanup

#### What is this PR about? / Why do we need it?

Our current ginkgo downloads test artifacts at runtime. Add a new environment variable `TEST_PATH_OVERRIDE` so a pre-compiled copy of the tests can be passed in.

#### How was this change tested?

```
TEST_PATH_OVERRIDE=.path/to/e2e.test make e2e/functional
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
