### PR TITLE
Use PULL_BASE_REF for image tag and version in cloudbuild.sh

### DIFF
--- a/hack/cloudbuild.sh
+++ b/hack/cloudbuild.sh
@@ -40,9 +40,8 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 loudecho "Push manifest list containing amazon linux and windows based images to GCR"
 export IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver
-# Prow passes GIT_TAG like "v20250306-v1.40.1" - strip first 10 characters to get real tag
-export TAG=${GIT_TAG:10}
-export VERSION=$PULL_BASE_REF
+export TAG=${PULL_BASE_REF}
+export VERSION=${PULL_BASE_REF}
 IMAGE=gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver make -j $(nproc) all-push
 
 # Push the Helm chart to the staging OCI registry when triggered by the


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What is this PR about? / Why do we need it?

Fixes an issue we saw during the 1.66 release - for some reason, `cloudbuild.sh` takes the image tag from a different place than the version which can lead to a mismatch. We ALWAYS want to use the `PULL_BASE_REF`, there's no reason to use another variable.

#### How was this change tested?

N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, enter your extended release note in the block below.
-->
```release-note
NONE
```
